### PR TITLE
New AvPop model with strictly monotonic behavior w/r/t mass and sSFR

### DIFF
--- a/diffsky/dustpop/avpop_mono.py
+++ b/diffsky/dustpop/avpop_mono.py
@@ -15,6 +15,8 @@ LGSM_K = 5.0
 LGSSFR_K = 5.0
 LGAGE_K = 5.0
 
+BOUNDING_K = 0.1
+
 LGAGE_GYR_X0 = 6.5 - 9.0
 LGSM_X0 = 10.0
 LGSSFR_X0 = -10.5
@@ -24,10 +26,10 @@ DEFAULT_AVPOP_PDICT = OrderedDict(
     suav_logssfr_x0=-10.25,
     suav_logsm_ylo_q_z_ylo=-0.25,
     suav_logsm_ylo_ms_z_ylo=-0.25,
-    suav_logsm_ylo_q_z_yhi=-0.25,
-    suav_logsm_ylo_ms_z_yhi=-0.25,
     suav_logsm_yhi_q_z_ylo=-0.25,
     suav_logsm_yhi_ms_z_ylo=-0.25,
+    suav_logsm_ylo_q_z_yhi=-0.25,
+    suav_logsm_ylo_ms_z_yhi=-0.25,
     suav_logsm_yhi_q_z_yhi=-0.25,
     suav_logsm_yhi_ms_z_yhi=-0.25,
     suav_z_x0=1.0,
@@ -45,10 +47,10 @@ AVPOP_PBOUNDS_PDICT = OrderedDict(
     suav_logssfr_x0=LGSSFR_X0_BOUNDS,
     suav_logsm_ylo_q_z_ylo=SUAV_BOUNDS,
     suav_logsm_ylo_ms_z_ylo=SUAV_BOUNDS,
-    suav_logsm_ylo_q_z_yhi=SUAV_BOUNDS,
-    suav_logsm_ylo_ms_z_yhi=SUAV_BOUNDS,
     suav_logsm_yhi_q_z_ylo=SUAV_BOUNDS,
     suav_logsm_yhi_ms_z_ylo=SUAV_BOUNDS,
+    suav_logsm_ylo_q_z_yhi=SUAV_BOUNDS,
+    suav_logsm_ylo_ms_z_yhi=SUAV_BOUNDS,
     suav_logsm_yhi_q_z_yhi=SUAV_BOUNDS,
     suav_logsm_yhi_ms_z_yhi=SUAV_BOUNDS,
     suav_z_x0=REDSHIFT_BOUNDS,
@@ -67,62 +69,64 @@ AVPOP_PBOUNDS = AvPopParams(**AVPOP_PBOUNDS_PDICT)
 
 
 @jjit
+def double_sigmoid_monotonic(
+    u_params, x, y, x0=10.0, y0=-10.5, xk=5.0, yk=5.0, z_bounds=(-3.0, 3.0)
+):
+    """4-D parameter space controlling double-sigmoid function z(x, y)
+    such that ∂z/∂x>0 and ∂z/∂y>0 for all points (x, y)
+
+    """
+    u_x_lo_y_lo, u_x_lo_y_hi, u_x_hi_y_lo, u_x_hi_y_hi = u_params
+
+    # (lo-x, lo-y) can be anything inside the z-bounds
+    x_lo_y_lo = _sigmoid(u_x_lo_y_lo, 0.0, BOUNDING_K, *z_bounds)
+
+    # (hi-x, lo-y) must be larger than (lo-x, lo-y)
+    x_hi_y_lo = _sigmoid(u_x_hi_y_lo, 0.0, BOUNDING_K, x_lo_y_lo, z_bounds[1])
+
+    # compute lower bound of z appropriate for the x-value
+    ylo = _sigmoid(x, x0, xk, x_lo_y_lo, x_hi_y_lo)
+
+    # Lowest value of z must be larger than ylo
+    x_lo_y_hi = _sigmoid(u_x_lo_y_hi, 0.0, BOUNDING_K, ylo, z_bounds[1])
+
+    # z must increase beyond its lowest value of x_lo_y_hi
+    x_hi_y_hi = _sigmoid(u_x_hi_y_hi, 0.0, BOUNDING_K, x_lo_y_hi, z_bounds[1])
+
+    # compute upper bound of z
+    yhi = _sigmoid(x, x0, xk, x_lo_y_hi, x_hi_y_hi)
+
+    z = _sigmoid(y, y0, yk, ylo, yhi)
+
+    return z
+
+
+@jjit
 def get_av_from_avpop_params_scalar(avpop_params, logsm, logssfr, redshift, lg_age_gyr):
-    suav_logssfr_q_z_ylo = _sigmoid(
-        logsm,
-        avpop_params.suav_logsm_x0,
-        LGSM_K,
+    u_params_z_ylo = (
         avpop_params.suav_logsm_ylo_q_z_ylo,
-        avpop_params.suav_logsm_yhi_q_z_ylo,
-    )
-    suav_logssfr_ms_z_ylo = _sigmoid(
-        logsm,
-        avpop_params.suav_logsm_x0,
-        LGSSFR_K,
         avpop_params.suav_logsm_ylo_ms_z_ylo,
+        avpop_params.suav_logsm_yhi_q_z_ylo,
         avpop_params.suav_logsm_yhi_ms_z_ylo,
     )
+    suav_z_ylo = double_sigmoid_monotonic(u_params_z_ylo, logsm, logssfr)
 
-    suav_z_ylo = _sigmoid(
-        logssfr,
-        avpop_params.suav_logssfr_x0,
-        LGSSFR_K,
-        suav_logssfr_q_z_ylo,
-        suav_logssfr_ms_z_ylo,
-    )
-
-    suav_logssfr_q_z_yhi = _sigmoid(
-        logsm,
-        avpop_params.suav_logsm_x0,
-        LGSM_K,
+    u_params_z_yhi = (
         avpop_params.suav_logsm_ylo_q_z_yhi,
-        avpop_params.suav_logsm_yhi_q_z_yhi,
-    )
-    suav_logssfr_ms_z_yhi = _sigmoid(
-        logsm,
-        avpop_params.suav_logsm_x0,
-        LGSSFR_K,
         avpop_params.suav_logsm_ylo_ms_z_yhi,
+        avpop_params.suav_logsm_yhi_q_z_yhi,
         avpop_params.suav_logsm_yhi_ms_z_yhi,
     )
+    suav_z_yhi = double_sigmoid_monotonic(u_params_z_yhi, logsm, logssfr)
 
-    suav_z_yhi = _sigmoid(
-        logssfr,
-        avpop_params.suav_logssfr_x0,
-        LGSSFR_K,
-        suav_logssfr_q_z_yhi,
-        suav_logssfr_ms_z_yhi,
-    )
-
-    u_av = _sigmoid(
+    suav = _sigmoid(
         redshift, avpop_params.suav_z_x0, REDSHIFT_K, suav_z_ylo, suav_z_yhi
     )
 
     delta_suav_age = _young_star_av_boost_kern(lg_age_gyr, avpop_params.delta_suav_age)
-    u_av = u_av + delta_suav_age
+    suav = suav + delta_suav_age
 
-    av = nn.softplus(u_av)
-
+    av = nn.softplus(suav)
     return av
 
 
@@ -135,14 +139,14 @@ def _young_star_av_boost_kern(lg_age_gyr, u_av_boost_ostars):
 def _get_bounded_suav_param(u_param, bound):
     lo, hi = bound
     mid = 0.5 * (lo + hi)
-    return _sigmoid(u_param, mid, 0.1, lo, hi)
+    return _sigmoid(u_param, mid, BOUNDING_K, lo, hi)
 
 
 @jjit
 def _get_unbounded_suav_param(param, bound):
     lo, hi = bound
     mid = 0.5 * (lo + hi)
-    return _inverse_sigmoid(param, mid, 0.1, lo, hi)
+    return _inverse_sigmoid(param, mid, BOUNDING_K, lo, hi)
 
 
 _C = (0, 0)

--- a/diffsky/dustpop/avpop_mono.py
+++ b/diffsky/dustpop/avpop_mono.py
@@ -1,0 +1,169 @@
+"""
+"""
+
+from collections import OrderedDict, namedtuple
+
+from jax import jit as jjit
+from jax import nn
+from jax import numpy as jnp
+from jax import vmap
+
+from ..utils import _inverse_sigmoid, _sigmoid
+
+REDSHIFT_K = 5.0
+LGSM_K = 5.0
+LGSSFR_K = 5.0
+LGAGE_K = 5.0
+
+LGAGE_GYR_X0 = 6.5 - 9.0
+LGSM_X0 = 10.0
+LGSSFR_X0 = -10.5
+
+DEFAULT_AVPOP_PDICT = OrderedDict(
+    lgav_logsm_x0=10.0,
+    lgav_logssfr_x0=-10.25,
+    lgav_logsm_ylo_q_z_ylo=-0.25,
+    lgav_logsm_ylo_ms_z_ylo=-0.25,
+    lgav_logsm_ylo_q_z_yhi=-0.25,
+    lgav_logsm_ylo_ms_z_yhi=-0.25,
+    lgav_logsm_yhi_q_z_ylo=-0.25,
+    lgav_logsm_yhi_ms_z_ylo=-0.25,
+    lgav_logsm_yhi_q_z_yhi=-0.25,
+    lgav_logsm_yhi_ms_z_yhi=-0.25,
+    lgav_z_x0=1.0,
+    delta_u_av=0.2,
+)
+
+LGSM_X0_BOUNDS = (8.0, 12.0)
+LGSSFR_X0_BOUNDS = (-13.0, -7.0)
+LGAV_BOUNDS = (-4.0, 1.5)
+REDSHIFT_BOUNDS = (0.0, 5.0)
+DELTA_U_AV_BOUNDS = (0.0, 1.0)
+
+AVPOP_PBOUNDS_PDICT = OrderedDict(
+    lgav_logsm_x0=LGSM_X0_BOUNDS,
+    lgav_logssfr_x0=LGSSFR_X0_BOUNDS,
+    lgav_logsm_ylo_q_z_ylo=LGAV_BOUNDS,
+    lgav_logsm_ylo_ms_z_ylo=LGAV_BOUNDS,
+    lgav_logsm_ylo_q_z_yhi=LGAV_BOUNDS,
+    lgav_logsm_ylo_ms_z_yhi=LGAV_BOUNDS,
+    lgav_logsm_yhi_q_z_ylo=LGAV_BOUNDS,
+    lgav_logsm_yhi_ms_z_ylo=LGAV_BOUNDS,
+    lgav_logsm_yhi_q_z_yhi=LGAV_BOUNDS,
+    lgav_logsm_yhi_ms_z_yhi=LGAV_BOUNDS,
+    lgav_z_x0=REDSHIFT_BOUNDS,
+    delta_u_av=DELTA_U_AV_BOUNDS,
+)
+
+
+AvPopParams = namedtuple("AvPopParams", DEFAULT_AVPOP_PDICT.keys())
+
+_AVPOP_UPNAMES = ["u_" + key for key in AVPOP_PBOUNDS_PDICT.keys()]
+AvPopUParams = namedtuple("AvPopUParams", _AVPOP_UPNAMES)
+
+
+DEFAULT_AVPOP_PARAMS = AvPopParams(**DEFAULT_AVPOP_PDICT)
+AVPOP_PBOUNDS = AvPopParams(**AVPOP_PBOUNDS_PDICT)
+
+
+@jjit
+def get_av_from_avpop_params_scalar(avpop_params, logsm, logssfr, redshift, lg_age_gyr):
+    lgav_logssfr_q_z_ylo = _sigmoid(
+        logsm,
+        avpop_params.lgav_logsm_x0,
+        LGSM_K,
+        avpop_params.lgav_logsm_ylo_q_z_ylo,
+        avpop_params.lgav_logsm_yhi_q_z_ylo,
+    )
+    lgav_logssfr_ms_z_ylo = _sigmoid(
+        logsm,
+        avpop_params.lgav_logsm_x0,
+        LGSSFR_K,
+        avpop_params.lgav_logsm_ylo_ms_z_ylo,
+        avpop_params.lgav_logsm_yhi_ms_z_ylo,
+    )
+
+    lgav_z_ylo = _sigmoid(
+        logssfr,
+        avpop_params.lgav_logssfr_x0,
+        LGSSFR_K,
+        lgav_logssfr_q_z_ylo,
+        lgav_logssfr_ms_z_ylo,
+    )
+
+    lgav_logssfr_q_z_yhi = _sigmoid(
+        logsm,
+        avpop_params.lgav_logsm_x0,
+        LGSM_K,
+        avpop_params.lgav_logsm_ylo_q_z_yhi,
+        avpop_params.lgav_logsm_yhi_q_z_yhi,
+    )
+    lgav_logssfr_ms_z_yhi = _sigmoid(
+        logsm,
+        avpop_params.lgav_logsm_x0,
+        LGSSFR_K,
+        avpop_params.lgav_logsm_ylo_ms_z_yhi,
+        avpop_params.lgav_logsm_yhi_ms_z_yhi,
+    )
+
+    lgav_z_yhi = _sigmoid(
+        logssfr,
+        avpop_params.lgav_logssfr_x0,
+        LGSSFR_K,
+        lgav_logssfr_q_z_yhi,
+        lgav_logssfr_ms_z_yhi,
+    )
+
+    u_av = _sigmoid(
+        redshift, avpop_params.lgav_z_x0, REDSHIFT_K, lgav_z_ylo, lgav_z_yhi
+    )
+
+    delta_u_av = _young_star_av_boost_kern(lg_age_gyr, avpop_params.u_av_boost_ostars)
+    u_av = u_av + delta_u_av
+
+    av = nn.softplus(u_av)
+
+    return av
+
+
+@jjit
+def _young_star_av_boost_kern(lg_age_gyr, u_av_boost_ostars):
+    return _sigmoid(lg_age_gyr, LGAGE_GYR_X0, LGAGE_K, u_av_boost_ostars, 0)
+
+
+@jjit
+def _get_bounded_lgav_param(u_param, bound):
+    lo, hi = bound
+    mid = 0.5 * (lo + hi)
+    return _sigmoid(u_param, mid, 0.1, lo, hi)
+
+
+@jjit
+def _get_unbounded_lgav_param(param, bound):
+    lo, hi = bound
+    mid = 0.5 * (lo + hi)
+    return _inverse_sigmoid(param, mid, 0.1, lo, hi)
+
+
+_C = (0, 0)
+_get_avpop_params_kern = jjit(vmap(_get_bounded_lgav_param, in_axes=_C))
+_get_lgav_u_params_kern = jjit(vmap(_get_unbounded_lgav_param, in_axes=_C))
+
+
+@jjit
+def get_bounded_avpop_params(u_params):
+    u_params = jnp.array([getattr(u_params, u_pname) for u_pname in _AVPOP_UPNAMES])
+    avpop_params = _get_avpop_params_kern(jnp.array(u_params), jnp.array(AVPOP_PBOUNDS))
+    return AvPopParams(*avpop_params)
+
+
+@jjit
+def get_unbounded_avpop_params(params):
+    params = jnp.array(
+        [getattr(params, pname) for pname in DEFAULT_AVPOP_PARAMS._fields]
+    )
+    u_params = _get_lgav_u_params_kern(jnp.array(params), jnp.array(AVPOP_PBOUNDS))
+    return AvPopUParams(*u_params)
+
+
+DEFAULT_AVPOP_U_PARAMS = AvPopUParams(*get_unbounded_avpop_params(DEFAULT_AVPOP_PARAMS))

--- a/diffsky/dustpop/avpop_mono.py
+++ b/diffsky/dustpop/avpop_mono.py
@@ -20,38 +20,38 @@ LGSM_X0 = 10.0
 LGSSFR_X0 = -10.5
 
 DEFAULT_AVPOP_PDICT = OrderedDict(
-    lgav_logsm_x0=10.0,
-    lgav_logssfr_x0=-10.25,
-    lgav_logsm_ylo_q_z_ylo=-0.25,
-    lgav_logsm_ylo_ms_z_ylo=-0.25,
-    lgav_logsm_ylo_q_z_yhi=-0.25,
-    lgav_logsm_ylo_ms_z_yhi=-0.25,
-    lgav_logsm_yhi_q_z_ylo=-0.25,
-    lgav_logsm_yhi_ms_z_ylo=-0.25,
-    lgav_logsm_yhi_q_z_yhi=-0.25,
-    lgav_logsm_yhi_ms_z_yhi=-0.25,
-    lgav_z_x0=1.0,
+    suav_logsm_x0=10.0,
+    suav_logssfr_x0=-10.25,
+    suav_logsm_ylo_q_z_ylo=-0.25,
+    suav_logsm_ylo_ms_z_ylo=-0.25,
+    suav_logsm_ylo_q_z_yhi=-0.25,
+    suav_logsm_ylo_ms_z_yhi=-0.25,
+    suav_logsm_yhi_q_z_ylo=-0.25,
+    suav_logsm_yhi_ms_z_ylo=-0.25,
+    suav_logsm_yhi_q_z_yhi=-0.25,
+    suav_logsm_yhi_ms_z_yhi=-0.25,
+    suav_z_x0=1.0,
     delta_u_av=0.2,
 )
 
-LGSM_X0_BOUNDS = (8.0, 12.0)
-LGSSFR_X0_BOUNDS = (-13.0, -7.0)
-LGAV_BOUNDS = (-4.0, 1.5)
+LGSM_X0_BOUNDS = (9.0, 11.0)
+LGSSFR_X0_BOUNDS = (-12.0, -8.0)
+SUAV_BOUNDS = (-3.0, 3.0)
 REDSHIFT_BOUNDS = (0.0, 5.0)
 DELTA_U_AV_BOUNDS = (0.0, 1.0)
 
 AVPOP_PBOUNDS_PDICT = OrderedDict(
-    lgav_logsm_x0=LGSM_X0_BOUNDS,
-    lgav_logssfr_x0=LGSSFR_X0_BOUNDS,
-    lgav_logsm_ylo_q_z_ylo=LGAV_BOUNDS,
-    lgav_logsm_ylo_ms_z_ylo=LGAV_BOUNDS,
-    lgav_logsm_ylo_q_z_yhi=LGAV_BOUNDS,
-    lgav_logsm_ylo_ms_z_yhi=LGAV_BOUNDS,
-    lgav_logsm_yhi_q_z_ylo=LGAV_BOUNDS,
-    lgav_logsm_yhi_ms_z_ylo=LGAV_BOUNDS,
-    lgav_logsm_yhi_q_z_yhi=LGAV_BOUNDS,
-    lgav_logsm_yhi_ms_z_yhi=LGAV_BOUNDS,
-    lgav_z_x0=REDSHIFT_BOUNDS,
+    suav_logsm_x0=LGSM_X0_BOUNDS,
+    suav_logssfr_x0=LGSSFR_X0_BOUNDS,
+    suav_logsm_ylo_q_z_ylo=SUAV_BOUNDS,
+    suav_logsm_ylo_ms_z_ylo=SUAV_BOUNDS,
+    suav_logsm_ylo_q_z_yhi=SUAV_BOUNDS,
+    suav_logsm_ylo_ms_z_yhi=SUAV_BOUNDS,
+    suav_logsm_yhi_q_z_ylo=SUAV_BOUNDS,
+    suav_logsm_yhi_ms_z_ylo=SUAV_BOUNDS,
+    suav_logsm_yhi_q_z_yhi=SUAV_BOUNDS,
+    suav_logsm_yhi_ms_z_yhi=SUAV_BOUNDS,
+    suav_z_x0=REDSHIFT_BOUNDS,
     delta_u_av=DELTA_U_AV_BOUNDS,
 )
 
@@ -68,54 +68,54 @@ AVPOP_PBOUNDS = AvPopParams(**AVPOP_PBOUNDS_PDICT)
 
 @jjit
 def get_av_from_avpop_params_scalar(avpop_params, logsm, logssfr, redshift, lg_age_gyr):
-    lgav_logssfr_q_z_ylo = _sigmoid(
+    suav_logssfr_q_z_ylo = _sigmoid(
         logsm,
-        avpop_params.lgav_logsm_x0,
+        avpop_params.suav_logsm_x0,
         LGSM_K,
-        avpop_params.lgav_logsm_ylo_q_z_ylo,
-        avpop_params.lgav_logsm_yhi_q_z_ylo,
+        avpop_params.suav_logsm_ylo_q_z_ylo,
+        avpop_params.suav_logsm_yhi_q_z_ylo,
     )
-    lgav_logssfr_ms_z_ylo = _sigmoid(
+    suav_logssfr_ms_z_ylo = _sigmoid(
         logsm,
-        avpop_params.lgav_logsm_x0,
+        avpop_params.suav_logsm_x0,
         LGSSFR_K,
-        avpop_params.lgav_logsm_ylo_ms_z_ylo,
-        avpop_params.lgav_logsm_yhi_ms_z_ylo,
+        avpop_params.suav_logsm_ylo_ms_z_ylo,
+        avpop_params.suav_logsm_yhi_ms_z_ylo,
     )
 
-    lgav_z_ylo = _sigmoid(
+    suav_z_ylo = _sigmoid(
         logssfr,
-        avpop_params.lgav_logssfr_x0,
+        avpop_params.suav_logssfr_x0,
         LGSSFR_K,
-        lgav_logssfr_q_z_ylo,
-        lgav_logssfr_ms_z_ylo,
+        suav_logssfr_q_z_ylo,
+        suav_logssfr_ms_z_ylo,
     )
 
-    lgav_logssfr_q_z_yhi = _sigmoid(
+    suav_logssfr_q_z_yhi = _sigmoid(
         logsm,
-        avpop_params.lgav_logsm_x0,
+        avpop_params.suav_logsm_x0,
         LGSM_K,
-        avpop_params.lgav_logsm_ylo_q_z_yhi,
-        avpop_params.lgav_logsm_yhi_q_z_yhi,
+        avpop_params.suav_logsm_ylo_q_z_yhi,
+        avpop_params.suav_logsm_yhi_q_z_yhi,
     )
-    lgav_logssfr_ms_z_yhi = _sigmoid(
+    suav_logssfr_ms_z_yhi = _sigmoid(
         logsm,
-        avpop_params.lgav_logsm_x0,
+        avpop_params.suav_logsm_x0,
         LGSSFR_K,
-        avpop_params.lgav_logsm_ylo_ms_z_yhi,
-        avpop_params.lgav_logsm_yhi_ms_z_yhi,
+        avpop_params.suav_logsm_ylo_ms_z_yhi,
+        avpop_params.suav_logsm_yhi_ms_z_yhi,
     )
 
-    lgav_z_yhi = _sigmoid(
+    suav_z_yhi = _sigmoid(
         logssfr,
-        avpop_params.lgav_logssfr_x0,
+        avpop_params.suav_logssfr_x0,
         LGSSFR_K,
-        lgav_logssfr_q_z_yhi,
-        lgav_logssfr_ms_z_yhi,
+        suav_logssfr_q_z_yhi,
+        suav_logssfr_ms_z_yhi,
     )
 
     u_av = _sigmoid(
-        redshift, avpop_params.lgav_z_x0, REDSHIFT_K, lgav_z_ylo, lgav_z_yhi
+        redshift, avpop_params.suav_z_x0, REDSHIFT_K, suav_z_ylo, suav_z_yhi
     )
 
     delta_u_av = _young_star_av_boost_kern(lg_age_gyr, avpop_params.u_av_boost_ostars)
@@ -132,22 +132,22 @@ def _young_star_av_boost_kern(lg_age_gyr, u_av_boost_ostars):
 
 
 @jjit
-def _get_bounded_lgav_param(u_param, bound):
+def _get_bounded_suav_param(u_param, bound):
     lo, hi = bound
     mid = 0.5 * (lo + hi)
     return _sigmoid(u_param, mid, 0.1, lo, hi)
 
 
 @jjit
-def _get_unbounded_lgav_param(param, bound):
+def _get_unbounded_suav_param(param, bound):
     lo, hi = bound
     mid = 0.5 * (lo + hi)
     return _inverse_sigmoid(param, mid, 0.1, lo, hi)
 
 
 _C = (0, 0)
-_get_avpop_params_kern = jjit(vmap(_get_bounded_lgav_param, in_axes=_C))
-_get_lgav_u_params_kern = jjit(vmap(_get_unbounded_lgav_param, in_axes=_C))
+_get_avpop_params_kern = jjit(vmap(_get_bounded_suav_param, in_axes=_C))
+_get_suav_u_params_kern = jjit(vmap(_get_unbounded_suav_param, in_axes=_C))
 
 
 @jjit
@@ -162,7 +162,7 @@ def get_unbounded_avpop_params(params):
     params = jnp.array(
         [getattr(params, pname) for pname in DEFAULT_AVPOP_PARAMS._fields]
     )
-    u_params = _get_lgav_u_params_kern(jnp.array(params), jnp.array(AVPOP_PBOUNDS))
+    u_params = _get_suav_u_params_kern(jnp.array(params), jnp.array(AVPOP_PBOUNDS))
     return AvPopUParams(*u_params)
 
 

--- a/diffsky/dustpop/tests/test_avpop_mono.py
+++ b/diffsky/dustpop/tests/test_avpop_mono.py
@@ -1,0 +1,163 @@
+"""
+"""
+
+import numpy as np
+from jax import random as jran
+
+from ..avpop_flex import (
+    DEFAULT_AVPOP_PARAMS,
+    DEFAULT_AVPOP_U_PARAMS,
+    LGAV_BOUNDS,
+    get_av_from_avpop_params_galpop,
+    get_av_from_avpop_params_singlegal,
+    get_av_from_avpop_u_params_galpop,
+    get_av_from_avpop_u_params_singlegal,
+    get_bounded_avpop_params,
+    get_unbounded_avpop_params,
+)
+
+TOL = 1e-2
+N_AGE = 75
+LGAGE_GYR = np.linspace(5, 10.25, N_AGE) - 9.0
+
+N_GALS = 10
+ZZ = np.zeros(N_GALS)
+
+
+def test_param_u_param_names_propagate_properly():
+    gen = zip(DEFAULT_AVPOP_U_PARAMS._fields, DEFAULT_AVPOP_PARAMS._fields)
+    for u_key, key in gen:
+        assert u_key[:2] == "u_"
+        assert u_key[2:] == key
+
+    inferred_default_params = get_bounded_avpop_params(DEFAULT_AVPOP_U_PARAMS)
+    assert set(inferred_default_params._fields) == set(DEFAULT_AVPOP_PARAMS._fields)
+
+    inferred_default_u_params = get_unbounded_avpop_params(DEFAULT_AVPOP_PARAMS)
+    assert set(inferred_default_u_params._fields) == set(DEFAULT_AVPOP_U_PARAMS._fields)
+
+
+def test_get_bounded_avpop_params_fails_when_passing_params():
+    try:
+        get_bounded_avpop_params(DEFAULT_AVPOP_PARAMS)
+        raise NameError("get_bounded_avpop_params should not accept u_params")
+    except AttributeError:
+        pass
+
+
+def test_get_unbounded_avpop_params_fails_when_passing_u_params():
+    try:
+        get_unbounded_avpop_params(DEFAULT_AVPOP_U_PARAMS)
+        raise NameError("get_unbounded_avpop_params should not accept u_params")
+    except AttributeError:
+        pass
+
+
+def test_get_av_from_avpop_params_fails_when_passing_u_params():
+    logsm, logssfr, redshift = 10.0 + ZZ, -11.0 + ZZ, 1.0 + ZZ
+
+    try:
+        get_av_from_avpop_params_galpop(
+            DEFAULT_AVPOP_U_PARAMS, logsm, logssfr, redshift, LGAGE_GYR
+        )
+        raise NameError("get_av_from_avpop_params should not accept u_params")
+    except AttributeError:
+        pass
+
+
+def test_get_av_from_avpop_u_params_fails_when_passing_params():
+    logsm, logssfr, redshift = 10.0 + ZZ, -11.0 + ZZ, 1.0 + ZZ
+
+    try:
+        get_av_from_avpop_u_params_galpop(
+            DEFAULT_AVPOP_PARAMS, logsm, logssfr, redshift, LGAGE_GYR
+        )
+        raise NameError("get_av_from_avpop_u_params should not accept u_params")
+    except AttributeError:
+        pass
+
+
+def test_get_av_from_avpop_params_galpop_evaluates():
+    ran_key = jran.PRNGKey(0)
+    logsm_key, logssfr_key, z_key = jran.split(ran_key, 3)
+    n_gals = 500
+    logsm = jran.uniform(logsm_key, minval=0, maxval=10, shape=(n_gals,))
+    logssfr = jran.uniform(logssfr_key, minval=-12, maxval=-8, shape=(n_gals,))
+    redshift = jran.uniform(z_key, minval=0, maxval=10, shape=(n_gals,))
+
+    av = get_av_from_avpop_params_galpop(
+        DEFAULT_AVPOP_PARAMS, logsm, logssfr, redshift, LGAGE_GYR
+    )
+    assert av.shape == (n_gals, N_AGE)
+    assert np.all(np.isfinite(av))
+
+
+def test_avpop_u_param_inversion_default_params():
+    assert np.allclose(
+        DEFAULT_AVPOP_PARAMS,
+        get_bounded_avpop_params(DEFAULT_AVPOP_U_PARAMS),
+        rtol=TOL,
+    )
+    assert np.allclose(
+        DEFAULT_AVPOP_U_PARAMS,
+        get_unbounded_avpop_params(DEFAULT_AVPOP_PARAMS),
+        rtol=TOL,
+    )
+
+
+def test_get_av_from_avpop_u_params_galpop_u_param_inversion_galpop():
+    n_tests = 1_000
+    ran_key = jran.PRNGKey(0)
+
+    n_gals = 500
+
+    for __ in range(n_tests):
+        ran_key, logsm_key, logssfr_key, z_key = jran.split(ran_key, 4)
+        logsm = jran.uniform(logsm_key, minval=0, maxval=10, shape=(n_gals,))
+        logssfr = jran.uniform(logssfr_key, minval=-12, maxval=-8, shape=(n_gals,))
+        redshift = jran.uniform(z_key, minval=0, maxval=10, shape=(n_gals,))
+
+        av = get_av_from_avpop_params_galpop(
+            DEFAULT_AVPOP_PARAMS, logsm, logssfr, redshift, LGAGE_GYR
+        )
+        assert av.shape == (n_gals, N_AGE)
+        assert np.all(np.isfinite(av))
+
+        av_u = get_av_from_avpop_u_params_galpop(
+            DEFAULT_AVPOP_U_PARAMS, logsm, logssfr, redshift, LGAGE_GYR
+        )
+        assert av_u.shape == (n_gals, N_AGE)
+        assert np.all(np.isfinite(av_u))
+
+        assert np.allclose(av, av_u, rtol=1e-4)
+
+        assert np.all(LGAV_BOUNDS[0] <= np.log10(av))
+        assert np.all(np.log10(av) < LGAV_BOUNDS[1])
+
+
+def test_get_av_from_avpop_u_params_galpop_pop_u_param_inversion_singlegal():
+    n_tests = 1_000
+    ran_key = jran.PRNGKey(0)
+
+    for __ in range(n_tests):
+        ran_key, logsm_key, logssfr_key, z_key = jran.split(ran_key, 4)
+        logsm = jran.uniform(logsm_key, minval=0, maxval=10, shape=())
+        logssfr = jran.uniform(logssfr_key, minval=-12, maxval=-8, shape=())
+        redshift = jran.uniform(z_key, minval=0, maxval=10, shape=())
+
+        av = get_av_from_avpop_params_singlegal(
+            DEFAULT_AVPOP_PARAMS, logsm, logssfr, redshift, LGAGE_GYR
+        )
+        assert av.shape == (N_AGE,)
+        assert np.all(np.isfinite(av))
+
+        av_u = get_av_from_avpop_u_params_singlegal(
+            DEFAULT_AVPOP_U_PARAMS, logsm, logssfr, redshift, LGAGE_GYR
+        )
+        assert av_u.shape == (N_AGE,)
+        assert np.all(np.isfinite(av_u))
+
+        assert np.allclose(av, av_u, rtol=1e-4)
+
+        assert np.all(LGAV_BOUNDS[0] <= np.log10(av))
+        assert np.all(np.log10(av) < LGAV_BOUNDS[1])


### PR DESCRIPTION
The `avpop_mono` module brings in a new model for AvPop that has strictly monotonic behavior w/r/t mass and sSFR. The new model has 12 parameters, compared to 18 in `avpop_flex`.

Here's a plot of the default model:
![default_avapop_mono_params](https://github.com/ArgonneCPAC/diffsky/assets/6951595/39ff91c7-395e-4ba7-96c4-70ba535ca1fd)

The plots below visualize the behavior of models selected from a few randomly generated points in `u_param` space. Notice that everything is always monotonic. There are unit tests in this PR that enforce this strict monotonic behavior for hundreds of randomly generated models.

![random_avapop_mono_params](https://github.com/ArgonneCPAC/diffsky/assets/6951595/bc73b0f3-f23d-4cf2-9bda-0b5bda63b0a3)
![random_avapop_mono_params2](https://github.com/ArgonneCPAC/diffsky/assets/6951595/5ffdf976-e764-461b-bef7-735bc4d2da4d)
![random_avapop_mono_params3](https://github.com/ArgonneCPAC/diffsky/assets/6951595/ccc8fbb4-30f2-4efb-bec2-a82c5bf06356)

@gbeltzmo I