### PR TITLE
Add crossmatch to top-level utils import

### DIFF
--- a/diffsky/utils/__init__.py
+++ b/diffsky/utils/__init__.py
@@ -1,3 +1,4 @@
 """ """
 
+from .crossmatch_utils import crossmatch  # noqa
 from .utility_funcs import _inverse_sigmoid, _sigmoid  # noqa

--- a/diffsky/utils/tests/test_crossmatch_utils.py
+++ b/diffsky/utils/tests/test_crossmatch_utils.py
@@ -11,6 +11,10 @@ __all__ = ("test_crossmatch1",)
 FIXED_SEED = 43
 
 
+def test_crossmatch_import():
+    from ...utils import crossmatch
+
+
 def test_crossmatch1():
     """x has unique entries. All y values are in x. All x values are in y."""
     x = np.array([1, 3, 5])


### PR DESCRIPTION
The following now works:
```
from diffsky.utils import crossmatch
```