### PR TITLE
Adjust bounds of freq-burst model and change default behavior

### DIFF
--- a/diffsky/burstpop/freqburst_mono.py
+++ b/diffsky/burstpop/freqburst_mono.py
@@ -17,24 +17,23 @@ LGSSFR_K = 5.0
 DEFAULT_FREQBURST_PDICT = OrderedDict(
     sufqb_logsm_x0=10.0,
     sufqb_logssfr_x0=-10.25,
-    sufqb_logsm_ylo_q=-0.25,
-    sufqb_logsm_ylo_ms=-0.25,
-    sufqb_logsm_yhi_q=-0.25,
-    sufqb_logsm_yhi_ms=-0.25,
+    sufqb_logsm_ylo_q=-10.0,
+    sufqb_logsm_ylo_ms=-10.0,
+    sufqb_logsm_yhi_q=-10.0,
+    sufqb_logsm_yhi_ms=-10.0,
 )
 
 LGSM_X0_BOUNDS = (9.0, 11.0)
 LGSSFR_X0_BOUNDS = (-12.0, -8.0)
-SUFQB_BOUNDS = (-5.0, -1.0)
-U_BOUNDS = (-100.0, 100.0)
+SUFQB_BOUNDS = (-15.0, -5.0)
 
 FREQBURST_PBOUNDS_PDICT = OrderedDict(
     sufqb_logsm_x0=LGSM_X0_BOUNDS,
     sufqb_logssfr_x0=LGSSFR_X0_BOUNDS,
-    sufqb_logsm_ylo_q=U_BOUNDS,
-    sufqb_logsm_ylo_ms=U_BOUNDS,
-    sufqb_logsm_yhi_q=U_BOUNDS,
-    sufqb_logsm_yhi_ms=U_BOUNDS,
+    sufqb_logsm_ylo_q=SUFQB_BOUNDS,
+    sufqb_logsm_ylo_ms=SUFQB_BOUNDS,
+    sufqb_logsm_yhi_q=SUFQB_BOUNDS,
+    sufqb_logsm_yhi_ms=SUFQB_BOUNDS,
 )
 
 
@@ -50,10 +49,10 @@ FREQBURST_PBOUNDS = FreqburstParams(**FREQBURST_PBOUNDS_PDICT)
 _EPS = 0.2
 ZEROBURST_FREQBURST_PARAMS = deepcopy(DEFAULT_FREQBURST_PARAMS)
 ZEROBURST_FREQBURST_PARAMS = ZEROBURST_FREQBURST_PARAMS._replace(
-    sufqb_logsm_ylo_q=U_BOUNDS[0] + _EPS,
-    sufqb_logsm_ylo_ms=U_BOUNDS[0] + _EPS,
-    sufqb_logsm_yhi_q=U_BOUNDS[0] + _EPS,
-    sufqb_logsm_yhi_ms=U_BOUNDS[0] + _EPS,
+    sufqb_logsm_ylo_q=SUFQB_BOUNDS[0] + _EPS,
+    sufqb_logsm_ylo_ms=SUFQB_BOUNDS[0] + _EPS,
+    sufqb_logsm_yhi_q=SUFQB_BOUNDS[0] + _EPS,
+    sufqb_logsm_yhi_ms=SUFQB_BOUNDS[0] + _EPS,
 )
 
 


### PR DESCRIPTION
This PR mimics what was done in #92 but now for `freqburst_mono.py`. This module already had monotonic kernels, however I noticed that the bounds were set to far too high, in light of recent results about how impactful burstiness is on massive galaxies especially. I'll show a comparison of plots of the old and new default models below, which shows that the new default model has much milder burst frequency than the previous model.

Probably more importantly than the change to the default behavior, I think the new bounds on the burst frequency variable should result in much less extreme models of burstiness.

![fq_burst_vs_logsm_old](https://github.com/user-attachments/assets/d4526f9c-6fc9-45c9-a3ba-ae51a997cba7)
![fq_burst_vs_logsm_new](https://github.com/user-attachments/assets/33d60208-b32f-41b3-ba89-b5677f1486eb)

@gbeltzmo 