### PR TITLE
Add analytical calculator for the differential halo mass function `predict_differential_hmf`

### DIFF
--- a/diffsky/mass_functions/__init__.py
+++ b/diffsky/mass_functions/__init__.py
@@ -1,3 +1,6 @@
 """
 """
+
 # flake8: noqa
+
+from .hmf_model import predict_cuml_hmf, predict_differential_hmf

--- a/diffsky/mass_functions/tests/test_mc_hosts.py
+++ b/diffsky/mass_functions/tests/test_mc_hosts.py
@@ -1,8 +1,10 @@
 """
 """
+
 import numpy as np
 from jax import random as jran
 
+from ..hmf_model import DEFAULT_HMF_PARAMS, predict_differential_hmf
 from ..mc_hosts import LGMH_MAX, mc_host_halos_singlez
 
 
@@ -14,3 +16,26 @@ def test_mc_host_halo_logmp_behaves_as_expected():
     assert lgmp_halopop.size > 0
     assert np.all(lgmp_halopop > lgmp_min)
     assert np.all(lgmp_halopop < LGMH_MAX)
+
+
+def test_differential_cumulative_hmf_consistency():
+    ran_key = jran.key(0)
+    z = 0.0
+    lgmp_min = 12.0
+    Lbox = 1000.0
+    Vbox = Lbox**3
+
+    lgm_halopop = mc_host_halos_singlez(ran_key, lgmp_min, z, Vbox)
+    lgm_bins = np.linspace(lgmp_min + 0.5, 14.0, 50)
+
+    differential_hmf = predict_differential_hmf(DEFAULT_HMF_PARAMS, lgm_bins, z)
+
+    binned_counts = np.histogram(lgm_halopop, bins=lgm_bins)[0]
+    differential_hmf_target = binned_counts / Vbox / np.diff(lgm_bins)
+
+    # Interpolate to compare same-sized arrays
+    lgm_binmids = 0.5 * (lgm_bins[:-1] + lgm_bins[1:])
+    lg_diff_hmf = np.log10(differential_hmf)
+    diff_hmf_interp = 10 ** np.interp(lgm_binmids, lgm_bins, lg_diff_hmf)
+
+    assert np.allclose(diff_hmf_interp, differential_hmf_target, rtol=0.1)


### PR DESCRIPTION
The `predict_differential_hmf` function is computed in terms of the gradient of the cumulative halo mass function `predict_cuml_hmf`.

The plot below visualizes a new unit test. To make the orange curve, we generate a Monte Carlo realization of the host halo population, a computation that uses the _cumulative_ halo mass function in the MC generation, and then use a histogram with hard-edged bins to estimate the differential HMF. To make the blue curve, we call the new analytical function, which is implemented by using `jax.grad` on the mass variable of the differential function. So this new unit test ensures self-consistency between the cumulative and differential implementations mass function implementations.
![cuml_vs_differential_hmf](https://github.com/ArgonneCPAC/diffsky/assets/6951595/321631d5-1a9d-4273-8287-070ae6a8face)
