### PR TITLE
Fix bug in synthetic lightcone redshifts

### DIFF
--- a/diffsky/experimental/mc_lightcone_halos.py
+++ b/diffsky/experimental/mc_lightcone_halos.py
@@ -1,7 +1,5 @@
 """Functions to generate Monte Carlo realizations of galaxies on a lightcone"""
 
-from functools import partial
-
 import numpy as np
 from diffmah.diffmah_kernels import _log_mah_kern
 from diffmah.diffmahpop_kernels.bimod_censat_params import DEFAULT_DIFFMAHPOP_PARAMS
@@ -69,52 +67,6 @@ def _spherical_shell_comoving_volume(z_grid, cosmo_params):
     # vol_shell_grid = 4π*R*R*dR
     vol_shell_grid = 4 * jnp.pi * r_grid * r_grid * d_r_grid
     return vol_shell_grid
-
-
-@partial(jjit, static_argnames=["npts"])
-def mc_lightcone_redshift(
-    ran_key, npts, z_min, z_max, cosmo_params=flat_wcdm.PLANCK15, n_table=1000
-):
-    """Generate a realization of redshifts in a lightcone spanning the input z-range
-
-    Parameters
-    ----------
-    ran_key : jax.random
-
-    n_pts : int
-        Number of points to generate
-
-    z_min : float
-
-    z_max : float
-
-    cosmo_params : namedtuple
-        dsps.cosmology.flat_wcdm cosmology
-        cosmo_params = (Om0, w0, wa, h)
-
-    n_table : int, optional
-        Number of points in the lookup table used to numerically invert the cdf
-
-    Returns
-    -------
-    mc_redshifts : ndarray, shape (n_pts, )
-        Redshifts distributed randomly within the lightcone volume
-
-    """
-    # Set up a uniform grid in redshift
-    z_grid = jnp.linspace(z_min, z_max, n_table)
-
-    # Compute the comoving volume of a thin shell at each grid point
-    vol_shell_grid = _spherical_shell_comoving_volume(z_grid, cosmo_params)
-
-    weights_grid = vol_shell_grid / vol_shell_grid.sum()
-    cdf_grid = jnp.cumsum(weights_grid)
-
-    # Assign redshift via inverse transformation sampling of the shell volume CDF
-    uran_z = jran.uniform(ran_key, minval=0, maxval=1, shape=(npts,))
-    mc_redshifts = jnp.interp(uran_z, cdf_grid, z_grid)
-
-    return mc_redshifts
 
 
 def mc_lightcone_host_halo_mass_function(


### PR DESCRIPTION
Previously, when generating a Monte Carlo realization of a halo lightcone, the redshift distribution in the range `z_min < z < z_max` was estimated by inverse transformation sampling a lookup table between `z--V`, where `V=4πR^2dR` is the cosmological volume of a shell at comoving distance `R(z)`. This does not take into account the evolution of the halo mass function. At higher redshift, there are fewer halos than at low redshift, and so the previous method overestimated the proportional abundance of halos at high-redshift. The plot below compares n(z) of a lightcone of halos in the Last Journey cosmological simulation to n(z) produced by the previous code. Note the downturn of n(z) at high redshift seen in the simulation, but not the Monte Carlo realization.
![mc_vs_real_lightcone_redshifts](https://github.com/user-attachments/assets/a8cc7950-6c38-418c-9030-fb371b220be0)

This PR fixes this error. The lightcone shells are now weighted by the expected number of halos in the shell, rather than the volume. The new code produces results that are in much better agreement with the simulation:
![mc_vs_real_lightcone_redshifts_bugfix](https://github.com/user-attachments/assets/115758aa-7063-4207-b73d-9b8e047274be)
The agreement is not perfect because the analytical halo mass function used to make this plot has not been calibrated against the Last Journey halo mass function, which could be improved in a future PR that brings in new mass function parameters calibrated against HACC simulations. But the fix here appears to completely resolve the qualitative failure of the old code.