### PR TITLE
single-redshift dust attenuation models

### DIFF
--- a/diffsky/experimental/dspspop/dust_deltapop.py
+++ b/diffsky/experimental/dspspop/dust_deltapop.py
@@ -1,0 +1,146 @@
+"""
+"""
+import numpy as np
+from collections import OrderedDict
+from jax import jit as jjit
+from jax import vmap
+from jax import numpy as jnp
+
+
+LGSM_K = 5.0
+LGSSFR_K = 5.0
+
+DEFAULT_DUST_DELTA_PDICT = OrderedDict(
+    dust_delta_logsm_x0_x0=10.0,
+    dust_delta_logsm_x0_q=10.5,
+    dust_delta_logsm_x0_ms=9.5,
+    dust_delta_logsm_ylo_x0=-10.25,
+    dust_delta_logsm_ylo_q=-0.5,
+    dust_delta_logsm_ylo_ms=-0.2,
+    dust_delta_logsm_yhi_x0=-11.25,
+    dust_delta_logsm_yhi_q=-0.3,
+    dust_delta_logsm_yhi_ms=-0.4,
+)
+
+LGSM_X0_BOUNDS = (8.0, 12.0)
+LGSSFR_X0_BOUNDS = (-13.0, -7.0)
+DUST_DELTA_BOUNDS = (-1.1, 0.0)
+DUST_DELTA_BOUNDS_PDICT = OrderedDict(
+    dust_delta_logsm_x0_x0=LGSM_X0_BOUNDS,
+    dust_delta_logsm_x0_q=LGSM_X0_BOUNDS,
+    dust_delta_logsm_x0_ms=LGSM_X0_BOUNDS,
+    dust_delta_logsm_ylo_x0=LGSSFR_X0_BOUNDS,
+    dust_delta_logsm_ylo_q=DUST_DELTA_BOUNDS,
+    dust_delta_logsm_ylo_ms=DUST_DELTA_BOUNDS,
+    dust_delta_logsm_yhi_x0=LGSSFR_X0_BOUNDS,
+    dust_delta_logsm_yhi_q=DUST_DELTA_BOUNDS,
+    dust_delta_logsm_yhi_ms=DUST_DELTA_BOUNDS,
+)
+
+DEFAULT_DUST_DELTA_PARAMS = np.array(list(DEFAULT_DUST_DELTA_PDICT.values()))
+DUST_DELTA_PBOUNDS = np.array(list(DUST_DELTA_BOUNDS_PDICT.values()))
+
+
+@jjit
+def _get_dust_delta_galpop_from_u_params(
+    gal_logsm, gal_logssfr, dust_delta_pop_u_params
+):
+    dust_delta_pop_params = _get_bounded_dust_delta_params(dust_delta_pop_u_params)
+    dust_delta = _get_dust_delta_galpop_from_params(
+        gal_logsm, gal_logssfr, dust_delta_pop_params
+    )
+    return dust_delta
+
+
+@jjit
+def _get_dust_delta_galpop_from_params(gal_logsm, gal_logssfr, dust_delta_pop_params):
+    (
+        dust_delta_logsm_x0_x0,
+        dust_delta_logsm_x0_q,
+        dust_delta_logsm_x0_ms,
+        dust_delta_logsm_ylo_x0,
+        dust_delta_logsm_ylo_q,
+        dust_delta_logsm_ylo_ms,
+        dust_delta_logsm_yhi_x0,
+        dust_delta_logsm_yhi_q,
+        dust_delta_logsm_yhi_ms,
+    ) = dust_delta_pop_params
+
+    dust_delta_logssfr_x0 = _sigmoid(
+        gal_logsm,
+        dust_delta_logsm_x0_x0,
+        LGSM_K,
+        dust_delta_logsm_ylo_x0,
+        dust_delta_logsm_yhi_x0,
+    )
+    dust_delta_logssfr_q = _sigmoid(
+        gal_logsm,
+        dust_delta_logsm_x0_q,
+        LGSM_K,
+        dust_delta_logsm_ylo_q,
+        dust_delta_logsm_yhi_q,
+    )
+    dust_delta_logssfr_ms = _sigmoid(
+        gal_logsm,
+        dust_delta_logsm_x0_ms,
+        LGSSFR_K,
+        dust_delta_logsm_ylo_ms,
+        dust_delta_logsm_yhi_ms,
+    )
+
+    dust_delta = _sigmoid(
+        gal_logssfr,
+        dust_delta_logssfr_x0,
+        LGSSFR_K,
+        dust_delta_logssfr_q,
+        dust_delta_logssfr_ms,
+    )
+    return dust_delta
+
+
+@jjit
+def _sigmoid(x, x0, k, ymin, ymax):
+    height_diff = ymax - ymin
+    return ymin + height_diff / (1 + jnp.exp(-k * (x - x0)))
+
+
+@jjit
+def _inverse_sigmoid(y, x0, k, ylo, yhi):
+    lnarg = (yhi - ylo) / (y - ylo) - 1
+    return x0 - jnp.log(lnarg) / k
+
+
+@jjit
+def _get_bounded_dust_delta_param(u_param, bound):
+    lo, hi = bound
+    mid = 0.5 * (lo + hi)
+    return _sigmoid(u_param, mid, 0.1, lo, hi)
+
+
+@jjit
+def _get_unbounded_dust_delta_param(param, bound):
+    lo, hi = bound
+    mid = 0.5 * (lo + hi)
+    return _inverse_sigmoid(param, mid, 0.1, lo, hi)
+
+
+_C = (0, 0)
+_get_dust_delta_params_kern = jjit(vmap(_get_bounded_dust_delta_param, in_axes=_C))
+_get_dust_delta_u_params_kern = jjit(vmap(_get_unbounded_dust_delta_param, in_axes=_C))
+
+
+@jjit
+def _get_bounded_dust_delta_params(u_params):
+    params = _get_dust_delta_params_kern(u_params, DUST_DELTA_PBOUNDS)
+    return params
+
+
+@jjit
+def _get_unbounded_dust_delta_params(params):
+    u_params = _get_dust_delta_u_params_kern(params, DUST_DELTA_PBOUNDS)
+    return u_params
+
+
+DEFAULT_DUST_DELTA_U_PARAMS = np.array(
+    _get_unbounded_dust_delta_params(DEFAULT_DUST_DELTA_PARAMS)
+)

--- a/diffsky/experimental/dspspop/lgavpop.py
+++ b/diffsky/experimental/dspspop/lgavpop.py
@@ -1,0 +1,140 @@
+"""
+"""
+import numpy as np
+from collections import OrderedDict
+from jax import jit as jjit
+from jax import vmap
+from jax import numpy as jnp
+
+
+LGSM_K = 5.0
+LGSSFR_K = 5.0
+
+DEFAULT_LGAV_PDICT = OrderedDict(
+    lgav_logsm_x0_x0=10.0,
+    lgav_logsm_x0_q=10.5,
+    lgav_logsm_x0_ms=9.5,
+    lgav_logsm_ylo_x0=-10.25,
+    lgav_logsm_ylo_q=-2.0,
+    lgav_logsm_ylo_ms=-0.75,
+    lgav_logsm_yhi_x0=-11.25,
+    lgav_logsm_yhi_q=-3.0,
+    lgav_logsm_yhi_ms=-1.0,
+)
+
+LGSM_X0_BOUNDS = (8.0, 12.0)
+LGSSFR_X0_BOUNDS = (-13.0, -7.0)
+LGAV_BOUNDS = (-4.0, 1.5)
+LGAV_BOUNDS_PDICT = OrderedDict(
+    lgav_logsm_x0_x0=LGSM_X0_BOUNDS,
+    lgav_logsm_x0_q=LGSM_X0_BOUNDS,
+    lgav_logsm_x0_ms=LGSM_X0_BOUNDS,
+    lgav_logsm_ylo_x0=LGSSFR_X0_BOUNDS,
+    lgav_logsm_ylo_q=LGAV_BOUNDS,
+    lgav_logsm_ylo_ms=LGAV_BOUNDS,
+    lgav_logsm_yhi_x0=LGSSFR_X0_BOUNDS,
+    lgav_logsm_yhi_q=LGAV_BOUNDS,
+    lgav_logsm_yhi_ms=LGAV_BOUNDS,
+)
+
+DEFAULT_LGAV_PARAMS = np.array(list(DEFAULT_LGAV_PDICT.values()))
+LGAV_PBOUNDS = np.array(list(LGAV_BOUNDS_PDICT.values()))
+
+
+@jjit
+def _get_lgav_galpop_from_u_params(gal_logsm, gal_logssfr, lgav_pop_u_params):
+    lgav_pop_params = _get_bounded_lgav_params(lgav_pop_u_params)
+    lgav = _get_lgav_galpop_from_params(gal_logsm, gal_logssfr, lgav_pop_params)
+    return lgav
+
+
+@jjit
+def _get_lgav_galpop_from_params(gal_logsm, gal_logssfr, lgav_pop_params):
+    (
+        lgav_logsm_x0_x0,
+        lgav_logsm_x0_q,
+        lgav_logsm_x0_ms,
+        lgav_logsm_ylo_x0,
+        lgav_logsm_ylo_q,
+        lgav_logsm_ylo_ms,
+        lgav_logsm_yhi_x0,
+        lgav_logsm_yhi_q,
+        lgav_logsm_yhi_ms,
+    ) = lgav_pop_params
+
+    lgav_logssfr_x0 = _sigmoid(
+        gal_logsm,
+        lgav_logsm_x0_x0,
+        LGSM_K,
+        lgav_logsm_ylo_x0,
+        lgav_logsm_yhi_x0,
+    )
+    lgav_logssfr_q = _sigmoid(
+        gal_logsm,
+        lgav_logsm_x0_q,
+        LGSM_K,
+        lgav_logsm_ylo_q,
+        lgav_logsm_yhi_q,
+    )
+    lgav_logssfr_ms = _sigmoid(
+        gal_logsm,
+        lgav_logsm_x0_ms,
+        LGSSFR_K,
+        lgav_logsm_ylo_ms,
+        lgav_logsm_yhi_ms,
+    )
+
+    lgav = _sigmoid(
+        gal_logssfr,
+        lgav_logssfr_x0,
+        LGSSFR_K,
+        lgav_logssfr_q,
+        lgav_logssfr_ms,
+    )
+    return lgav
+
+
+@jjit
+def _sigmoid(x, x0, k, ymin, ymax):
+    height_diff = ymax - ymin
+    return ymin + height_diff / (1 + jnp.exp(-k * (x - x0)))
+
+
+@jjit
+def _inverse_sigmoid(y, x0, k, ylo, yhi):
+    lnarg = (yhi - ylo) / (y - ylo) - 1
+    return x0 - jnp.log(lnarg) / k
+
+
+@jjit
+def _get_bounded_lgav_param(u_param, bound):
+    lo, hi = bound
+    mid = 0.5 * (lo + hi)
+    return _sigmoid(u_param, mid, 0.1, lo, hi)
+
+
+@jjit
+def _get_unbounded_lgav_param(param, bound):
+    lo, hi = bound
+    mid = 0.5 * (lo + hi)
+    return _inverse_sigmoid(param, mid, 0.1, lo, hi)
+
+
+_C = (0, 0)
+_get_lgav_params_kern = jjit(vmap(_get_bounded_lgav_param, in_axes=_C))
+_get_lgav_u_params_kern = jjit(vmap(_get_unbounded_lgav_param, in_axes=_C))
+
+
+@jjit
+def _get_bounded_lgav_params(u_params):
+    params = _get_lgav_params_kern(u_params, LGAV_PBOUNDS)
+    return params
+
+
+@jjit
+def _get_unbounded_lgav_params(params):
+    u_params = _get_lgav_u_params_kern(params, LGAV_PBOUNDS)
+    return u_params
+
+
+DEFAULT_LGAV_U_PARAMS = np.array(_get_unbounded_lgav_params(DEFAULT_LGAV_PARAMS))

--- a/diffsky/experimental/dspspop/photpop.py
+++ b/diffsky/experimental/dspspop/photpop.py
@@ -44,7 +44,8 @@ def get_obs_photometry_singlez(
     gal_sfr_table,
     lgfburst_pop_u_params,
     burstshapepop_u_params,
-    att_curve_params_pop,
+    lgav_u_params,
+    dust_delta_u_params,
     fracuno_pop_u_params,
     cosmo_params,
     z_obs,
@@ -84,8 +85,11 @@ def get_obs_photometry_singlez(
     burstshapepop_u_params : ndarray of shape (n_burstshapepop_params, )
         Unbounded parameters of the burstshapepop model
 
-    att_curve_params_pop : 2-element tuple of bounded parameters
-        att_curve_params_pop = (tau_params, delta_params)
+    lgav_u_params : ndarray of shape (n_lgavpop_params, )
+        Unbounded parameters of the lgav model
+
+    dust_delta_u_params : ndarray of shape (n_dust_deltapop_params, )
+        Unbounded parameters of the dust_delta model
 
     fracuno_pop_u_params : ndarray of shape (n_funo_params, )
         unbounded parameters of the boris_dust model
@@ -184,7 +188,8 @@ def get_obs_photometry_singlez(
         ssp_lg_age_gyr,
         filter_waves,
         filter_trans,
-        att_curve_params_pop,
+        lgav_u_params,
+        dust_delta_u_params,
         fracuno_pop_u_params,
     )
 

--- a/diffsky/experimental/dspspop/tests/test_attavpop.py
+++ b/diffsky/experimental/dspspop/tests/test_attavpop.py
@@ -1,0 +1,45 @@
+"""
+"""
+import numpy as np
+from ..lgavpop import _get_lgav_galpop_from_params
+from ..lgavpop import _get_lgav_galpop_from_u_params
+from ..lgavpop import DEFAULT_LGAV_U_PARAMS, DEFAULT_LGAV_PARAMS
+from ..lgavpop import _get_bounded_lgav_params, _get_unbounded_lgav_params
+
+
+def test_get_bursty_age_weights_pop_evaluates():
+    n_gals = 500
+    gal_logsm = np.random.uniform(0, 10, size=(n_gals,))
+    gal_logssfr = np.random.uniform(-12, -8, size=(n_gals,))
+
+    gal_lgav = _get_lgav_galpop_from_params(gal_logsm, gal_logssfr, DEFAULT_LGAV_PARAMS)
+    assert gal_lgav.shape == (n_gals,)
+
+
+def test_get_bursty_age_weights_pop_u_param_inversion():
+    assert np.allclose(
+        DEFAULT_LGAV_PARAMS,
+        _get_bounded_lgav_params(DEFAULT_LGAV_U_PARAMS),
+        rtol=1e-3,
+    )
+
+    inferred_default_params = _get_bounded_lgav_params(
+        _get_unbounded_lgav_params(DEFAULT_LGAV_PARAMS)
+    )
+    assert np.allclose(DEFAULT_LGAV_PARAMS, inferred_default_params, rtol=1e-3)
+
+    n_gals = 500
+    gal_logsm = np.random.uniform(0, 10, size=(n_gals,))
+    gal_logssfr = np.random.uniform(-12, -8, size=(n_gals,))
+
+    gal_lgav = _get_lgav_galpop_from_params(gal_logsm, gal_logssfr, DEFAULT_LGAV_PARAMS)
+    assert gal_lgav.shape == (n_gals,)
+    assert np.all(np.isfinite(gal_lgav))
+
+    gal_lgav_u = _get_lgav_galpop_from_u_params(
+        gal_logsm, gal_logssfr, DEFAULT_LGAV_U_PARAMS
+    )
+    assert gal_lgav_u.shape == (n_gals,)
+    assert np.all(np.isfinite(gal_lgav_u))
+
+    assert np.allclose(gal_lgav, gal_lgav_u, rtol=1e-4)

--- a/diffsky/experimental/dspspop/tests/test_dustdeltapop.py
+++ b/diffsky/experimental/dspspop/tests/test_dustdeltapop.py
@@ -1,0 +1,52 @@
+"""
+"""
+import numpy as np
+from ..dust_deltapop import _get_dust_delta_galpop_from_params
+from ..dust_deltapop import _get_dust_delta_galpop_from_u_params
+from ..dust_deltapop import DEFAULT_DUST_DELTA_U_PARAMS, DEFAULT_DUST_DELTA_PARAMS
+from ..dust_deltapop import (
+    _get_bounded_dust_delta_params,
+    _get_unbounded_dust_delta_params,
+)
+
+
+def test_get_bursty_age_weights_pop_evaluates():
+    n_gals = 500
+    gal_logsm = np.random.uniform(0, 10, size=(n_gals,))
+    gal_logssfr = np.random.uniform(-12, -8, size=(n_gals,))
+
+    gal_dust_delta = _get_dust_delta_galpop_from_params(
+        gal_logsm, gal_logssfr, DEFAULT_DUST_DELTA_PARAMS
+    )
+    assert gal_dust_delta.shape == (n_gals,)
+
+
+def test_get_bursty_age_weights_pop_u_param_inversion():
+    assert np.allclose(
+        DEFAULT_DUST_DELTA_PARAMS,
+        _get_bounded_dust_delta_params(DEFAULT_DUST_DELTA_U_PARAMS),
+        rtol=1e-3,
+    )
+
+    inferred_default_params = _get_bounded_dust_delta_params(
+        _get_unbounded_dust_delta_params(DEFAULT_DUST_DELTA_PARAMS)
+    )
+    assert np.allclose(DEFAULT_DUST_DELTA_PARAMS, inferred_default_params, rtol=1e-3)
+
+    n_gals = 500
+    gal_logsm = np.random.uniform(0, 10, size=(n_gals,))
+    gal_logssfr = np.random.uniform(-12, -8, size=(n_gals,))
+
+    gal_dust_delta = _get_dust_delta_galpop_from_params(
+        gal_logsm, gal_logssfr, DEFAULT_DUST_DELTA_PARAMS
+    )
+    assert gal_dust_delta.shape == (n_gals,)
+    assert np.all(np.isfinite(gal_dust_delta))
+
+    gal_dust_delta_u = _get_dust_delta_galpop_from_u_params(
+        gal_logsm, gal_logssfr, DEFAULT_DUST_DELTA_U_PARAMS
+    )
+    assert gal_dust_delta_u.shape == (n_gals,)
+    assert np.all(np.isfinite(gal_dust_delta_u))
+
+    assert np.allclose(gal_dust_delta, gal_dust_delta_u, rtol=1e-4)

--- a/diffsky/experimental/dspspop/tests/test_photpop.py
+++ b/diffsky/experimental/dspspop/tests/test_photpop.py
@@ -5,10 +5,11 @@ import numpy as np
 from dsps.cosmology import DEFAULT_COSMOLOGY
 
 from ..photpop import get_obs_photometry_singlez
-from ..nagaraj22_dust import TAU_PARAMS, DELTA_PARAMS
 from ..boris_dust import DEFAULT_PARAMS as DEFAULT_BORIS_PARAMS
 from ..lgfburstpop import DEFAULT_LGFBURST_U_PARAMS
 from ..burstshapepop import DEFAULT_BURSTSHAPE_U_PARAMS
+from ..lgavpop import DEFAULT_LGAV_U_PARAMS
+from ..dust_deltapop import DEFAULT_DUST_DELTA_U_PARAMS
 
 
 def test_newphotpop_evaluates():
@@ -32,7 +33,6 @@ def test_newphotpop_evaluates():
 
     z_obs = 0.5
 
-    att_curve_params = (TAU_PARAMS, DELTA_PARAMS)
     ran_key = jran.PRNGKey(0)
 
     res = get_obs_photometry_singlez(
@@ -46,7 +46,8 @@ def test_newphotpop_evaluates():
         gal_sfr_table,
         DEFAULT_LGFBURST_U_PARAMS,
         DEFAULT_BURSTSHAPE_U_PARAMS,
-        att_curve_params,
+        DEFAULT_LGAV_U_PARAMS,
+        DEFAULT_DUST_DELTA_U_PARAMS,
         DEFAULT_BORIS_PARAMS,
         DEFAULT_COSMOLOGY,
         z_obs,


### PR DESCRIPTION
@gbeltzmo this PR implements sigmoid-type models of the attenuation curve parameters Av and δ. All SPS parameters accepted by `dust.get_obs_photometry_singlez` are now bounded. And the Av model no longer depends on redshift.