### PR TITLE
Monte Carlo generators for `t_peak`-based Diffmah

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: test-latest-releases
 
 on:
   push:
@@ -43,6 +43,8 @@ jobs:
             "setuptools_scm>=7,<8" \
             matplotlib \
             python-build
+          pip uninstall diffmah --yes
+          pip install --no-deps git+https://github.com/ArgonneCPAC/diffmah.git
           pip uninstall dsps --yes
           pip install --no-deps git+https://github.com/ArgonneCPAC/dsps.git
           python -m pip install --no-build-isolation --no-deps -e .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: test-latest-releases
+name: test-latest-diffstuff-releases
 
 on:
   push:
@@ -43,8 +43,6 @@ jobs:
             "setuptools_scm>=7,<8" \
             matplotlib \
             python-build
-          pip uninstall diffmah --yes
-          pip install --no-deps git+https://github.com/ArgonneCPAC/diffmah.git
           pip uninstall dsps --yes
           pip install --no-deps git+https://github.com/ArgonneCPAC/dsps.git
           python -m pip install --no-build-isolation --no-deps -e .

--- a/.github/workflows/tests_cron.yml
+++ b/.github/workflows/tests_cron.yml
@@ -1,4 +1,4 @@
-name: test_main_branch_dependencies
+name: test-main-branch-diffstuff
 
 on:
   workflow_dispatch: null

--- a/diffsky/__init__.py
+++ b/diffsky/__init__.py
@@ -1,5 +1,7 @@
 """
 """
+
 # flake8: noqa
 
 from ._version import __version__
+from .mass_functions.mc_diffmah_tpeak import mc_subhalos

--- a/diffsky/mass_functions/mc_diffmah_tpeak.py
+++ b/diffsky/mass_functions/mc_diffmah_tpeak.py
@@ -1,0 +1,144 @@
+"""
+"""
+
+import typing
+
+import numpy as np
+from diffmah.diffmah_kernels import DiffmahParams
+from diffmah.diffmahpop_kernels.diffmahpop_params_monocensat import (
+    DEFAULT_DIFFMAHPOP_PARAMS,
+)
+from diffmah.diffmahpop_kernels.mc_diffmahpop_kernels_monocens import (
+    mc_diffmah_params_cenpop,
+)
+from diffmah.diffmahpop_kernels.mc_diffmahpop_kernels_monosats import (
+    mc_diffmah_params_satpop,
+)
+from dsps.cosmology.defaults import DEFAULT_COSMOLOGY
+from dsps.cosmology.flat_wcdm import _age_at_z_kern
+from jax import random as jran
+
+from .mc_hosts import mc_host_halos_singlez
+from .mc_subs import generate_subhalopop
+
+
+class SubhaloCatalog(typing.NamedTuple):
+    mah_params: np.ndarray
+    log_mpeak_penultimate_infall: np.ndarray
+    log_mpeak_ultimate_infall: np.ndarray
+    log_mhost_penultimate_infall: np.ndarray
+    log_mhost_ultimate_infall: np.ndarray
+    t_obs: np.ndarray
+    t_penultimate_infall: np.ndarray
+    t_ultimate_infall: np.ndarray
+    upids: np.ndarray
+    penultimate_indx: np.ndarray
+    ultimate_indx: np.ndarray
+
+
+def mc_subhalo_catalog_singlez(
+    ran_key,
+    lgmp_min,
+    redshift,
+    volume_com,
+    cosmo=DEFAULT_COSMOLOGY,
+    diffmahpop_params=DEFAULT_DIFFMAHPOP_PARAMS,
+):
+    """Monte Carlo realization of a subhalo catalog at the input redshift
+
+    Parameters
+    ----------
+    ran_key : jran.PRNGKey
+
+    lgmp_min : float
+        Base-10 log of the halo mass competeness limit of the generated population
+
+        Smaller values of lgmp_min produce more halos in the returned sample
+
+    redshift : float
+        Redshift of the halo population
+
+    volume_com : float
+        volume_com = Lbox**3 where Lbox is in comoving in units of Mpc/h
+
+        Larger values of volume_com produce more halos in the returned sample
+
+    Returns
+    -------
+    SubhaloCatalog : namedtuple
+
+        mah_params: np.ndarray, shape (n_halos, 4)
+        log_mpeak_penultimate_infall: np.ndarray, shape (n_halos, )
+        log_mpeak_ultimate_infall: np.ndarray, shape (n_halos, )
+        log_mhost_penultimate_infall: np.ndarray, shape (n_halos, )
+        log_mhost_ultimate_infall: np.ndarray, shape (n_halos, )
+        t_obs: float
+        t_penultimate_infall: np.ndarray, shape (n_halos, )
+        t_ultimate_infall: np.ndarray, shape (n_halos, )
+        upids: np.ndarray, shape (n_halos, )
+        penultimate_indx: np.ndarray, shape (n_halos, )
+        ultimate_indx: np.ndarray, shape (n_halos, )
+
+    """
+
+    host_key1, host_key2, sub_key1, sub_key2 = jran.split(ran_key, 4)
+    hosts_logmh_at_z = mc_host_halos_singlez(host_key1, lgmp_min, redshift, volume_com)
+
+    subhalo_info = generate_subhalopop(sub_key1, hosts_logmh_at_z, lgmp_min)
+    subs_lgmu, subs_lgmhost, subs_host_halo_indx = subhalo_info
+
+    subs_logmh_at_z = subs_lgmu + subs_lgmhost
+
+    t_obs = _age_at_z_kern(redshift, *cosmo)
+    t_0 = _age_at_z_kern(0.0, *cosmo)
+    lgt0 = np.log10(t_0)
+
+    n_cens = hosts_logmh_at_z.size
+    hosts_halo_id = np.arange(n_cens).astype(int)
+    _ZH = np.zeros(n_cens)
+
+    hosts_diffmah, hosts_t_peak = mc_diffmah_params_cenpop(
+        diffmahpop_params, hosts_logmh_at_z, t_obs + _ZH, host_key2, lgt0
+    )
+
+    n_sats = subs_logmh_at_z.size
+    _ZS = np.zeros(n_sats)
+    subs_diffmah, subs_t_peak = mc_diffmah_params_satpop(
+        diffmahpop_params, subs_logmh_at_z, t_obs + _ZS, sub_key2
+    )
+
+    mah_params = DiffmahParams(
+        *[np.concatenate((x, y)) for x, y in zip(hosts_diffmah, subs_diffmah)]
+    )
+
+    log_mpeak_penultimate_infall = np.concatenate((hosts_logmh_at_z, subs_logmh_at_z))
+    log_mpeak_ultimate_infall = np.concatenate((hosts_logmh_at_z, subs_logmh_at_z))
+
+    log_mhost_penultimate_infall = np.concatenate((hosts_logmh_at_z, subs_lgmhost))
+    log_mhost_ultimate_infall = np.concatenate((hosts_logmh_at_z, subs_lgmhost))
+
+    t_penultimate_infall = np.concatenate((hosts_t_peak, subs_t_peak))
+    t_ultimate_infall = np.concatenate((hosts_t_peak, subs_t_peak))
+
+    upids = np.concatenate(
+        (np.zeros(n_cens).astype(int) - 1, hosts_halo_id[subs_host_halo_indx])
+    )
+
+    penultimate_indx = np.concatenate(
+        (np.arange(n_cens).astype(int), subs_host_halo_indx)
+    )
+    ultimate_indx = np.concatenate((np.arange(n_cens).astype(int), subs_host_halo_indx))
+    subcat = SubhaloCatalog(
+        mah_params,
+        log_mpeak_penultimate_infall,
+        log_mpeak_ultimate_infall,
+        log_mhost_penultimate_infall,
+        log_mhost_ultimate_infall,
+        t_obs,
+        t_penultimate_infall,
+        t_ultimate_infall,
+        upids,
+        penultimate_indx,
+        ultimate_indx,
+    )
+    return subcat

--- a/diffsky/mass_functions/mc_diffmah_tpeak.py
+++ b/diffsky/mass_functions/mc_diffmah_tpeak.py
@@ -41,7 +41,7 @@ class SubhaloCatalog(typing.NamedTuple):
     ult_host_indx: np.ndarray
 
 
-def mc_subhalo_catalog_singlez(
+def mc_subhalos(
     ran_key,
     lgmp_min,
     redshift,

--- a/diffsky/mass_functions/mc_diffmah_tpeak.py
+++ b/diffsky/mass_functions/mc_diffmah_tpeak.py
@@ -28,6 +28,7 @@ class SubhaloCatalog(typing.NamedTuple):
     t_peak: np.ndarray
     host_mah_params: np.ndarray
     host_t_peak: np.ndarray
+    lgmp_at_t_obs: np.ndarray
     lgmp_pen_inf: np.ndarray
     lgmp_ult_inf: np.ndarray
     lgmhost_pen_inf: np.ndarray
@@ -155,6 +156,7 @@ def mc_subhalo_catalog_singlez(
     mah_params = DiffmahParams(
         *[np.concatenate((x, y)) for x, y in zip(hosts_diffmah, subs_diffmah)]
     )
+    lgmp_at_t_obs = np.array(_log_mah_kern(mah_params, t_obs, t_peak, lgt0))
 
     host_mah_params = DiffmahParams(
         *[np.concatenate((x, y)) for x, y in zip(hosts_diffmah, subs_host_diffmah)]
@@ -190,6 +192,7 @@ def mc_subhalo_catalog_singlez(
         t_peak,
         host_mah_params,
         host_t_peak,
+        lgmp_at_t_obs,
         lgmp_pen_inf,
         lgmp_ult_inf,
         lgmhost_pen_inf,

--- a/diffsky/mass_functions/mc_subhalo_catalog.py
+++ b/diffsky/mass_functions/mc_subhalo_catalog.py
@@ -10,9 +10,9 @@ from dsps.cosmology.defaults import DEFAULT_COSMOLOGY
 from dsps.cosmology.flat_wcdm import _age_at_z_kern
 from jax import random as jran
 
-from diffsky.mass_functions.mc_hosts import mc_host_halos_singlez
-from diffsky.mass_functions.mc_subs import generate_subhalopop
-from diffsky.mass_functions.mc_tinfall import mc_time_since_infall
+from .mc_hosts import mc_host_halos_singlez
+from .mc_subs import generate_subhalopop
+from .mc_tinfall import mc_time_since_infall
 
 
 class SubhaloCatalog(typing.NamedTuple):

--- a/diffsky/mass_functions/tests/test_mc_diffmah_tpeak.py
+++ b/diffsky/mass_functions/tests/test_mc_diffmah_tpeak.py
@@ -1,0 +1,21 @@
+"""
+"""
+
+import numpy as np
+from jax import random as jran
+
+from ..mc_diffmah_tpeak import mc_subhalo_catalog_singlez
+
+
+def test_mc_subhalo_catalog_singlez():
+
+    ran_key = jran.PRNGKey(0)
+    lgmp_min = 11.0
+    redshift = 0.5
+    Lbox = 25.0
+    volume_com = Lbox**3
+    args = ran_key, lgmp_min, redshift, volume_com
+
+    subhalo_catalog = mc_subhalo_catalog_singlez(*args)
+    for x in subhalo_catalog:
+        assert np.all(np.isfinite(x))

--- a/diffsky/mass_functions/tests/test_mc_diffmah_tpeak.py
+++ b/diffsky/mass_functions/tests/test_mc_diffmah_tpeak.py
@@ -16,6 +16,11 @@ def test_mc_subhalo_catalog_singlez():
     volume_com = Lbox**3
     args = ran_key, lgmp_min, redshift, volume_com
 
-    subhalo_catalog = mc_subhalo_catalog_singlez(*args)
-    for x in subhalo_catalog:
+    subcat = mc_subhalo_catalog_singlez(*args)
+    for x in subcat:
         assert np.all(np.isfinite(x))
+
+    n_gals = subcat.lgmp_pen_inf.size
+    assert subcat.lgmp_pen_inf.shape == (n_gals,)
+    for mah_p in subcat.mah_params:
+        assert mah_p.shape == (n_gals,)

--- a/diffsky/mass_functions/tests/test_mc_diffmah_tpeak.py
+++ b/diffsky/mass_functions/tests/test_mc_diffmah_tpeak.py
@@ -4,7 +4,7 @@
 import numpy as np
 from jax import random as jran
 
-from ..mc_diffmah_tpeak import mc_subhalo_catalog_singlez
+from ..mc_diffmah_tpeak import mc_subhalos
 
 
 def test_mc_subhalo_catalog_singlez():
@@ -16,7 +16,7 @@ def test_mc_subhalo_catalog_singlez():
     volume_com = Lbox**3
     args = ran_key, lgmp_min, redshift, volume_com
 
-    subcat = mc_subhalo_catalog_singlez(*args)
+    subcat = mc_subhalos(*args)
     for x in subcat:
         assert np.all(np.isfinite(x))
 

--- a/docs/source/demo_diffmahpop_t_peak.ipynb
+++ b/docs/source/demo_diffmahpop_t_peak.ipynb
@@ -84,6 +84,7 @@
    "outputs": [],
    "source": [
     "from diffmah.diffmah_kernels import mah_halopop\n",
+    "import numpy as np\n",
     "\n",
     "t_0 = 13.8\n",
     "lgt0 = np.log10(t_0)\n",

--- a/docs/source/demo_diffmahpop_t_peak.ipynb
+++ b/docs/source/demo_diffmahpop_t_peak.ipynb
@@ -1,0 +1,166 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1cea7043-98d7-4638-92d6-fdf60d092da1",
+   "metadata": {},
+   "source": [
+    "# Monte Carlo Samples of Subhalo Merger Trees"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "924b193d-8ce3-4473-a1e7-251552e9b758",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jax import random as jran\n",
+    "ran_key = jran.key(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53d5c9ac-710b-48f8-a86f-cd82278e3bec",
+   "metadata": {},
+   "source": [
+    "### Generate a sample of halos at $z=0.5$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e11ac073-7e5d-4ac2-8ccb-298d0ed89e7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from diffsky import mc_subhalos\n",
+    "\n",
+    "lgmp_min = 10.5 # minimum halo mass\n",
+    "z_obs = 0.5\n",
+    "Lbox_com = 200.0 # Mpc/h\n",
+    "volume_com = Lbox_com**3 \n",
+    "\n",
+    "subcat = mc_subhalos(ran_key, lgmp_min, z_obs, volume_com)\n",
+    "subcat._fields"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9dd1e6f7-6ecb-4d15-ab24-418d9d5634c3",
+   "metadata": {},
+   "source": [
+    "#### Plot subhalo mass function at $z_{\\rm obs}$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76eca22b-2bed-4576-93ab-789ca33c1376",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(1, 1)\n",
+    "yscale = ax.set_yscale('log')\n",
+    "__=ax.hist(subcat.lgmp_at_t_obs, bins=100, alpha=0.7)\n",
+    "xlabel = ax.set_xlabel(r'$\\log M_{\\rm h}(z_{\\rm obs})$')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4a93204-2d86-4546-9e74-bfe38d73af7a",
+   "metadata": {},
+   "source": [
+    "## Compute halo MAHs with ${\\tt diffmah}$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6878f635-51a7-45e9-97a6-58da616fc4a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from diffmah.diffmah_kernels import mah_halopop\n",
+    "\n",
+    "t_0 = 13.8\n",
+    "lgt0 = np.log10(t_0)\n",
+    "tarr = np.linspace(0.5, t_0, 100)\n",
+    "\n",
+    "args = (subcat.mah_params, tarr, subcat.t_peak, lgt0)\n",
+    "dmhdt, log_mah = mah_halopop(*args)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ab06a2e-1b5f-4b23-8e6e-7dfe08ce41ee",
+   "metadata": {},
+   "source": [
+    "### Plot some MAHs for halos of different mass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "738e5a67-667a-48f7-9cbf-8b28a688f285",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mskm105 = np.abs(subcat.lgmp_at_t_obs - 10.5) < 0.2\n",
+    "mskm115 = np.abs(subcat.lgmp_at_t_obs - 11.5) < 0.2\n",
+    "mskm125 = np.abs(subcat.lgmp_at_t_obs - 12.5) < 0.2\n",
+    "mskm135 = np.abs(subcat.lgmp_at_t_obs - 13.5) < 0.2\n",
+    "mskm145 = np.abs(subcat.lgmp_at_t_obs - 14.5) < 0.2\n",
+    "\n",
+    "fig, ax = plt.subplots(1, 1)\n",
+    "xlim = ax.set_xlim(0.5, t_0)\n",
+    "yscale = ax.set_yscale('log')\n",
+    "\n",
+    "mred = u'#d62728' \n",
+    "morange = u'#ff7f0e'  \n",
+    "mgreen = u'#2ca02c'\n",
+    "mblue = u'#1f77b4' \n",
+    "mpurple = u'#9467bd' \n",
+    "for i in range(10):\n",
+    "    __=ax.plot(tarr, 10**log_mah[mskm105][i], lw=0.5, color=mpurple)\n",
+    "    __=ax.plot(tarr, 10**log_mah[mskm115][i], lw=0.5, color=mblue)\n",
+    "    __=ax.plot(tarr, 10**log_mah[mskm125][i], lw=0.5, color=mgreen)\n",
+    "    __=ax.plot(tarr, 10**log_mah[mskm135][i], lw=0.5, color=morange)\n",
+    "    __=ax.plot(tarr, 10**log_mah[mskm145][i], lw=0.5, color=mred)\n",
+    "\n",
+    "xlabel = ax.set_xlabel(r'${\\rm cosmic\\ time\\ [Gyr]}$')\n",
+    "ylabel = ax.set_ylabel(r'$M_{\\rm halo}\\ {\\rm [M_{\\odot}]}$')\n",
+    "title = ax.set_title(r'${\\rm DiffmahPop}$-${\\rm generated\\ MAHs}$')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4279208-3231-4f1a-9236-a7467738a089",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/demo_diffmahpop_t_peak.ipynb
+++ b/docs/source/demo_diffmahpop_t_peak.ipynb
@@ -60,6 +60,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from matplotlib import pyplot as plt\n",
+    "\n",
     "fig, ax = plt.subplots(1, 1)\n",
     "yscale = ax.set_yscale('log')\n",
     "__=ax.hist(subcat.lgmp_at_t_obs, bins=100, alpha=0.7)\n",
@@ -158,7 +160,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/demos.rst
+++ b/docs/source/demos.rst
@@ -1,0 +1,8 @@
+Diffsky Code Demos
+==================
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Notebooks:
+
+   demo_diffmahpop_t_peak.ipynb

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@ of a population of galaxies and their co-evolving dark matter halos.
    :caption: Contents:
 
    installation.rst
+   demos.rst
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
This PR adds a new Monte Carlo generator of subhalo catalogs based on the new version of DiffmahPop. The PR includes an RTD doctest notebook demonstrating how to use the generator by making the plot below.
![mc_diffmahpop_demo](https://github.com/user-attachments/assets/52e719e9-1976-43fe-95b6-b7cd33a2ac62)
