### PR TITLE
Add tw_ndhist_weighted kernel to diffndhist module

### DIFF
--- a/diffsky/tests/test_diffndhist.py
+++ b/diffsky/tests/test_diffndhist.py
@@ -52,3 +52,79 @@ def test_tw_ndhist_returns_correct_values_hard_coded_examples():
     result = diffndhist._tw_ndhist_vmap(nddata, ndsig, nddata_lo, nddata_hi)
     correct_result = np.array((npts, npts, 0))
     assert np.allclose(result, correct_result)
+
+
+def test_tw_ndhist_weighted_sum_kern():
+    ndim = 3
+
+    xin = np.zeros(ndim)
+    yin = 1.0
+    ndsig = np.zeros(ndim) + 0.1
+    ndlo = np.arange(ndim)
+    ndhi = ndlo + 1
+    res = diffndhist._tw_ndhist_weighted_sum_kern(xin, ndsig, yin, ndlo, ndhi)
+    assert res.shape == ()
+
+
+def test_tw_ndhist_weighted_sum_vmap():
+    npts, ndim = 200, 3
+
+    xin = np.zeros((npts, ndim))
+    sigin = np.zeros((npts, ndim)) + 0.1
+    yin = np.ones(npts)
+    ndlo = np.arange(ndim)
+    ndhi = ndlo + 1
+    result = diffndhist._tw_ndhist_weighted_sum_vmap(xin, sigin, yin, ndlo, ndhi)
+    assert result.shape == (npts,)
+
+
+def test_tw_ndhist_weighted_returns_correctly_shaped_results():
+    npts, ndim = 200, 3
+    nbins = 5
+
+    xin = np.zeros((npts, ndim))
+    sigin = np.zeros((npts, ndim)) + 0.1
+    yin = np.ones(npts)
+    loin = np.zeros((nbins, ndim))
+    hiin = loin + 2.0
+    result = diffndhist.tw_ndhist_weighted(xin, sigin, yin, loin, hiin)
+    assert result.shape == (nbins,)
+
+
+def test_tw_ndhist_weighted_returns_correct_values_hard_coded_examples():
+    """Manually check a few hard-coded specific examples"""
+    xc, yc = -0.5, 0.5
+    npts, ndim = 200, 2
+    nddata = np.tile((xc, yc), npts).reshape((npts, ndim))
+    ndsig = np.zeros_like(nddata) + 0.001
+    ydata = np.random.uniform(0, 1, npts)  # randoms for y
+
+    # Choose 3 different cells to compute the histogram
+    # Cell 1: (1.0 < x < 2.0) & (0.0 < y < 1.0)
+    # Cell 2: (-1.0 < x < 1.0) & (0.0 < y < 3.0)
+    # Cell 3: (0.0 < x < 4.0) & (1.0 < y < 5.0)
+    nddata_lo = np.array([(1.0, 0.0), (-1.0, 0.0), (0.0, 1.0)])
+    nddata_hi = np.array([(2.0, 1.0), (1.0, 3.0), (4.0, 5.0)])
+    result = diffndhist.tw_ndhist_weighted(nddata, ndsig, ydata, nddata_lo, nddata_hi)
+    correct_result = np.array((0, ydata.sum(), 0))
+    assert np.allclose(result, correct_result)
+
+    # Choose 3 different cells to compute the histogram
+    # Cell 1: (-1.0 < x < 0.0) & (-1.0 < y < 0.0)
+    # Cell 2: (0.0 < x < 1.0) & (0.0 < y < 1.0)
+    # Cell 3: (1.0 < x < 2.0) & (1.0 < y < 2.0)
+    nddata_lo = np.array([(-1.0, -1.0), (0.0, 0.0), (1.0, 1.0)])
+    nddata_hi = np.array([(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)])
+    result = diffndhist.tw_ndhist_weighted(nddata, ndsig, ydata, nddata_lo, nddata_hi)
+    correct_result = np.zeros(3)
+    assert np.allclose(result, correct_result)
+
+    # Choose 3 different cells to compute the histogram
+    # Cell 1: (-1.0 < x < 0.0) & (0.0 < y < 1.0)
+    # Cell 2: (-1.0 < x < 0.0) & (-1.0 < y < 1.0)
+    # Cell 3: (1.0 < x < 2.0) & (-2.0 < y < 3.0)
+    nddata_lo = np.array([(-1.0, 0.0), (-1.0, -1.0), (1.0, -2.0)])
+    nddata_hi = np.array([(0.0, 1.0), (0.0, 1.0), (2.0, 3.0)])
+    result = diffndhist.tw_ndhist_weighted(nddata, ndsig, ydata, nddata_lo, nddata_hi)
+    correct_result = np.array((ydata.sum(), ydata.sum(), 0))
+    assert np.allclose(result, correct_result)


### PR DESCRIPTION
The diffndhist module now contains a new kernel, `tw_ndhist_weighted`, that facilitates calculation of quantities such as 
`<y | x0, x0, ..., x2>`. This new kernel works in the same way as `tw_ndhist` in that the N-dimensional points stored in the input `nddata` will be differentiably histogrammed using the triweight trick, only `tw_ndhist_weighted` will sum up `w*y` whereas `tw_ndhist` only summed `w`. Thus dividing the result of `tw_ndhist_weighted` by the result of `tw_ndhist` calculates `<y | x0, x0, ..., x2>`.

@gbeltzmo I'm not sure whether you will want to use this new kernel `tw_ndhist_weighted` or stick with just `tw_ndhist`, it depends on what sumstat you choose. For example, maybe we decide that for our sumstats we want to stick with generalized abundance functions, such as the _number density_ of galaxies residing in some 2-d cells in the space of `{m_r, m_g-m_r}`; in that case you would _only_ need the `tw_ndhist` function. The `tw_ndhist` function works in arbitrary dimension, and so could also be used to calculate number density of galaxies in some 3-d cells in the space of `{m_r, m_g-m_r, m_r-m_z}`.

But if you wanted to include a constraint on, for example, the _average_ color `m_r-m_z` of galaxies residing in a 2-d cell of `{m_r, m_g-m_r}`, then you would need to use the `tw_ndhist_weighted` function.

Whichever sumstats you choose, either kernel lets you manually select whatever binning scheme you want. So I think you will want to make some scatter plots of COSMOS-20 data to pick the N-dimensional cells into which you will bin the data. This way, there is no strict need to span the COSMOS-20 color--magnitude space, and the collection of cells you choose can be whatever regions you want to try to match.