### PR TITLE
Update burst frequency model to be even less conservative

### DIFF
--- a/diffsky/burstpop/freqburst_mono.py
+++ b/diffsky/burstpop/freqburst_mono.py
@@ -16,15 +16,15 @@ LGSSFR_K = 5.0
 DEFAULT_FREQBURST_PDICT = OrderedDict(
     sufqb_logsm_x0=10.0,
     sufqb_logssfr_x0=-10.25,
-    sufqb_logsm_ylo_q=-10.0,
+    sufqb_logsm_ylo_q=-5.0,
     sufqb_logsm_ylo_ms=-0.2,
-    sufqb_logsm_yhi_q=-10.0,
+    sufqb_logsm_yhi_q=-5.0,
     sufqb_logsm_yhi_ms=-0.5,
 )
 
 LGSM_X0_BOUNDS = (9.0, 11.0)
 LGSSFR_X0_BOUNDS = (-12.0, -8.0)
-SUFQB_BOUNDS = (-15.0, 0.5)
+SUFQB_BOUNDS = (-10.0, 0.5)
 
 FREQBURST_PBOUNDS_PDICT = OrderedDict(
     sufqb_logsm_x0=LGSM_X0_BOUNDS,

--- a/diffsky/burstpop/tests/test_freqburst_mono.py
+++ b/diffsky/burstpop/tests/test_freqburst_mono.py
@@ -200,7 +200,7 @@ def test_zeroburst_params_produce_zero_burstiness():
     assert fqb.shape == (n_gals,)
     assert np.all(np.isfinite(fqb))
     assert np.all(fqb >= 0.0)
-    assert np.all(fqb < 0.01), fqb.max()
+    assert np.all(fqb < 0.1), fqb.max()
 
     sufq_max = SUFQB_BOUNDS[1]
     fqb_max = nn.softplus(sufq_max)


### PR DESCRIPTION
The updated burstpop model now looks like the plot below

![pburstpop_default_vs_zeroburst](https://github.com/user-attachments/assets/540c94cb-3e08-4c73-9fdc-ea2650e809a1)

@gbeltzmo 