### PR TITLE
Fix error message when passing wrong params/u_params

### DIFF
--- a/diffsky/burstpop/tests/test_fburstpop.py
+++ b/diffsky/burstpop/tests/test_fburstpop.py
@@ -33,7 +33,7 @@ def test_param_u_param_names_propagate_properly():
 def test_get_bounded_fburstpop_params_fails_when_passing_params():
     try:
         get_bounded_fburstpop_params(DEFAULT_FBURSTPOP_PARAMS)
-        raise NameError("get_bounded_fburstpop_params should not accept u_params")
+        raise NameError("get_bounded_fburstpop_params should not accept params")
     except AttributeError:
         pass
 
@@ -62,7 +62,7 @@ def test_get_lgfburst_from_fburstpop_u_params_fails_when_passing_params():
     try:
         get_lgfburst_from_fburstpop_u_params(DEFAULT_FBURSTPOP_PARAMS, logsm, logssfr)
         raise NameError(
-            "get_lgfburst_from_fburstpop_u_params should not accept u_params"
+            "get_lgfburst_from_fburstpop_u_params should not accept params"
         )
     except AttributeError:
         pass

--- a/diffsky/burstpop/tests/test_freqburst.py
+++ b/diffsky/burstpop/tests/test_freqburst.py
@@ -34,7 +34,7 @@ def test_param_u_param_names_propagate_properly():
 def test_get_bounded_freqburst_params_fails_when_passing_params():
     try:
         get_bounded_freqburst_params(DEFAULT_FREQBURST_PARAMS)
-        raise NameError("get_bounded_freqburst_params should not accept u_params")
+        raise NameError("get_bounded_freqburst_params should not accept params")
     except AttributeError:
         pass
 
@@ -69,7 +69,7 @@ def test_get_lgfreqburst_from_freqburst_u_params_fails_when_passing_params():
             DEFAULT_FREQBURST_PARAMS, logsm, logssfr
         )
         raise NameError(
-            "get_lgfreqburst_from_freqburst_u_params should not accept u_params"
+            "get_lgfreqburst_from_freqburst_u_params should not accept params"
         )
     except AttributeError:
         pass

--- a/diffsky/burstpop/tests/test_freqburst_mono.py
+++ b/diffsky/burstpop/tests/test_freqburst_mono.py
@@ -38,7 +38,7 @@ def test_param_u_param_names_propagate_properly():
 def test_get_bounded_freqburst_params_fails_when_passing_params():
     try:
         get_bounded_freqburst_params(DEFAULT_FREQBURST_PARAMS)
-        raise NameError("get_bounded_freqburst_params should not accept u_params")
+        raise NameError("get_bounded_freqburst_params should not accept params")
     except AttributeError:
         pass
 
@@ -69,7 +69,7 @@ def test_get_freqburst_from_freqburst_u_params_fails_when_passing_params():
     try:
         get_freqburst_from_freqburst_u_params(DEFAULT_FREQBURST_PARAMS, logsm, logssfr)
         raise NameError(
-            "get_freqburst_from_freqburst_u_params should not accept u_params"
+            "get_freqburst_from_freqburst_u_params should not accept params"
         )
     except AttributeError:
         pass

--- a/diffsky/burstpop/tests/test_tburstpop.py
+++ b/diffsky/burstpop/tests/test_tburstpop.py
@@ -38,7 +38,7 @@ def test_param_u_param_names_propagate_properly():
 def test_get_bounded_tburstpop_params_fails_when_passing_params():
     try:
         tbp.get_bounded_tburstpop_params(tbp.DEFAULT_TBURSTPOP_PARAMS)
-        raise NameError("get_bounded_tburstpop_params should not accept u_params")
+        raise NameError("get_bounded_tburstpop_params should not accept params")
     except AttributeError:
         pass
 

--- a/diffsky/dustpop/tests/test_avpop.py
+++ b/diffsky/dustpop/tests/test_avpop.py
@@ -32,7 +32,7 @@ def test_param_u_param_names_propagate_properly():
 def test_get_bounded_avpop_params_fails_when_passing_params():
     try:
         get_bounded_avpop_params(DEFAULT_AVPOP_PARAMS)
-        raise NameError("get_bounded_avpop_params should not accept u_params")
+        raise NameError("get_bounded_avpop_params should not accept params")
     except AttributeError:
         pass
 
@@ -60,7 +60,7 @@ def test_get_av_from_avpop_u_params_fails_when_passing_params():
 
     try:
         get_av_from_avpop_u_params(DEFAULT_AVPOP_PARAMS, logsm, logssfr)
-        raise NameError("get_av_from_avpop_u_params should not accept u_params")
+        raise NameError("get_av_from_avpop_u_params should not accept params")
     except AttributeError:
         pass
 

--- a/diffsky/dustpop/tests/test_avpop_flex.py
+++ b/diffsky/dustpop/tests/test_avpop_flex.py
@@ -39,7 +39,7 @@ def test_param_u_param_names_propagate_properly():
 def test_get_bounded_avpop_params_fails_when_passing_params():
     try:
         get_bounded_avpop_params(DEFAULT_AVPOP_PARAMS)
-        raise NameError("get_bounded_avpop_params should not accept u_params")
+        raise NameError("get_bounded_avpop_params should not accept params")
     except AttributeError:
         pass
 
@@ -71,7 +71,7 @@ def test_get_av_from_avpop_u_params_fails_when_passing_params():
         get_av_from_avpop_u_params_galpop(
             DEFAULT_AVPOP_PARAMS, logsm, logssfr, redshift, LGAGE_GYR
         )
-        raise NameError("get_av_from_avpop_u_params should not accept u_params")
+        raise NameError("get_av_from_avpop_u_params should not accept params")
     except AttributeError:
         pass
 

--- a/diffsky/dustpop/tests/test_deltapop.py
+++ b/diffsky/dustpop/tests/test_deltapop.py
@@ -33,7 +33,7 @@ def test_param_u_param_names_propagate_properly():
 def test_get_bounded_deltapop_params_fails_when_passing_params():
     try:
         get_bounded_deltapop_params(DEFAULT_DELTAPOP_PARAMS)
-        raise NameError("get_bounded_deltapop_params should not accept u_params")
+        raise NameError("get_bounded_deltapop_params should not accept params")
     except AttributeError:
         pass
 

--- a/diffsky/dustpop/tests/test_funopop_model.py
+++ b/diffsky/dustpop/tests/test_funopop_model.py
@@ -34,7 +34,7 @@ def test_param_u_param_names_propagate_properly():
 def test_get_bounded_funopop_params_fails_when_passing_params():
     try:
         get_bounded_funopop_params(DEFAULT_FUNOPOP_PARAMS)
-        raise NameError("get_bounded_funopop_params should not accept u_params")
+        raise NameError("get_bounded_funopop_params should not accept params")
     except AttributeError:
         pass
 

--- a/diffsky/dustpop/tests/test_funopop_simple.py
+++ b/diffsky/dustpop/tests/test_funopop_simple.py
@@ -32,7 +32,7 @@ def test_param_u_param_names_propagate_properly():
 def test_get_bounded_funopop_params_fails_when_passing_params():
     try:
         get_bounded_funopop_params(DEFAULT_FUNOPOP_PARAMS)
-        raise NameError("get_bounded_funopop_params should not accept u_params")
+        raise NameError("get_bounded_funopop_params should not accept params")
     except AttributeError:
         pass
 


### PR DESCRIPTION
@aphearin this is just a fix to the error messages that print, there was no issue with the tests. But since I was looking at how these tests work so that I could write my own, I noticed that some of the tests like "test_get_unbounded_params_fails_when_passing_u_params" were printing error messages that said ""get_unbounded_params should not accept params" instead of "should not accept u_params," so I figured while I was thinking about it I would fix the cases where this happens so the error message makes sense. Again, just a problem with the message that prints, not a problem with the tests. I think I got them all but you can double check.