### PR TITLE
Add consistency test of SFR_MIN between dsps and diffstar

### DIFF
--- a/diffsky/tests/test_dependencies.py
+++ b/diffsky/tests/test_dependencies.py
@@ -1,0 +1,9 @@
+"""
+"""
+import numpy as np
+from diffstar.defaults import SFR_MIN as DIFFSTAR_SFR_MIN
+from dsps.constants import SFR_MIN as DSPS_SFR_MIN
+
+
+def test_diffstar_dsps_sfr_min_consistency():
+    assert np.allclose(DIFFSTAR_SFR_MIN, DSPS_SFR_MIN)


### PR DESCRIPTION
These two packages each implement a clip at SFR_MIN, but neither package depends on the other. Diffsky depends on both, and so this test is natural to enforce here. 