### PR TITLE
Add kernel for prior on SMHM

### DIFF
--- a/diffsky/tests/test_utils.py
+++ b/diffsky/tests/test_utils.py
@@ -1,13 +1,26 @@
 """
 """
+
 import numpy as np
-from ..utils import _sigmoid, _inverse_sigmoid
+
+from .. import utils as ut
 
 
 def test_sigmoid_inversion():
     xarr = np.linspace(-10, 10, 500)
 
     x0, k, ylo, yhi = 0, 0.1, -5, 5
-    y = _sigmoid(xarr, x0, k, ylo, yhi)
-    x2 = _inverse_sigmoid(y, x0, k, ylo, yhi)
+    y = ut._sigmoid(xarr, x0, k, ylo, yhi)
+    x2 = ut._inverse_sigmoid(y, x0, k, ylo, yhi)
     assert np.allclose(xarr, x2, rtol=1e-4)
+
+
+def test_smhm_loss_penalty():
+    logsm_target = np.linspace(8, 12, 100)
+    logsm_pred = np.random.uniform(-0.5, 0.5, 100) + logsm_target
+    penalty = 10.0
+    loss = ut.smhm_loss_penalty(logsm_pred, logsm_target, penalty)
+    assert np.all(loss >= 0)
+    assert np.all(loss <= penalty)
+    assert np.any(loss > 0)
+    assert np.any(loss < penalty)

--- a/diffsky/utils.py
+++ b/diffsky/utils.py
@@ -1,8 +1,10 @@
 """
 """
 
+from dsps.utils import _tw_cuml_kern
 from jax import jit as jjit
 from jax import lax, nn
+from jax import numpy as jnp
 
 
 @jjit
@@ -15,3 +17,53 @@ def _sigmoid(x, x0, k, ymin, ymax):
 def _inverse_sigmoid(y, x0, k, ylo, yhi):
     lnarg = (yhi - ylo) / (y - ylo) - 1
     return x0 - lax.log(lnarg) / k
+
+
+@jjit
+def smhm_loss_penalty(logsm_pred, logsm_target, penalty, dlgsm_max=0.5, h=0.1):
+    """Penalty term for error in log10(Mstar)
+
+    Parameters
+    ----------
+    logsm_pred : array, shape (n, )
+
+    logsm_target : array, shape (n, )
+
+    penalty : float
+        Value to add to the loss for out-of-bounds predictions
+        Should probably be ~1-10x the un-penalized loss
+
+    logsm_pred : array, shape (n, )
+
+    dlgsm_max : float, optional
+        Parameter sets the maximum tolerated logsm difference
+        Larger values produce a wider range in tolerated errors
+
+    h : float, optional
+        Transition speed of the triweight sigmoid used in the kernel
+
+    Returns
+    -------
+    loss_penalty : array, shape (n, )
+
+    """
+    dlgsm = logsm_pred - logsm_target
+    loss_penalty = _tophat_loss_kern(dlgsm, penalty, dlgsm_max, h)
+    return loss_penalty
+
+
+@jjit
+def _tophat_loss_kern(x, penalty, dlgsm_max, h):
+    w = 2 * (dlgsm_max - 6 * h)
+    w = jnp.clip(w, 0.0)
+
+    b = -w / 2.0
+    x0 = b - 3 * h
+    sigmoid_lo = penalty - _tw_cuml_kern(x, x0, h) * penalty
+
+    b = w / 2.0
+    x0 = b + 3 * h
+    sigmoid_hi = _tw_cuml_kern(x, x0, h) * penalty
+
+    loss = sigmoid_lo + sigmoid_hi
+    return loss


### PR DESCRIPTION
This PR brings in a function that computes a penalty for models whose stellar-to-halo-mass relation differ from some input target SMHM. The code is really just a convenience wrapper around a couple of triweight kernels with hyperparameters that have tuned to reasonable values for the typical prior we want to assume for the SMHM.

For the _width_ of the kernel, I just tuned the triweight square well to have a width of ~0.5dex. The _magnitude_ of the penalty function is not set to any default value, but is a required input to this function. I think this should probably ideally be ~1-10x the un-penalized value of the typical loss, which of course will depend on whatever are the other target sumstats in the analysis, and so tuning this hyper-parameter might require a little experimentation.
![penalty_smhm](https://github.com/user-attachments/assets/67123c7b-f60d-4d84-a2e9-ecfa2e2f99f1)
