### PR TITLE
Improve edge case treatment of get_timestep_range_from_z_range function

### DIFF
--- a/diffsky/data_loaders/hacc_core_utils.py
+++ b/diffsky/data_loaders/hacc_core_utils.py
@@ -108,16 +108,34 @@ def get_timestep_range_from_z_range(sim_name, z_min, z_max):
     timestep_min, timestep_max : ints
         Timesteps that span the input z-range
 
+    Notes
+    -----
+    sim = HACCSim.simulations[sim_name]
+    timesteps = np.array(sim.cosmotools_steps)
+    timestep_min = timesteps[idx_step_min]
+    timestep_max = timesteps[idx_step_max]
+
     """
     sim = HACCSim.simulations[sim_name]
     timesteps = np.array(sim.cosmotools_steps)
+    z_arr = sim.step2z(timesteps)
 
     a_max = 1 / (1 + z_min)
     a_min = 1 / (1 + z_max)
     a_arr = sim.step2a(timesteps)
 
-    idx_step_min = np.searchsorted(a_arr, a_min) - 1
-    idx_step_max = np.searchsorted(a_arr, a_max)
+    if a_min < a_arr[0]:
+        idx_step_min = 0
+    else:
+        idx_step_min = np.searchsorted(a_arr, a_min) - 1
+
+    if a_max > a_arr[-1]:
+        idx_step_max = len(timesteps) - 1
+        print(f"Input z_max={z_max} > largest lightcone redshift={z_arr.max()}")
+    else:
+        idx_step_max = np.searchsorted(a_arr, a_max)
+
     timestep_min = timesteps[idx_step_min]
     timestep_max = timesteps[idx_step_max]
+
     return idx_step_min, idx_step_max, timestep_min, timestep_max

--- a/diffsky/data_loaders/tests/test_hacc_core_utils.py
+++ b/diffsky/data_loaders/tests/test_hacc_core_utils.py
@@ -1,5 +1,4 @@
-"""
-"""
+""" """
 
 import numpy as np
 import pytest
@@ -58,3 +57,23 @@ def test_get_timestep_range_from_z_range():
         # Enforce the next timestep would have undershot z_max
         if idx_step_max > 0:
             assert z_max > z_arr[idx_step_min + 1]
+
+
+@pytest.mark.skipif(not HAS_HACCYTREES, reason=NO_HACC_MSG)
+def test_get_timestep_range_from_z_range_edge_cases():
+    sim_name = "LastJourney"
+    sim = HACCSim.simulations[sim_name]
+    timesteps = np.array(sim.cosmotools_steps)
+    z_arr = sim.step2z(timesteps)
+
+    # z_min = 0.0
+    z_min, z_max = 0.0, 3.0
+    _res = hcu.get_timestep_range_from_z_range(sim_name, z_min, z_max)
+    idx_step_min, idx_step_max, timestep_min, timestep_max = _res
+    assert timestep_max == timesteps[-1]
+
+    # z_max > z_arr.max()
+    z_min, z_max = 0.1, z_arr.max() + 10.0
+    _res = hcu.get_timestep_range_from_z_range(sim_name, z_min, z_max)
+    idx_step_min, idx_step_max, timestep_min, timestep_max = _res
+    assert timestep_min == timesteps[0]


### PR DESCRIPTION
Function can now accept `z_min=0` and also `z_max` greater than max lightcone redshift without crashing