### PR TITLE
Add weekly cron

### DIFF
--- a/.github/workflows/tests_cron.yml
+++ b/.github/workflows/tests_cron.yml
@@ -1,4 +1,4 @@
-name: tests
+name: test_main_branch_dependencies
 
 on:
   workflow_dispatch: null

--- a/.github/workflows/tests_cron.yml
+++ b/.github/workflows/tests_cron.yml
@@ -1,0 +1,87 @@
+name: tests
+
+on:
+  workflow_dispatch: null
+  schedule:
+    # Runs "every Monday & Thursday at 3:05am Central"
+    - cron: '5 8 * * 1,4'
+  push:
+    branches:
+      - main
+  pull_request: null
+
+jobs:
+  tests:
+    name: tests
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.9
+          channels: conda-forge,defaults
+          channel-priority: strict
+          show-channel-urls: true
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
+
+      - name: configure conda and install code
+      # Test against current main branch of all diff+ dependencies
+        shell: bash -l {0}
+        run: |
+          conda config --set always_yes yes
+          mamba install --quiet \
+            --file=requirements.txt
+          mamba install -y -q \
+            flake8 \
+            pytest \
+            pytest-xdist \
+            pytest-cov \
+            pip \
+            setuptools \
+            "setuptools_scm>=7,<8" \
+            python-build
+          pip uninstall diffmah --yes
+          pip uninstall diffstar --yes
+          pip uninstall dsps --yes
+          pip install --no-deps git+https://github.com/ArgonneCPAC/diffmah.git
+          pip install --no-deps git+https://github.com/ArgonneCPAC/diffstar.git
+          pip install --no-deps git+https://github.com/ArgonneCPAC/dsps.git
+          python -m pip install --no-build-isolation --no-deps -e .
+
+      - name: test
+        shell: bash -l {0}
+        run: |
+          pytest -v diffsky --cov --cov-report=xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+
+      - name: test versions
+        shell: bash -el {0}
+        run: |
+          pip uninstall diffsky --yes
+          [[ $(python setup.py --version) != "0.0.0" ]] || exit 1
+
+          rm -rf dist/*
+          python setup.py sdist
+          pip install --no-deps --no-build-isolation dist/*.tar.gz
+          pushd ..
+          python -c "import diffsky; assert diffsky.__version__ != '0.0.0'"
+          popd
+          pip uninstall diffsky --yes
+
+          rm -rf dist/*
+          python -m build --sdist . --outdir dist
+          pip install --no-deps --no-build-isolation dist/*.tar.gz
+          pushd ..
+          python -c "import diffsky; assert diffsky.__version__ != '0.0.0'"
+          popd
+          pip uninstall diffsky --yes
+
+          python -m pip install -v --no-deps --no-build-isolation -e .


### PR DESCRIPTION
With every PR, we now have two separate workflows that run our test suite in different environment configurations:

1. Using the latest releases of all the Diff+ codes in our dependency chain
2. Using the current main branch of all the Diff+ codes in our dependency chain

In addition to tests triggered by a PR, tests with environment config (2) are now part of a cron job that runs this workflow twice a week (early in the morning every Monday and Thursday). This new cron should help make sure we notice when changes to the main branch of one of the Diff+ codes has downstream consequences for this repo.
See https://github.com/LSSTDESC/lsstdesc-diffsky/pull/59 for the analogous implementation in lsstdesc-diffsky.