### PR TITLE
Fqburst mono

### DIFF
--- a/diffsky/burstpop/freqburst_mono.py
+++ b/diffsky/burstpop/freqburst_mono.py
@@ -1,0 +1,141 @@
+"""
+"""
+
+from collections import OrderedDict, namedtuple
+
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import vmap
+
+from ..utils import _inverse_sigmoid, _sigmoid
+
+LGSM_K = 5.0
+LGSSFR_K = 5.0
+
+DEFAULT_FREQBURST_PDICT = OrderedDict(
+    lgfreqburst_logsm_x0_x0=10.0,
+    lgfreqburst_logsm_x0_q=10.5,
+    lgfreqburst_logsm_x0_ms=9.5,
+    lgfreqburst_logsm_ylo_x0=-10.25,
+    lgfreqburst_logsm_ylo_q=-1.0,
+    lgfreqburst_logsm_ylo_ms=-1.0,
+    lgfreqburst_logsm_yhi_x0=-11.25,
+    lgfreqburst_logsm_yhi_q=-1.0,
+    lgfreqburst_logsm_yhi_ms=-1.0,
+)
+
+_LGSM_X0_BOUNDS = (8.0, 12.0)
+_LGSSFR_X0_BOUNDS = (-13.0, -7.0)
+_LGFREQBURST_BOUNDS = (-4.0, 0.0)
+FREQBURST_BOUNDS_PDICT = OrderedDict(
+    lgfreqburst_logsm_x0_x0=_LGSM_X0_BOUNDS,
+    lgfreqburst_logsm_x0_q=_LGSM_X0_BOUNDS,
+    lgfreqburst_logsm_x0_ms=_LGSM_X0_BOUNDS,
+    lgfreqburst_logsm_ylo_x0=_LGSSFR_X0_BOUNDS,
+    lgfreqburst_logsm_ylo_q=_LGFREQBURST_BOUNDS,
+    lgfreqburst_logsm_ylo_ms=_LGFREQBURST_BOUNDS,
+    lgfreqburst_logsm_yhi_x0=_LGSSFR_X0_BOUNDS,
+    lgfreqburst_logsm_yhi_q=_LGFREQBURST_BOUNDS,
+    lgfreqburst_logsm_yhi_ms=_LGFREQBURST_BOUNDS,
+)
+
+FreqburstParams = namedtuple("FreqburstParams", DEFAULT_FREQBURST_PDICT.keys())
+_FREQBURST_UPNAMES = ["u_" + key for key in DEFAULT_FREQBURST_PDICT.keys()]
+FreqburstUParams = namedtuple("FreqburstUParams", _FREQBURST_UPNAMES)
+
+
+DEFAULT_FREQBURST_PARAMS = FreqburstParams(**DEFAULT_FREQBURST_PDICT)
+FREQBURST_PBOUNDS = FreqburstParams(**FREQBURST_BOUNDS_PDICT)
+
+
+@jjit
+def get_lgfreqburst_from_freqburst_u_params(freqburst_u_params, logsm, logssfr):
+    freqburst_params = get_bounded_freqburst_params(freqburst_u_params)
+    lgfreqburst = get_lgfreqburst_from_freqburst_params(
+        freqburst_params, logsm, logssfr
+    )
+    return lgfreqburst
+
+
+@jjit
+def get_lgfreqburst_from_freqburst_params(freqburst_params, logsm, logssfr):
+    lgfreqburst_logssfr_x0 = _sigmoid(
+        logsm,
+        freqburst_params.lgfreqburst_logsm_x0_x0,
+        LGSM_K,
+        freqburst_params.lgfreqburst_logsm_ylo_x0,
+        freqburst_params.lgfreqburst_logsm_yhi_x0,
+    )
+    lgfreqburst_logssfr_q = _sigmoid(
+        logsm,
+        freqburst_params.lgfreqburst_logsm_x0_q,
+        LGSM_K,
+        freqburst_params.lgfreqburst_logsm_ylo_q,
+        freqburst_params.lgfreqburst_logsm_yhi_q,
+    )
+    lgfreqburst_logssfr_ms = _sigmoid(
+        logsm,
+        freqburst_params.lgfreqburst_logsm_x0_ms,
+        LGSSFR_K,
+        freqburst_params.lgfreqburst_logsm_ylo_ms,
+        freqburst_params.lgfreqburst_logsm_yhi_ms,
+    )
+
+    lgfreqburst = _sigmoid(
+        logssfr,
+        lgfreqburst_logssfr_x0,
+        LGSSFR_K,
+        lgfreqburst_logssfr_q,
+        lgfreqburst_logssfr_ms,
+    )
+    return lgfreqburst
+
+
+@jjit
+def _get_bounded_freqburst_param(u_param, bound):
+    lo, hi = bound
+    mid = 0.5 * (lo + hi)
+    return _sigmoid(u_param, mid, 0.1, lo, hi)
+
+
+@jjit
+def _get_unbounded_freqburst_param(param, bound):
+    lo, hi = bound
+    mid = 0.5 * (lo + hi)
+    return _inverse_sigmoid(param, mid, 0.1, lo, hi)
+
+
+_C = (0, 0)
+_get_bounded_freqburst_params_kern = jjit(
+    vmap(_get_bounded_freqburst_param, in_axes=_C)
+)
+_get_unbounded_freqburst_params_kern = jjit(
+    vmap(_get_unbounded_freqburst_param, in_axes=_C)
+)
+
+
+@jjit
+def get_bounded_freqburst_params(u_params):
+    u_params = jnp.array([getattr(u_params, u_pname) for u_pname in _FREQBURST_UPNAMES])
+    params = _get_bounded_freqburst_params_kern(
+        jnp.array(u_params), jnp.array(FREQBURST_PBOUNDS)
+    )
+    freqburst_params = FreqburstParams(*params)
+    return freqburst_params
+
+
+@jjit
+def get_unbounded_freqburst_params(params):
+    params = jnp.array(
+        [getattr(params, pname) for pname in DEFAULT_FREQBURST_PARAMS._fields]
+    )
+    u_params = _get_unbounded_freqburst_params_kern(
+        jnp.array(params), jnp.array(FREQBURST_PBOUNDS)
+    )
+    freqburst_u_params = FreqburstUParams(*u_params)
+    return freqburst_u_params
+
+
+DEFAULT_FREQBURST_U_PARAMS = FreqburstUParams(
+    *get_unbounded_freqburst_params(DEFAULT_FREQBURST_PARAMS)
+)

--- a/diffsky/burstpop/tests/test_freqburst_mono.py
+++ b/diffsky/burstpop/tests/test_freqburst_mono.py
@@ -1,0 +1,121 @@
+"""
+"""
+
+import numpy as np
+from jax import random as jran
+
+from ..freqburst_mono import (
+    DEFAULT_FREQBURST_PARAMS,
+    DEFAULT_FREQBURST_U_PARAMS,
+    get_bounded_freqburst_params,
+    get_lgfreqburst_from_freqburst_params,
+    get_lgfreqburst_from_freqburst_u_params,
+    get_unbounded_freqburst_params,
+)
+
+TOL = 1e-2
+
+
+def test_param_u_param_names_propagate_properly():
+    gen = zip(DEFAULT_FREQBURST_U_PARAMS._fields, DEFAULT_FREQBURST_PARAMS._fields)
+    for u_key, key in gen:
+        assert u_key[:2] == "u_"
+        assert u_key[2:] == key
+
+    inferred_default_params = get_bounded_freqburst_params(DEFAULT_FREQBURST_U_PARAMS)
+    assert set(inferred_default_params._fields) == set(DEFAULT_FREQBURST_PARAMS._fields)
+
+    inferred_default_u_params = get_unbounded_freqburst_params(DEFAULT_FREQBURST_PARAMS)
+    assert set(inferred_default_u_params._fields) == set(
+        DEFAULT_FREQBURST_U_PARAMS._fields
+    )
+
+
+def test_get_bounded_freqburst_params_fails_when_passing_params():
+    try:
+        get_bounded_freqburst_params(DEFAULT_FREQBURST_PARAMS)
+        raise NameError("get_bounded_freqburst_params should not accept u_params")
+    except AttributeError:
+        pass
+
+
+def test_get_unbounded_freqburst_params_fails_when_passing_u_params():
+    try:
+        get_unbounded_freqburst_params(DEFAULT_FREQBURST_U_PARAMS)
+        raise NameError("get_unbounded_freqburst_params should not accept u_params")
+    except AttributeError:
+        pass
+
+
+def test_get_lgfreqburst_from_freqburst_params_fails_when_passing_u_params():
+    logsm, logssfr = 10.0, -11.0
+
+    try:
+        get_lgfreqburst_from_freqburst_params(
+            DEFAULT_FREQBURST_U_PARAMS, logsm, logssfr
+        )
+        raise NameError(
+            "get_lgfreqburst_from_freqburst_params should not accept u_params"
+        )
+    except AttributeError:
+        pass
+
+
+def test_get_lgfreqburst_from_freqburst_u_params_fails_when_passing_params():
+    logsm, logssfr = 10.0, -11.0
+
+    try:
+        get_lgfreqburst_from_freqburst_u_params(
+            DEFAULT_FREQBURST_PARAMS, logsm, logssfr
+        )
+        raise NameError(
+            "get_lgfreqburst_from_freqburst_u_params should not accept u_params"
+        )
+    except AttributeError:
+        pass
+
+
+def test_get_bursty_age_weights_evaluates():
+    ran_key = jran.PRNGKey(0)
+    n_gals = 500
+    ran_key, logsm_key, logssfr_key = jran.split(ran_key, 3)
+    logsm = jran.uniform(logsm_key, minval=0, maxval=10, shape=(n_gals,))
+    logssfr = jran.uniform(logssfr_key, minval=-12, maxval=-8, shape=(n_gals,))
+
+    gal_lgfreqburst = get_lgfreqburst_from_freqburst_params(
+        DEFAULT_FREQBURST_PARAMS, logsm, logssfr
+    )
+    assert gal_lgfreqburst.shape == (n_gals,)
+
+
+def test_get_bursty_age_weights_u_param_inversion():
+    assert np.allclose(
+        DEFAULT_FREQBURST_PARAMS,
+        get_bounded_freqburst_params(DEFAULT_FREQBURST_U_PARAMS),
+        rtol=TOL,
+    )
+
+    inferred_default_params = get_bounded_freqburst_params(
+        get_unbounded_freqburst_params(DEFAULT_FREQBURST_PARAMS)
+    )
+    assert np.allclose(DEFAULT_FREQBURST_PARAMS, inferred_default_params, rtol=TOL)
+
+    ran_key = jran.PRNGKey(0)
+    n_gals = 500
+    ran_key, logsm_key, logssfr_key = jran.split(ran_key, 3)
+    logsm = jran.uniform(logsm_key, minval=0, maxval=10, shape=(n_gals,))
+    logssfr = jran.uniform(logssfr_key, minval=-12, maxval=-8, shape=(n_gals,))
+
+    gal_lgfreqburst = get_lgfreqburst_from_freqburst_params(
+        DEFAULT_FREQBURST_PARAMS, logsm, logssfr
+    )
+    assert gal_lgfreqburst.shape == (n_gals,)
+    assert np.all(np.isfinite(gal_lgfreqburst))
+
+    gal_lgfreqburst_u = get_lgfreqburst_from_freqburst_u_params(
+        DEFAULT_FREQBURST_U_PARAMS, logsm, logssfr
+    )
+    assert gal_lgfreqburst_u.shape == (n_gals,)
+    assert np.all(np.isfinite(gal_lgfreqburst_u))
+
+    assert np.allclose(gal_lgfreqburst, gal_lgfreqburst_u, rtol=1e-4)

--- a/diffsky/burstpop/tests/test_freqburst_mono.py
+++ b/diffsky/burstpop/tests/test_freqburst_mono.py
@@ -8,8 +8,8 @@ from ..freqburst_mono import (
     DEFAULT_FREQBURST_PARAMS,
     DEFAULT_FREQBURST_U_PARAMS,
     get_bounded_freqburst_params,
-    get_lgfreqburst_from_freqburst_params,
-    get_lgfreqburst_from_freqburst_u_params,
+    get_freqburst_from_freqburst_params,
+    get_freqburst_from_freqburst_u_params,
     get_unbounded_freqburst_params,
 )
 
@@ -47,48 +47,44 @@ def test_get_unbounded_freqburst_params_fails_when_passing_u_params():
         pass
 
 
-def test_get_lgfreqburst_from_freqburst_params_fails_when_passing_u_params():
+def test_get_freqburst_from_freqburst_params_fails_when_passing_u_params():
     logsm, logssfr = 10.0, -11.0
 
     try:
-        get_lgfreqburst_from_freqburst_params(
-            DEFAULT_FREQBURST_U_PARAMS, logsm, logssfr
-        )
+        get_freqburst_from_freqburst_params(DEFAULT_FREQBURST_U_PARAMS, logsm, logssfr)
         raise NameError(
-            "get_lgfreqburst_from_freqburst_params should not accept u_params"
+            "get_freqburst_from_freqburst_params should not accept u_params"
         )
     except AttributeError:
         pass
 
 
-def test_get_lgfreqburst_from_freqburst_u_params_fails_when_passing_params():
+def test_get_freqburst_from_freqburst_u_params_fails_when_passing_params():
     logsm, logssfr = 10.0, -11.0
 
     try:
-        get_lgfreqburst_from_freqburst_u_params(
-            DEFAULT_FREQBURST_PARAMS, logsm, logssfr
-        )
+        get_freqburst_from_freqburst_u_params(DEFAULT_FREQBURST_PARAMS, logsm, logssfr)
         raise NameError(
-            "get_lgfreqburst_from_freqburst_u_params should not accept u_params"
+            "get_freqburst_from_freqburst_u_params should not accept u_params"
         )
     except AttributeError:
         pass
 
 
-def test_get_bursty_age_weights_evaluates():
+def test_get_freqburst_from_freqburst_params_evaluates():
     ran_key = jran.PRNGKey(0)
     n_gals = 500
     ran_key, logsm_key, logssfr_key = jran.split(ran_key, 3)
     logsm = jran.uniform(logsm_key, minval=0, maxval=10, shape=(n_gals,))
     logssfr = jran.uniform(logssfr_key, minval=-12, maxval=-8, shape=(n_gals,))
 
-    gal_lgfreqburst = get_lgfreqburst_from_freqburst_params(
+    gal_freqburst = get_freqburst_from_freqburst_params(
         DEFAULT_FREQBURST_PARAMS, logsm, logssfr
     )
-    assert gal_lgfreqburst.shape == (n_gals,)
+    assert gal_freqburst.shape == (n_gals,)
 
 
-def test_get_bursty_age_weights_u_param_inversion():
+def test_freqburst_u_param_inversion():
     assert np.allclose(
         DEFAULT_FREQBURST_PARAMS,
         get_bounded_freqburst_params(DEFAULT_FREQBURST_U_PARAMS),
@@ -106,16 +102,16 @@ def test_get_bursty_age_weights_u_param_inversion():
     logsm = jran.uniform(logsm_key, minval=0, maxval=10, shape=(n_gals,))
     logssfr = jran.uniform(logssfr_key, minval=-12, maxval=-8, shape=(n_gals,))
 
-    gal_lgfreqburst = get_lgfreqburst_from_freqburst_params(
+    gal_freqburst = get_freqburst_from_freqburst_params(
         DEFAULT_FREQBURST_PARAMS, logsm, logssfr
     )
-    assert gal_lgfreqburst.shape == (n_gals,)
-    assert np.all(np.isfinite(gal_lgfreqburst))
+    assert gal_freqburst.shape == (n_gals,)
+    assert np.all(np.isfinite(gal_freqburst))
 
-    gal_lgfreqburst_u = get_lgfreqburst_from_freqburst_u_params(
+    gal_freqburst_u = get_freqburst_from_freqburst_u_params(
         DEFAULT_FREQBURST_U_PARAMS, logsm, logssfr
     )
-    assert gal_lgfreqburst_u.shape == (n_gals,)
-    assert np.all(np.isfinite(gal_lgfreqburst_u))
+    assert gal_freqburst_u.shape == (n_gals,)
+    assert np.all(np.isfinite(gal_freqburst_u))
 
-    assert np.allclose(gal_lgfreqburst, gal_lgfreqburst_u, rtol=1e-4)
+    assert np.allclose(gal_freqburst, gal_freqburst_u, rtol=1e-4)


### PR DESCRIPTION
The `freqburst_mono` module brings in a new model for AvPop that has strictly monotonic behavior w/r/t mass and sSFR. The new model has 6 parameters, compared to 9 in `freqburst`.

Here's a plot of the default model:
![default_fqburst_mono_params](https://github.com/ArgonneCPAC/diffsky/assets/6951595/bb7bff3b-e35e-4c3a-a747-2b9a31655746)

The plots below visualize the behavior of models selected from a few randomly generated points in u_param space. Notice that everything is always monotonic. Notice also that the trends with stellar mass are reversed here relative to the model implemented in #56 - here, burst frequency is enforced to _increase_ with decreasing stellar mass. There are unit tests in this PR that enforce this strict monotonic behavior for hundreds of randomly generated models.
![random_fqburst_mono_params](https://github.com/ArgonneCPAC/diffsky/assets/6951595/ff24bdfb-fccf-4fab-bef4-d1c405de908f)
![random_fqburst_mono_params2](https://github.com/ArgonneCPAC/diffsky/assets/6951595/f10b03b3-e3ed-4086-826e-f0460a2a7645)
![random_fqburst_mono_params3](https://github.com/ArgonneCPAC/diffsky/assets/6951595/d2472341-6340-4009-b9c1-3519ac6241a2)

