### PR TITLE
Add Monte Carlo generator of lightcone redshifts

### DIFF
--- a/diffsky/experimental/monte_carlo_lightcone_redshifts.py
+++ b/diffsky/experimental/monte_carlo_lightcone_redshifts.py
@@ -1,0 +1,51 @@
+""""""
+
+from functools import partial
+
+import jax.numpy as jnp
+from dsps.cosmology import flat_wcdm
+from jax import jit as jjit
+from jax import random, vmap
+
+_CD = (0, None, None, None, None)
+comoving_distance = jjit(vmap(flat_wcdm.comoving_distance_to_z, in_axes=_CD))
+
+
+@partial(jjit, static_argnames=["n_pts"])
+def mc_lightcone_redshift(ran_key, n_pts, z_min, z_max, cosmo_params, n_table=1_000):
+    """Generate a realization of redshifts in a lightcone spanning the input z-range
+
+    Parameters
+    ----------
+    ran_key : jax.random
+
+    n_pts : int
+        Number of points to generate
+
+    z_min : float
+
+    z_max : float
+
+    cosmo_params : namedtuple
+        dsps.cosmology.flat_wcdm cosmo_params = (Om0, w0, wa, h)
+
+    n_table : int, optional
+        Number of points in the lookup table used to numerically invert the cdf
+
+    Returns
+    -------
+    mc_redshifts : ndarray, shape (n_pts, )
+
+    """
+    z_table = jnp.linspace(z_min, z_max, n_table)
+
+    prefactor = 4.0 * jnp.pi / 3.0
+    vol_com = prefactor * comoving_distance(z_table, *cosmo_params) ** 3
+
+    weights = vol_com / vol_com.sum()
+    cdf = jnp.cumsum(weights)
+
+    uran = random.uniform(ran_key, shape=(n_pts,))
+    mc_redshifts = jnp.interp(uran, cdf, z_table)
+
+    return mc_redshifts

--- a/diffsky/experimental/tests/test_monte_carlo_lightcone_redshifts.py
+++ b/diffsky/experimental/tests/test_monte_carlo_lightcone_redshifts.py
@@ -1,0 +1,22 @@
+""" """
+
+import numpy as np
+from dsps.cosmology import flat_wcdm
+from jax import random as jran
+
+from .. import monte_carlo_lightcone_redshifts as mclr
+
+
+def test_mc_lightcone_redshift():
+    ran_key = jran.key(0)
+    z_min, z_max = 0.1, 2.0
+    npts = 2_000
+    cosmo_params = flat_wcdm.PLANCK15
+    redshifts = mclr.mc_lightcone_redshift(ran_key, npts, z_min, z_max, cosmo_params)
+    assert redshifts.shape == (npts,)
+    assert np.all(np.isfinite(redshifts))
+    assert np.all(redshifts > z_min)
+    assert np.all(redshifts < z_max)
+    zbins = np.linspace(z_min, z_max, 10)
+    zcounts = np.histogram(redshifts, bins=zbins)[0]
+    assert np.all(np.diff(zcounts) > 0)  # always have more galaxies at higher redshift


### PR DESCRIPTION
New `mc_lightcone_redshift` function generates a sample of redshifts from a lightcone spanning `(z_min, z_max)` assuming a constant comoving number density of points (i.e., passive evolution). The MC generator works by inverse transformation sampling:
1. calculate the comoving cosmological volume on a redshift grid `z_table` that spans the input range, `V_table = (4π/3)Rcom(z_table)**3`
2. define `CDF_table` as the unit-normalized cumulative sum of the volume grid
3. draw uniform randoms, `u`
4. interpolate `u` on the lookup table relation `CDF_table--z_table` to get a random redshift

@gbeltzmo I'm putting this new function in the experimental directory for now. We can use this when we put together a Monte Carlo generator of lightcone photometry.