### PR TITLE
Add `logmp_cutoff` feature to Monte Carlo lightcone halos

### DIFF
--- a/diffsky/experimental/mc_lightcone_halos.py
+++ b/diffsky/experimental/mc_lightcone_halos.py
@@ -306,7 +306,7 @@ def mc_lightcone_host_halo_diffmah(
     """
 
     lc_hmf_key, mah_key = jran.split(ran_key, 2)
-    z_halopop, logmp_halopop = mc_lightcone_host_halo_mass_function(
+    z_obs, logmp_obs_mf = mc_lightcone_host_halo_mass_function(
         lc_hmf_key,
         lgmp_min,
         z_min,
@@ -316,25 +316,19 @@ def mc_lightcone_host_halo_diffmah(
         hmf_params=hmf_params,
         n_hmf_grid=n_hmf_grid,
     )
-    t_obs_halopop = flat_wcdm.age_at_z(z_halopop, *cosmo_params)
+    t_obs = flat_wcdm.age_at_z(z_obs, *cosmo_params)
     t_0 = flat_wcdm.age_at_z0(*cosmo_params)
     lgt0 = jnp.log10(t_0)
 
     tarr = np.array((10**lgt0,))
-    args = (diffmahpop_params, tarr, logmp_halopop, t_obs_halopop, mah_key, lgt0)
+    args = (diffmahpop_params, tarr, logmp_obs_mf, t_obs, mah_key, lgt0)
     halopop = mc_cenpop(*args)  # mah_params, dmhdt, log_mah
     logmp0_halopop = halopop.log_mah[:, 0]
 
-    logmp_obs_halopop = _log_mah_kern(halopop.mah_params, t_obs_halopop, lgt0)
+    logmp_obs = _log_mah_kern(halopop.mah_params, t_obs, lgt0)
 
     fields = ("z_obs", "t_obs", "logmp_obs", "mah_params", "logmp0")
-    values = (
-        z_halopop,
-        t_obs_halopop,
-        logmp_obs_halopop,
-        halopop.mah_params,
-        logmp0_halopop,
-    )
+    values = (z_obs, t_obs, logmp_obs, halopop.mah_params, logmp0_halopop)
     cenpop_out = dict()
     for key, value in zip(fields, values):
         cenpop_out[key] = value

--- a/diffsky/experimental/mc_lightcone_halos.py
+++ b/diffsky/experimental/mc_lightcone_halos.py
@@ -288,6 +288,10 @@ def mc_lightcone_host_halo_diffmah(
         dsps.cosmology.flat_wcdm cosmology
         cosmo_params = (Om0, w0, wa, h)
 
+    logmp_cutoff : float, optional
+        Minimum halo mass for which DiffmahPop is used to generate MAHs.
+        For logmp < logmp_cutoff, P(θ_MAH | logmp) = P(θ_MAH | logmp_cutoff)
+
     Returns
     -------
     cenpop : dict

--- a/diffsky/mass_functions/mc_diffmah_tpeak.py
+++ b/diffsky/mass_functions/mc_diffmah_tpeak.py
@@ -1,5 +1,4 @@
-"""
-"""
+""" """
 
 from collections import namedtuple
 
@@ -214,6 +213,7 @@ def mc_host_halos(
     hosts_logmh_at_z=None,
     cosmo_params=DEFAULT_COSMOLOGY,
     diffmahpop_params=DEFAULT_DIFFMAHPOP_PARAMS,
+    logmp_cutoff=0.0,
 ):
     """Monte Carlo realization of a subhalo catalog at a single redshift"""
     host_key1, host_key2 = jran.split(ran_key, 2)
@@ -225,6 +225,9 @@ def mc_host_halos(
 
         hosts_logmh_at_z = mc_host_halos_singlez(host_key1, lgmp_min, z_obs, volume_com)
 
+    hosts_logmh_at_z_clipped = np.clip(hosts_logmh_at_z, logmp_cutoff, np.inf)
+    delta_logmh_clip = hosts_logmh_at_z_clipped - hosts_logmh_at_z
+
     t_obs = _age_at_z_kern(z_obs, *cosmo_params)
     t_0 = age_at_z0(*cosmo_params)
     lgt0 = np.log10(t_0)
@@ -235,8 +238,9 @@ def mc_host_halos(
 
     tarr = np.zeros(1) + 10**lgt0
     mah_params = mc_cenpop(
-        diffmahpop_params, tarr, hosts_logmh_at_z, t_obs + _ZH, host_key2, lgt0
+        diffmahpop_params, tarr, hosts_logmh_at_z_clipped, t_obs + _ZH, host_key2, lgt0
     )[0]
+    mah_params = mah_params._replace(logm0=mah_params.logm0 - delta_logmh_clip)
 
     host_mah_params = mah_params
     lgmhost_pen_inf = np.copy(hosts_logmh_at_z)


### PR DESCRIPTION
Add `logmp_cutoff` feature to Monte Carlo lightcone halos. The idea behind this simple fix is to assume the following for logmp < logmp_cutoff:

```
P(θ_MAH | logmp) = P(θ_MAH | logmp_cutoff)
```

As a sanity check on the code, I generated two populations of halos using `lgmp_min=10`. The blue population does not use the cutoff, and the orange population has `logmp_cutoff=11`. If the cutoff had no consequences, the two distributions would be identical. Instead, the orange distribution starts to deviate from the blue below the cutoff. Based on this plot, this feature looks worth including since it's better than not having any low-mass halos at all, but there's clearly room for improvement.

@AlanPearl could you check whether this feature resolves the weird photometry reported in #147? To run the test, simply rerun your photometry calculation using this branch and with `logmp_cutoff=11`.