### PR TITLE
Document how the tw_ndhist kernel is built

### DIFF
--- a/diffsky/diffndhist.py
+++ b/diffsky/diffndhist.py
@@ -8,7 +8,10 @@ from jax import lax
 
 @jjit
 def _tw_cuml_lax_kern(x, m, h):
-    """Triweight kernel version of an err function."""
+    """Triweight kernel version of an err function.
+
+    This kernel accepts and returns scalars for all arguments
+    """
     z = (x - m) / h
     val = (
         -5 * z**7 / 69984
@@ -23,62 +26,44 @@ def _tw_cuml_lax_kern(x, m, h):
 
 
 @jjit
-def _tw_cuml_kern(x, m, h):
-    """Triweight kernel version of an err function."""
-    z = (x - m) / h
-    val = (
-        -5 * z**7 / 69984
-        + 7 * z**5 / 2592
-        - 35 * z**3 / 864
-        + 35 * z / 96
-        + 1 / 2
-    )
-    val = jnp.where(z < -3, 0, val)
-    val = jnp.where(z > 3, 1, val)
-    return val
-
-
-@jjit
-def _tw_bin_weight_kern(x, sig, lo, hi):
-    """Triweight kernel integrated across the boundaries of a single bin."""
-    a = _tw_cuml_kern(x, lo, sig)
-    b = _tw_cuml_kern(x, hi, sig)
-    return a - b
-
-
-@jjit
 def _tw_bin_weight_lax_kern(x, sig, lo, hi):
-    """Triweight kernel integrated across the boundaries of a single bin."""
+    """Triweight kernel integrated across the boundaries of a single bin.
+
+    This kernel accepts and returns scalars for all arguments
+    """
     a = _tw_cuml_lax_kern(x, lo, sig)
     b = _tw_cuml_lax_kern(x, hi, sig)
     return a - b
 
 
-_tw_hist1d_vmap = jjit(vmap(_tw_bin_weight_kern, in_axes=(None, None, 0, 0)))
-
-
-@jjit
-def tw_hist1d(x, sig, xbins):
-    return jnp.sum(_tw_hist1d_vmap(x, sig, xbins[:-1], xbins[1:]), axis=1)
-
-
+# vmap each individual scalar point to be an individual point in n-dimensions
 _A = (0, 0, 0, 0)
 _tw_bin_weight_lax_kern_vmap = jjit(vmap(_tw_bin_weight_lax_kern, in_axes=_A))
 
 
 @jjit
 def _tw_ndhist_kern(nddata, ndsig, ndlo, ndhi):
+    """
+    For an individual scalar point in n-dimensions
+    we take the product of the weights across all dimensions
+    for a single n-dimensional bin
+    """
     return jnp.prod(_tw_bin_weight_lax_kern_vmap(nddata, ndsig, ndlo, ndhi))
 
 
+# Vectorize from a single n-dimensional point to many n-dimensional points
 _tw_ndhist_kern_vmap = jjit(vmap(_tw_ndhist_kern, in_axes=(0, 0, None, None)))
 
 
 @jjit
 def _tw_ndhist_sumkern(nddata, ndsig, ndlo, ndhi):
+    """Sum contributions from all the n-dimensional points
+    again for a single n-dimensional bin
+    """
     return jnp.sum(_tw_ndhist_kern_vmap(nddata, ndsig, ndlo, ndhi))
 
 
+# Repeat the _tw_ndhist_sumkern kernel for many bins at once
 _tw_ndhist_vmap = jjit(vmap(_tw_ndhist_sumkern, in_axes=(None, None, 0, 0)))
 
 


### PR DESCRIPTION
This PR removes a few obsolete kernels and adds some in-line comments to explain how the vmapping works for the `tw_ndhist` function