### PR TITLE
Update readthedocs build environment

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "mambaforge-22.9"
+    python: "miniconda-latest"
 
 conda:
   environment: docs/source/rtd_environment.yaml


### PR DESCRIPTION
Switch to miniconda-latest from mambaforge-22.9 in RTD build env. This is because mambaforge is being sunsetted (as explained [here](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/)). This same change is implemented in https://github.com/ArgonneCPAC/diffmah/pull/163 and https://github.com/ArgonneCPAC/diffstar/pull/75 and https://github.com/ArgonneCPAC/dsps/pull/96. 