### PR TITLE
Monte Carlo central galaxies on a lightcone

### DIFF
--- a/diffsky/experimental/mc_lightcone_halos.py
+++ b/diffsky/experimental/mc_lightcone_halos.py
@@ -242,10 +242,41 @@ def mc_lightcone_host_halo_diffmah(
 
     logmp_obs_halopop = _log_mah_kern(halopop.mah_params, t_obs_halopop, lgt0)
 
-    colnames = ("z_obs", "logmp_obs", "mah_params", "logmp0")
+    colnames = ("z_obs", "t_obs_halopop", "logmp_obs", "mah_params", "logmp0")
     DiffmahCenPop = namedtuple("DiffmahCenPop", colnames)
     cenpop = DiffmahCenPop._make(
-        (z_halopop, logmp_obs_halopop, halopop.mah_params, logmp0_halopop)
+        (
+            z_halopop,
+            t_obs_halopop,
+            logmp_obs_halopop,
+            halopop.mah_params,
+            logmp0_halopop,
+        )
     )
 
+    return cenpop
+
+
+def mc_lightcone_diffstar_cens(
+    ran_key,
+    lgmp_min,
+    z_min,
+    z_max,
+    sky_area_degsq,
+    cosmo_params=flat_wcdm.PLANCK15,
+    hmf_params=mc_hosts.DEFAULT_HMF_PARAMS,
+    diffmahpop_params=DEFAULT_DIFFMAHPOP_PARAMS,
+    n_grid=2_000,
+):
+    cenpop = mc_lightcone_host_halo_diffmah(
+        ran_key,
+        lgmp_min,
+        z_min,
+        z_max,
+        sky_area_degsq,
+        cosmo_params=cosmo_params,
+        hmf_params=hmf_params,
+        diffmahpop_params=diffmahpop_params,
+        n_grid=n_grid,
+    )
     return cenpop

--- a/diffsky/experimental/mc_lightcone_halos.py
+++ b/diffsky/experimental/mc_lightcone_halos.py
@@ -193,7 +193,7 @@ def mc_lightcone_host_halo_diffmah(
     diffmahpop_params=DEFAULT_DIFFMAHPOP_PARAMS,
     n_grid=2_000,
 ):
-    """Generate mass assembly histories for host halos sampled from a lightcone
+    """Generate halo MAHs for host halos sampled from a lightcone
 
     Parameters
     ----------
@@ -280,7 +280,7 @@ def mc_lightcone_diffstar_cens(
     n_t_table=100,
 ):
     """
-    Generate halo and galaxy assembly histories for host halos sampled from a lightcone
+    Generate halo MAH and galaxy SFH for host halos sampled from a lightcone
 
     Parameters
     ----------
@@ -416,6 +416,66 @@ def mc_lightcone_diffstar_stellar_ages_cens(
     n_grid=2_000,
     n_t_table=100,
 ):
+    """
+    Generate halo MAH and galaxy SFH and stellar age weights
+    for host halos sampled from a lightcone
+
+    Parameters
+    ----------
+    ran_key : jax.random.key
+
+    lgmp_min : float
+        Minimum halo mass
+
+    z_min, z_max : float
+
+    sky_area_degsq : float
+        Sky area in units of deg^2
+
+    cosmo_params : namedtuple
+        dsps.cosmology.flat_wcdm cosmology
+        cosmo_params = (Om0, w0, wa, h)
+
+    Returns
+    -------
+    cenpop : dict
+
+        z_obs : narray, shape (n_halos, )
+            Lightcone redshift
+
+        logmp_obs : narray, shape (n_halos, )
+            Halo mass at the lightcone redshift
+
+        mah_params : namedtuple of diffmah params
+            Each tuple entry is an ndarray with shape (n_halos, )
+
+        logmp0 : narray, shape (n_halos, )
+            log10 of halo mass at z=0
+
+        logsm_obs : narray, shape (n_halos, )
+            log10(Mstar) at the time of observation
+
+        logssfr_obs : narray, shape (n_halos, )
+            log10(SFR/Mstar) at the time of observation
+
+        sfh_params : namedtuple
+            Diffstar params for every galaxy
+
+        sfh_table : narray, shape (n_halos, n_times)
+            Star formation rate in Msun/yr
+
+        t_table : narray, shape (n_times, )
+
+        diffstarpop_data : dict
+            ancillary diffstarpop data such as frac_q
+
+        age_weights : ndarray, shape (n_halos, n_ages)
+            Stellar age PDF, P(τ), for every galaxy
+
+        ssp_lg_age_gyr : ndarray, shape (n_ages, )
+            log10 stellar age grid in Gyr
+
+    """
     cenpop = mc_lightcone_diffstar_cens(
         ran_key,
         lgmp_min,

--- a/diffsky/experimental/mc_lightcone_halos.py
+++ b/diffsky/experimental/mc_lightcone_halos.py
@@ -419,7 +419,9 @@ def mc_lightcone_diffstar_stellar_ages_cens(
         cosmo_params=cosmo_params,
         hmf_params=hmf_params,
         diffmahpop_params=diffmahpop_params,
+        diffstarpop_params=diffstarpop_params,
         n_grid=n_grid,
+        n_t_table=n_t_table,
     )
     age_weights_galpop = calc_age_weights_from_sfh_table_vmap(
         cenpop.t_table, cenpop.sfh_table, ssp_lg_age_gyr, cenpop.t_obs

--- a/diffsky/experimental/mc_lightcone_halos.py
+++ b/diffsky/experimental/mc_lightcone_halos.py
@@ -1,4 +1,4 @@
-""" """
+"""Functions to generate Monte Carlo realizations of galaxies on a lightcone"""
 
 from functools import partial
 

--- a/diffsky/experimental/mc_lightcone_halos.py
+++ b/diffsky/experimental/mc_lightcone_halos.py
@@ -558,6 +558,17 @@ def mc_lightcone_diffstar_ssp_weights_cens(
     return cenpop
 
 
+def get_precompute_ssp_mag_redshift_table(tcurves, ssp_data, z_phot_table):
+    collector = []
+    for z_obs in z_phot_table:
+        ssp_obsflux_table = psp.get_ssp_obsflux_table(
+            ssp_data, tcurves, z_obs, flat_wcdm.PLANCK15
+        )
+        collector.append(ssp_obsflux_table)
+    precomputed_ssp_mag_table = -2.5 * np.log10(np.array(collector))
+    return precomputed_ssp_mag_table
+
+
 def mc_lightcone_obs_mags_cens(
     ran_key,
     lgmp_min,
@@ -565,9 +576,8 @@ def mc_lightcone_obs_mags_cens(
     z_max,
     sky_area_degsq,
     ssp_data,
-    tcurves=None,
-    precomputed_ssp_mag_table=None,
-    z_phot_table=None,
+    precomputed_ssp_mag_table,
+    z_phot_table,
     cosmo_params=flat_wcdm.PLANCK15,
     hmf_params=mc_hosts.DEFAULT_HMF_PARAMS,
     diffmahpop_params=DEFAULT_DIFFMAHPOP_PARAMS,
@@ -576,16 +586,8 @@ def mc_lightcone_obs_mags_cens(
     lgmet_scatter=umzr.MZR_SCATTER,
     n_grid=2_000,
     n_t_table=100,
-    n_z_phot_table=50,
     phot_keys=LSST_PHOTKEYS,
 ):
-    if precomputed_ssp_mag_table is not None:
-        assert z_phot_table is not None
-        assert z_phot_table.size == precomputed_ssp_mag_table.shape[0]
-    else:
-        if z_phot_table is None:
-            z_phot_table = np.linspace(z_min, z_max, n_z_phot_table)
-
     cenpop = mc_lightcone_diffstar_ssp_weights_cens(
         ran_key,
         lgmp_min,

--- a/diffsky/experimental/mc_lightcone_halos.py
+++ b/diffsky/experimental/mc_lightcone_halos.py
@@ -559,6 +559,21 @@ def mc_lightcone_diffstar_ssp_weights_cens(
 
 
 def get_precompute_ssp_mag_redshift_table(tcurves, ssp_data, z_phot_table):
+    """Calculate precomputed SSP magnitude table to use for lightcone interpolation
+
+    Parameters
+    ----------
+    tcurves : list of n_bands transmission curves
+
+    ssp_data : namedtuple
+
+    z_phot_table : ndarray, shape (n_phot_table, )
+
+    Returns
+    -------
+    precomputed_ssp_mag_table : ndarray, shape (n_phot_table, n_bands, n_met, n_age)
+
+    """
     collector = []
     for z_obs in z_phot_table:
         ssp_obsflux_table = psp.get_ssp_obsflux_table(
@@ -588,6 +603,75 @@ def mc_lightcone_obs_mags_cens(
     n_t_table=100,
     phot_keys=LSST_PHOTKEYS,
 ):
+    """
+    Generate photometry for host halos sampled from a lightcone
+
+    Parameters
+    ----------
+    ran_key : jax.random.key
+
+    lgmp_min : float
+        Minimum halo mass
+
+    z_min, z_max : float
+
+    sky_area_degsq : float
+        Sky area in units of deg^2
+
+    cosmo_params : namedtuple
+        dsps.cosmology.flat_wcdm cosmology
+        cosmo_params = (Om0, w0, wa, h)
+
+    ssp_data : namedtuple
+
+    precomputed_ssp_mag_table : ndarray, shape (n_phot_table, n_bands, n_met, n_age)
+        Computed by the get_precompute_ssp_mag_redshift_table function
+
+    z_phot_table : ndarray, shape (n_phot_table, )
+
+    Returns
+    -------
+    cenpop : dict
+
+        z_obs : narray, shape (n_halos, )
+            Lightcone redshift
+
+        logmp_obs : narray, shape (n_halos, )
+            Halo mass at the lightcone redshift
+
+        mah_params : namedtuple of diffmah params
+            Each tuple entry is an ndarray with shape (n_halos, )
+
+        logmp0 : narray, shape (n_halos, )
+            log10 of halo mass at z=0
+
+        logsm_obs : narray, shape (n_halos, )
+            log10(Mstar) at the time of observation
+
+        logssfr_obs : narray, shape (n_halos, )
+            log10(SFR/Mstar) at the time of observation
+
+        sfh_params : namedtuple
+            Diffstar params for every galaxy
+
+        sfh_table : narray, shape (n_halos, n_times)
+            Star formation rate in Msun/yr
+
+        t_table : narray, shape (n_times, )
+
+        diffstarpop_data : dict
+            ancillary diffstarpop data such as frac_q
+
+        age_weights : ndarray, shape (n_halos, n_ages)
+            Stellar age PDF, P(τ), for every galaxy
+
+        ssp_lg_age_gyr : ndarray, shape (n_ages, )
+            log10 stellar age grid in Gyr
+
+        obs_mags : ndarray, shape (n_bands, n_gals)
+            Apparent magnitude of each galaxy in each band
+
+    """
     cenpop = mc_lightcone_diffstar_ssp_weights_cens(
         ran_key,
         lgmp_min,

--- a/diffsky/experimental/tests/test_mc_lightcone_halos.py
+++ b/diffsky/experimental/tests/test_mc_lightcone_halos.py
@@ -67,7 +67,7 @@ def test_mc_lightcone_host_halo_mass_function():
 
 
 def test_mc_lightcone_host_halo_diffmah():
-    """Enforce mc_lightcone_host_halo_mah returns reasonable results"""
+    """Enforce mc_lightcone_host_halo_diffmah returns reasonable results"""
     ran_key = jran.key(0)
     lgmp_min = 12.0
     sky_area_degsq = 1.0
@@ -93,7 +93,7 @@ def test_mc_lightcone_host_halo_diffmah():
 
 
 def test_mc_lightcone_diffstar_cens():
-    """Enforce mc_lightcone_host_halo_mah returns reasonable results"""
+    """Enforce mc_lightcone_diffstar_cens returns reasonable results"""
     ran_key = jran.key(0)
     lgmp_min = 12.0
     sky_area_degsq = 1.0
@@ -105,3 +105,21 @@ def test_mc_lightcone_diffstar_cens():
     assert np.all(np.isfinite(cenpop.logsm_obs))
     assert np.all(np.isfinite(cenpop.logssfr_obs))
     assert cenpop.logsm_obs.min() > 4
+
+
+def test_mc_lightcone_diffstar_stellar_ages_cens():
+    """Enforce mc_lightcone_diffstar_stellar_ages_cens returns reasonable results"""
+    ran_key = jran.key(0)
+    lgmp_min = 12.0
+    sky_area_degsq = 1.0
+
+    z_min, z_max = 0.1, 0.5
+    z_min = z_max - 0.05
+    args = (ran_key, lgmp_min, z_min, z_max, sky_area_degsq)
+    cenpop = mclh.mc_lightcone_diffstar_stellar_ages_cens(*args)
+    assert np.all(np.isfinite(cenpop.logsm_obs))
+    assert np.all(np.isfinite(cenpop.logssfr_obs))
+    assert cenpop.logsm_obs.min() > 4
+
+    assert np.all(np.isfinite(cenpop.age_weights))
+    assert np.allclose(1.0, np.sum(cenpop.age_weights, axis=1), rtol=1e-3)

--- a/diffsky/experimental/tests/test_mc_lightcone_halos.py
+++ b/diffsky/experimental/tests/test_mc_lightcone_halos.py
@@ -90,3 +90,18 @@ def test_mc_lightcone_host_halo_diffmah():
         # Some halos with logmp_obs<lgmp_min is ok,
         # but too many indicates an issue with DiffmahPop replicating logmp_obs
         assert np.mean(cenpop.logmp_obs < lgmp_min) < 0.2, f"z_min={z_min:.2f}"
+
+
+def test_mc_lightcone_diffstar_cens():
+    """Enforce mc_lightcone_host_halo_mah returns reasonable results"""
+    ran_key = jran.key(0)
+    lgmp_min = 12.0
+    sky_area_degsq = 1.0
+
+    z_min, z_max = 0.1, 0.5
+    z_min = z_max - 0.05
+    args = (ran_key, lgmp_min, z_min, z_max, sky_area_degsq)
+    cenpop = mclh.mc_lightcone_diffstar_cens(*args)
+    assert np.all(np.isfinite(cenpop.logsm_obs))
+    assert np.all(np.isfinite(cenpop.logssfr_obs))
+    assert cenpop.logsm_obs.min() > 4

--- a/diffsky/experimental/tests/test_mc_lightcone_halos.py
+++ b/diffsky/experimental/tests/test_mc_lightcone_halos.py
@@ -6,8 +6,7 @@ from dsps.data_loaders import retrieve_fake_fsps_data
 from dsps.data_loaders.defaults import TransmissionCurve
 from jax import random as jran
 
-from diffsky.mass_functions import mc_hosts
-
+from ...mass_functions import mc_hosts
 from .. import mc_lightcone_halos as mclh
 
 

--- a/diffsky/experimental/tests/test_mc_lightcone_halos.py
+++ b/diffsky/experimental/tests/test_mc_lightcone_halos.py
@@ -80,16 +80,16 @@ def test_mc_lightcone_host_halo_diffmah():
         args = (test_key, lgmp_min, z_min, z_max, sky_area_degsq)
 
         cenpop = mclh.mc_lightcone_host_halo_diffmah(*args)
-        n_gals = cenpop.z_obs.size
-        assert cenpop.logmp_obs.size == cenpop.logmp0.size == n_gals
-        assert np.all(np.isfinite(cenpop.z_obs))
+        n_gals = cenpop["z_obs"].size
+        assert cenpop["logmp_obs"].size == cenpop["logmp0"].size == n_gals
+        assert np.all(np.isfinite(cenpop["z_obs"]))
 
-        assert np.all(cenpop.z_obs >= z_min)
-        assert np.all(cenpop.z_obs <= z_max)
+        assert np.all(cenpop["z_obs"] >= z_min)
+        assert np.all(cenpop["z_obs"] <= z_max)
 
         # Some halos with logmp_obs<lgmp_min is ok,
         # but too many indicates an issue with DiffmahPop replicating logmp_obs
-        assert np.mean(cenpop.logmp_obs < lgmp_min) < 0.2, f"z_min={z_min:.2f}"
+        assert np.mean(cenpop["logmp_obs"] < lgmp_min) < 0.2, f"z_min={z_min:.2f}"
 
 
 def test_mc_lightcone_diffstar_cens():
@@ -102,9 +102,19 @@ def test_mc_lightcone_diffstar_cens():
     z_min = z_max - 0.05
     args = (ran_key, lgmp_min, z_min, z_max, sky_area_degsq)
     cenpop = mclh.mc_lightcone_diffstar_cens(*args)
-    assert np.all(np.isfinite(cenpop.logsm_obs))
-    assert np.all(np.isfinite(cenpop.logssfr_obs))
-    assert cenpop.logsm_obs.min() > 4
+    assert np.all(np.isfinite(cenpop["logsm_obs"]))
+    assert np.all(np.isfinite(cenpop["logssfr_obs"]))
+    assert cenpop["logsm_obs"].min() > 4
+
+    assert np.all(np.isfinite(cenpop["diffstarpop_data"]["sfh_params_ms"].ms_params))
+    assert np.all(np.isfinite(cenpop["diffstarpop_data"]["sfh_params_ms"].q_params))
+    assert np.all(np.isfinite(cenpop["diffstarpop_data"]["sfh_params_q"].ms_params))
+    assert np.all(np.isfinite(cenpop["diffstarpop_data"]["sfh_params_q"].q_params))
+
+    assert np.all(np.isfinite(cenpop["diffstarpop_data"]["sfh_ms"]))
+    assert np.all(np.isfinite(cenpop["diffstarpop_data"]["sfh_q"]))
+    assert np.all(cenpop["diffstarpop_data"]["frac_q"] >= 0)
+    assert np.all(cenpop["diffstarpop_data"]["frac_q"] <= 1)
 
 
 def test_mc_lightcone_diffstar_stellar_ages_cens():
@@ -117,9 +127,9 @@ def test_mc_lightcone_diffstar_stellar_ages_cens():
     z_min = z_max - 0.05
     args = (ran_key, lgmp_min, z_min, z_max, sky_area_degsq)
     cenpop = mclh.mc_lightcone_diffstar_stellar_ages_cens(*args)
-    assert np.all(np.isfinite(cenpop.logsm_obs))
-    assert np.all(np.isfinite(cenpop.logssfr_obs))
-    assert cenpop.logsm_obs.min() > 4
+    assert np.all(np.isfinite(cenpop["logsm_obs"]))
+    assert np.all(np.isfinite(cenpop["logssfr_obs"]))
+    assert cenpop["logsm_obs"].min() > 4
 
-    assert np.all(np.isfinite(cenpop.age_weights))
-    assert np.allclose(1.0, np.sum(cenpop.age_weights, axis=1), rtol=1e-3)
+    assert np.all(np.isfinite(cenpop["age_weights"]))
+    assert np.allclose(1.0, np.sum(cenpop["age_weights"], axis=1), rtol=1e-3)

--- a/diffsky/experimental/tests/test_mc_lightcone_halos.py
+++ b/diffsky/experimental/tests/test_mc_lightcone_halos.py
@@ -1,7 +1,5 @@
 """ """
 
-from time import time
-
 import numpy as np
 from dsps.cosmology import flat_wcdm
 from dsps.data_loaders import retrieve_fake_fsps_data
@@ -176,19 +174,15 @@ def test_mc_lightcone_obs_mags_cens():
 
     tcurves = [TransmissionCurve(wave, x) for x in (u, g, r, i, z, y)]
 
-    args = (ran_key, lgmp_min, z_min, z_max, sky_area_degsq, ssp_data)
-    start = time()
-    cenpop = mclh.mc_lightcone_obs_mags_cens(*args, tcurves=tcurves, n_z_phot_table=5)
-    end = time()
-    runtime0 = end - start
-    assert np.all(np.isfinite(cenpop["obs_mags"]))
-
-    start = time()
-    cenpop2 = mclh.mc_lightcone_obs_mags_cens(
-        *args,
-        precomputed_ssp_mag_table=cenpop["precomputed_ssp_mag_table"],
-        z_phot_table=cenpop["z_phot_table"],
+    z_phot_table = np.linspace(z_min, z_max, 5)
+    precomputed_ssp_mag_table = mclh.get_precompute_ssp_mag_redshift_table(
+        tcurves, ssp_data, z_phot_table
     )
-    runtime1 = end - start
-    assert np.allclose(cenpop["obs_mags"], cenpop2["obs_mags"])
-    assert runtime1 < runtime0 / 2
+
+    args = (ran_key, lgmp_min, z_min, z_max, sky_area_degsq, ssp_data)
+    cenpop = mclh.mc_lightcone_obs_mags_cens(
+        *args,
+        precomputed_ssp_mag_table=precomputed_ssp_mag_table,
+        z_phot_table=z_phot_table,
+    )
+    assert np.all(np.isfinite(cenpop["obs_mags"]))

--- a/diffsky/experimental/tests/test_mc_lightcone_halos.py
+++ b/diffsky/experimental/tests/test_mc_lightcone_halos.py
@@ -133,3 +133,26 @@ def test_mc_lightcone_diffstar_stellar_ages_cens():
 
     assert np.all(np.isfinite(cenpop["age_weights"]))
     assert np.allclose(1.0, np.sum(cenpop["age_weights"], axis=1), rtol=1e-3)
+
+
+def test_mc_lightcone_diffstar_ssp_weights_cens():
+    ran_key = jran.key(0)
+    lgmp_min = 12.0
+    sky_area_degsq = 1.0
+
+    z_min, z_max = 0.1, 0.5
+    z_min = z_max - 0.05
+    args = (ran_key, lgmp_min, z_min, z_max, sky_area_degsq)
+    cenpop = mclh.mc_lightcone_diffstar_ssp_weights_cens(*args)
+    assert np.all(np.isfinite(cenpop["logsm_obs"]))
+    assert np.all(np.isfinite(cenpop["logssfr_obs"]))
+    assert cenpop["logsm_obs"].min() > 4
+
+    assert np.all(np.isfinite(cenpop["age_weights"]))
+    assert np.allclose(1.0, np.sum(cenpop["age_weights"], axis=1), rtol=1e-3)
+
+    assert np.all(np.isfinite(cenpop["lgmet_weights"]))
+    assert np.allclose(1.0, np.sum(cenpop["lgmet_weights"], axis=1), rtol=1e-3)
+
+    assert np.all(np.isfinite(cenpop["ssp_weights"]))
+    assert np.allclose(1.0, np.sum(cenpop["ssp_weights"], axis=(1, 2)), rtol=1e-3)


### PR DESCRIPTION
This PR brings in code to generate Monte Carlo realizations of central galaxy photometry on a lightcone. The photometry only includes smooth SFH, no burstiness, no dust, and no SSP errors. Here are a couple of example plots made with the new code.

![synthetic_lightcone_diffstar](https://github.com/user-attachments/assets/d70448a6-64b0-42bc-a6ae-6a2ce8052a8c)
![synthetic_lightcone_ri_redshift](https://github.com/user-attachments/assets/1578ad88-6929-40ae-b113-7c05e1e3bde0)
![synthetic_lightcone_gr_redshift](https://github.com/user-attachments/assets/9e8f3235-d590-4473-8b77-3d6b8eba8a4e)
