### PR TITLE
Incorporate `_mono` burst models into unified burstpop model

### DIFF
--- a/diffsky/burstpop/diffqburstpop_mono.py
+++ b/diffsky/burstpop/diffqburstpop_mono.py
@@ -1,0 +1,97 @@
+"""
+"""
+
+from collections import namedtuple
+
+from dsps.sfh.diffburst import BurstParams, calc_bursty_age_weights
+from jax import jit as jjit
+
+from .fburstpop import (
+    DEFAULT_FBURSTPOP_PARAMS,
+    get_bounded_fburstpop_params,
+    get_lgfburst_from_fburstpop_params,
+    get_unbounded_fburstpop_params,
+)
+from .freqburst import (
+    DEFAULT_FREQBURST_PARAMS,
+    get_bounded_freqburst_params,
+    get_unbounded_freqburst_params,
+)
+from .tburstpop import (
+    DEFAULT_TBURSTPOP_PARAMS,
+    get_bounded_tburstpop_params,
+    get_tburst_params_from_tburstpop_params,
+    get_unbounded_tburstpop_params,
+)
+
+DiffburstPopParams = namedtuple(
+    "DiffburstPopParams", ["freqburst_params", "fburstpop_params", "tburstpop_params"]
+)
+DEFAULT_DIFFBURSTPOP_PARAMS = DiffburstPopParams(
+    DEFAULT_FREQBURST_PARAMS, DEFAULT_FBURSTPOP_PARAMS, DEFAULT_TBURSTPOP_PARAMS
+)
+_BURSTPOP_UPNAMES = [
+    key.replace("params", "u_params") for key in DEFAULT_DIFFBURSTPOP_PARAMS._fields
+]
+DiffburstPopUParams = namedtuple("DiffburstPopUParams", _BURSTPOP_UPNAMES)
+
+
+@jjit
+def get_bounded_diffburstpop_params(u_params):
+    u_freqburst_params, u_fburstpop_params, u_tburstpop_params = u_params
+    bounded_freqburst_params = get_bounded_freqburst_params(u_freqburst_params)
+    bounded_tburstpop_params = get_bounded_tburstpop_params(u_tburstpop_params)
+    bounded_fburstpop_params = get_bounded_fburstpop_params(u_fburstpop_params)
+    diffburstpop_params = DiffburstPopParams(
+        bounded_freqburst_params, bounded_fburstpop_params, bounded_tburstpop_params
+    )
+    return diffburstpop_params
+
+
+@jjit
+def get_unbounded_diffburstpop_params(params):
+    freqburst_params, fburstpop_params, tburstpop_params = params
+    unbounded_freqburst_params = get_unbounded_freqburst_params(freqburst_params)
+    unbounded_fburstpop_params = get_unbounded_fburstpop_params(fburstpop_params)
+    unbounded_tburstpop_params = get_unbounded_tburstpop_params(tburstpop_params)
+    diffburstpop_u_params = DiffburstPopUParams(
+        unbounded_freqburst_params,
+        unbounded_fburstpop_params,
+        unbounded_tburstpop_params,
+    )
+    return diffburstpop_u_params
+
+
+@jjit
+def calc_bursty_age_weights_from_diffburstpop_params(
+    diffburstpop_params, logsm, logssfr, ssp_lg_age_gyr, smooth_age_weights
+):
+    lgfburst = get_lgfburst_from_fburstpop_params(
+        diffburstpop_params.fburstpop_params, logsm, logssfr
+    )
+
+    tburst_params = get_tburst_params_from_tburstpop_params(
+        diffburstpop_params.tburstpop_params, logsm, logssfr
+    )
+    lgyr_peak, lgyr_max = tburst_params
+    burst_params = BurstParams(lgfburst, lgyr_peak, lgyr_max)
+
+    age_weights = calc_bursty_age_weights(
+        burst_params, smooth_age_weights, ssp_lg_age_gyr
+    )
+
+    return age_weights, burst_params
+
+
+def calc_bursty_age_weights_from_diffburstpop_u_params(
+    diffburstpop_u_params, logsm, logssfr, ssp_lg_age_gyr, smooth_age_weights
+):
+    diffburstpop_params = get_bounded_diffburstpop_params(diffburstpop_u_params)
+    args = diffburstpop_params, logsm, logssfr, ssp_lg_age_gyr, smooth_age_weights
+    age_weights, burst_params = calc_bursty_age_weights_from_diffburstpop_params(*args)
+    return age_weights, burst_params
+
+
+DEFAULT_DIFFBURSTPOP_U_PARAMS = DiffburstPopUParams(
+    *get_unbounded_diffburstpop_params(DEFAULT_DIFFBURSTPOP_PARAMS)
+)

--- a/diffsky/burstpop/diffqburstpop_mono.py
+++ b/diffsky/burstpop/diffqburstpop_mono.py
@@ -12,7 +12,7 @@ from .fburstpop_mono import (
     get_fburst_from_fburstpop_params,
     get_unbounded_fburstpop_params,
 )
-from .freqburst import (
+from .freqburst_mono import (
     DEFAULT_FREQBURST_PARAMS,
     get_bounded_freqburst_params,
     get_unbounded_freqburst_params,

--- a/diffsky/burstpop/diffqburstpop_mono.py
+++ b/diffsky/burstpop/diffqburstpop_mono.py
@@ -102,3 +102,6 @@ def calc_bursty_age_weights_from_diffburstpop_u_params(
 DEFAULT_DIFFBURSTPOP_U_PARAMS = DiffburstPopUParams(
     *get_unbounded_diffburstpop_params(DEFAULT_DIFFBURSTPOP_PARAMS)
 )
+ZERO_DIFFBURSTPOP_U_PARAMS = get_unbounded_diffburstpop_params(
+    DEFAULT_DIFFBURSTPOP_PARAMS
+)

--- a/diffsky/burstpop/diffqburstpop_mono.py
+++ b/diffsky/burstpop/diffqburstpop_mono.py
@@ -1,15 +1,15 @@
-"""
-"""
+""" """
 
 from collections import namedtuple
 
 from dsps.sfh.diffburst import BurstParams, calc_bursty_age_weights
 from jax import jit as jjit
+from jax import numpy as jnp
 
-from .fburstpop import (
+from .fburstpop_mono import (
     DEFAULT_FBURSTPOP_PARAMS,
     get_bounded_fburstpop_params,
-    get_lgfburst_from_fburstpop_params,
+    get_fburst_from_fburstpop_params,
     get_unbounded_fburstpop_params,
 )
 from .freqburst import (
@@ -66,9 +66,10 @@ def get_unbounded_diffburstpop_params(params):
 def calc_bursty_age_weights_from_diffburstpop_params(
     diffburstpop_params, logsm, logssfr, ssp_lg_age_gyr, smooth_age_weights
 ):
-    lgfburst = get_lgfburst_from_fburstpop_params(
+    f_burst = get_fburst_from_fburstpop_params(
         diffburstpop_params.fburstpop_params, logsm, logssfr
     )
+    lgfburst = jnp.log10(f_burst)
 
     tburst_params = get_tburst_params_from_tburstpop_params(
         diffburstpop_params.tburstpop_params, logsm, logssfr

--- a/diffsky/burstpop/diffqburstpop_mono.py
+++ b/diffsky/burstpop/diffqburstpop_mono.py
@@ -8,12 +8,14 @@ from jax import numpy as jnp
 
 from .fburstpop_mono import (
     DEFAULT_FBURSTPOP_PARAMS,
+    ZEROBURST_FBURSTPOP_PARAMS,
     get_bounded_fburstpop_params,
     get_fburst_from_fburstpop_params,
     get_unbounded_fburstpop_params,
 )
 from .freqburst_mono import (
     DEFAULT_FREQBURST_PARAMS,
+    ZEROBURST_FREQBURST_PARAMS,
     get_bounded_freqburst_params,
     get_unbounded_freqburst_params,
 )
@@ -34,6 +36,10 @@ _BURSTPOP_UPNAMES = [
     key.replace("params", "u_params") for key in DEFAULT_DIFFBURSTPOP_PARAMS._fields
 ]
 DiffburstPopUParams = namedtuple("DiffburstPopUParams", _BURSTPOP_UPNAMES)
+
+ZERO_DIFFBURSTPOP_PARAMS = DiffburstPopParams(
+    ZEROBURST_FREQBURST_PARAMS, ZEROBURST_FBURSTPOP_PARAMS, DEFAULT_TBURSTPOP_PARAMS
+)
 
 
 @jjit

--- a/diffsky/burstpop/tests/test_diffqburstpop_mono.py
+++ b/diffsky/burstpop/tests/test_diffqburstpop_mono.py
@@ -5,7 +5,7 @@ from dsps.sfh import diffburst
 from jax import random as jran
 
 from .. import diffqburstpop_mono as dbp
-from ..fburstpop import FburstPopUParams
+from ..fburstpop_mono import FburstPopUParams
 from ..freqburst import FreqburstUParams
 from ..tburstpop import TburstPopUParams
 

--- a/diffsky/burstpop/tests/test_diffqburstpop_mono.py
+++ b/diffsky/burstpop/tests/test_diffqburstpop_mono.py
@@ -6,7 +6,7 @@ from jax import random as jran
 
 from .. import diffqburstpop_mono as dbp
 from ..fburstpop_mono import FburstPopUParams
-from ..freqburst import FreqburstUParams
+from ..freqburst_mono import FreqburstUParams
 from ..tburstpop import TburstPopUParams
 
 TOL = 1e-2

--- a/diffsky/burstpop/tests/test_diffqburstpop_mono.py
+++ b/diffsky/burstpop/tests/test_diffqburstpop_mono.py
@@ -1,0 +1,128 @@
+""" """
+
+import numpy as np
+from dsps.sfh import diffburst
+from jax import random as jran
+
+from .. import diffqburstpop_mono as dbp
+from ..fburstpop import FburstPopUParams
+from ..freqburst import FreqburstUParams
+from ..tburstpop import TburstPopUParams
+
+TOL = 1e-2
+
+
+def test_calc_bursty_age_weights_from_diffburstpop_params_evaluates_on_defaults():
+    n_age = 107
+    ssp_lg_age_gyr = np.linspace(5.5, 10.5, n_age)
+    ran_key = jran.PRNGKey(0)
+
+    n_tests = 1_000
+    for __ in range(n_tests):
+        ran_key, logsm_key, logssfr_key, smooth_key = jran.split(ran_key, 4)
+        logsm = jran.uniform(logsm_key, minval=0, maxval=10, shape=())
+        logssfr = jran.uniform(logssfr_key, minval=-12, maxval=-8, shape=())
+        smooth_age_weights = jran.uniform(
+            smooth_key, minval=0, maxval=1, shape=(n_age,)
+        )
+
+        smooth_age_weights = smooth_age_weights / smooth_age_weights.sum()
+        args = (
+            dbp.DEFAULT_DIFFBURSTPOP_PARAMS,
+            logsm,
+            logssfr,
+            ssp_lg_age_gyr,
+            smooth_age_weights,
+        )
+        (
+            age_weights,
+            burst_params,
+        ) = dbp.calc_bursty_age_weights_from_diffburstpop_params(*args)
+        assert age_weights.shape == (n_age,)
+        assert np.all(np.isfinite(age_weights))
+
+        unity = np.sum(age_weights)
+        assert np.allclose(unity, 1.0, atol=1e-2)
+
+        assert diffburst.LGFBURST_MIN < burst_params.lgfburst < diffburst.LGFBURST_MAX
+        assert (
+            diffburst.LGYR_PEAK_MIN < burst_params.lgyr_peak < diffburst.LGYR_PEAK_MAX
+        )
+
+        assert burst_params.lgyr_peak < burst_params.lgyr_max < diffburst.LGAGE_MAX
+
+
+def test_calc_bursty_age_weights_from_diffburstpop_u_params_evaluates_on_u_randoms():
+    n_age = 107
+    ssp_lg_age_gyr = np.linspace(5.5, 10.5, n_age) - 9.0
+
+    n_freqburst_params = len(dbp.DEFAULT_DIFFBURSTPOP_PARAMS.freqburst_params)
+    n_fburstpop_params = len(dbp.DEFAULT_DIFFBURSTPOP_PARAMS.fburstpop_params)
+    n_tburstpop_params = len(dbp.DEFAULT_DIFFBURSTPOP_PARAMS.tburstpop_params)
+    ran_key = jran.PRNGKey(0)
+
+    n_tests = 1_000
+    for __ in range(n_tests):
+        ran_key, logsm_key, logssfr_key, smooth_key = jran.split(ran_key, 4)
+        logsm = jran.uniform(logsm_key, minval=0, maxval=10, shape=())
+        logssfr = jran.uniform(logssfr_key, minval=-12, maxval=-8, shape=())
+        smooth_age_weights = jran.uniform(
+            smooth_key, minval=0, maxval=1, shape=(n_age,)
+        )
+        ran_key, fqb_key, fb_key, tb_key = jran.split(ran_key, 4)
+        u_freqb = jran.uniform(
+            fqb_key, minval=-10, maxval=10, shape=(n_freqburst_params,)
+        )
+        u_fb = jran.uniform(fb_key, minval=-10, maxval=10, shape=(n_fburstpop_params,))
+        u_tb = jran.uniform(tb_key, minval=-10, maxval=10, shape=(n_tburstpop_params,))
+        freqburst_u_params = FreqburstUParams(*u_freqb)
+        fburstpop_u_params = FburstPopUParams(*u_fb)
+        tburstpop_u_params = TburstPopUParams(*u_tb)
+
+        diffburstpop_u_params = dbp.DiffburstPopUParams(
+            freqburst_u_params, fburstpop_u_params, tburstpop_u_params
+        )
+
+        smooth_age_weights = smooth_age_weights / smooth_age_weights.sum()
+        args = (
+            diffburstpop_u_params,
+            logsm,
+            logssfr,
+            ssp_lg_age_gyr,
+            smooth_age_weights,
+        )
+        (
+            age_weights,
+            burst_params,
+        ) = dbp.calc_bursty_age_weights_from_diffburstpop_u_params(*args)
+        assert age_weights.shape == (n_age,)
+        assert np.all(np.isfinite(age_weights))
+
+        unity = np.sum(age_weights)
+        assert np.allclose(unity, 1.0, atol=1e-2)
+
+        assert diffburst.LGFBURST_MIN <= burst_params.lgfburst <= diffburst.LGFBURST_MAX
+        assert (
+            diffburst.LGYR_PEAK_MIN <= burst_params.lgyr_peak <= diffburst.LGYR_PEAK_MAX
+        )
+
+        assert burst_params.lgyr_peak <= burst_params.lgyr_max <= diffburst.LGAGE_MAX
+
+
+def test_diffburstpop_u_param_inversion():
+    u_params = dbp.get_unbounded_diffburstpop_params(dbp.DEFAULT_DIFFBURSTPOP_PARAMS)
+    u_params_freqburst, u_params_fburst, u_params_tburst = u_params
+
+    assert np.allclose(
+        dbp.DEFAULT_DIFFBURSTPOP_U_PARAMS.freqburst_u_params,
+        u_params_freqburst,
+        rtol=TOL,
+    )
+
+    assert np.allclose(
+        dbp.DEFAULT_DIFFBURSTPOP_U_PARAMS.fburstpop_u_params, u_params_fburst, rtol=TOL
+    )
+
+    assert np.allclose(
+        dbp.DEFAULT_DIFFBURSTPOP_U_PARAMS.tburstpop_u_params, u_params_tburst, rtol=TOL
+    )


### PR DESCRIPTION
For a while now, we have been using monotonic versions of ingredients for burst frequency (`freqburst_mono`) and burst intensity (`fburstpop_mono`). However, there has been no unified burstiness model that includes these components. This PR implements a new `diffqburstpop_mono.py` model that is the exact analog of `diffqburstpop.py`, but using the monotonic ingredients. This will eliminate the need to implement code that unifies these ingredients within the diffdesi repo.