### PR TITLE
Fix bug in subs_lgmhost_ult_inf

### DIFF
--- a/diffsky/mass_functions/mc_diffmah_tpeak.py
+++ b/diffsky/mass_functions/mc_diffmah_tpeak.py
@@ -159,7 +159,7 @@ def mc_subhalos(
     subs_lgmp_ult_inf = subs_lgmp_pen_inf
 
     subs_lgmhost_pen_inf = _log_mah_kern(subs_host_diffmah, subs_diffmah.t_peak, lgt0)
-    subs_lgmhost_ult_inf = subs_diffmah.t_peak
+    subs_lgmhost_ult_inf = subs_lgmhost_pen_inf
 
     lgmp_pen_inf = np.concatenate((hosts_logmh_at_z, subs_lgmp_pen_inf))
     lgmp_ult_inf = np.concatenate((hosts_logmh_at_z, subs_lgmp_ult_inf))

--- a/diffsky/mass_functions/tests/test_mc_diffmah_tpeak.py
+++ b/diffsky/mass_functions/tests/test_mc_diffmah_tpeak.py
@@ -41,6 +41,17 @@ def test_mc_subhalo_catalog_singlez():
     for mah_p in subcat.mah_params:
         assert mah_p.shape == (n_gals,)
 
+    logmp_ult_inf_sats = subcat.logmp_ult_inf[subcat.upids != -1]
+    logmhost_ult_inf_sats = subcat.logmhost_ult_inf[subcat.upids != -1]
+    logmu_ult_sats = logmp_ult_inf_sats - logmhost_ult_inf_sats
+    assert np.median(logmu_ult_sats < -0.75)
+
+    sat_bigger_than_host = (
+        subcat.logmp_ult_inf[subcat.upids != -1]
+        > subcat.logmhost_ult_inf[subcat.upids != -1]
+    )
+    assert np.mean(sat_bigger_than_host) < 0.2
+
 
 def test_mc_subhalo_catalog_colnames_are_stable():
     """Changing colnames of SubhaloCatalog may break something downstream"""


### PR DESCRIPTION
The `mc_subhalos` function generates a Monte Carlo realization of a subhalo population. Previously, the quantity `subcat.subs_lgmhost_ult_inf` was assigned to be `subcat.tpeak`, a bug leading to grossly unrealistic values for host halo mass. This PR fixes the bug.