### PR TITLE
Require python 3.9 for rtd

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ sphinx:
   configuration: docs/source/conf.py
 
 python:
-  version: 3
+  version: "3.9"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
Attempts to resolve recent RTD build failure due to upstream dependency change