### PR TITLE
Fix bug in experimental function `mc_lightcone_obs_mags_cens`

### DIFF
--- a/diffsky/experimental/mc_lightcone_halos.py
+++ b/diffsky/experimental/mc_lightcone_halos.py
@@ -949,7 +949,7 @@ def mc_lightcone_obs_mags_cens(
 
     n_gals, n_bands, n_met, n_age = cenpop["ssp_photflux_table"].shape
     w = cenpop["ssp_weights"].reshape((n_gals, 1, n_met, n_age))
-    sm = 10 ** cenpop["logmp_obs"].reshape((n_gals, 1))
+    sm = 10 ** cenpop["logsm_obs"].reshape((n_gals, 1))
 
     integrand = w * cenpop["ssp_photflux_table"]
     photflux_galpop = jnp.sum(integrand, axis=(2, 3)) * sm


### PR DESCRIPTION
The previous version of the `mc_lightcone_obs_mags_cens` function incorrectly normalized the weighted SSP summation by _halo_ mass rather than _stellar_mass. The figure shows this error has a dramatic effect on the galaxy counts. Fortunately, this function was still in diffsky.experimental and we had not started doing science with it yet.
![buggy_normalization](https://github.com/user-attachments/assets/5f1fc2f4-e6ed-448f-a6e5-182fe5b21b58)
