### PR TITLE
Fix call to config.update to be above other jax imports

### DIFF
--- a/diffsky/experimental/lc_phot_kern.py
+++ b/diffsky/experimental/lc_phot_kern.py
@@ -1,8 +1,12 @@
 """ """
 
+from jax import config
+
+config.update("jax_enable_x64", True)
+
+
 from collections import namedtuple
 
-import jax
 from diffstar.utils import cumulative_mstar_formed_galpop
 from diffstarpop import mc_diffstar_sfh_galpop
 from dsps.constants import T_TABLE_MIN
@@ -22,8 +26,6 @@ from ..phot_utils import get_wave_eff_from_tcurves
 from ..ssp_err_model import ssp_err_model
 from . import mc_lightcone_halos as mclh
 from . import photometry_interpolation as photerp
-
-jax.config.update("jax_enable_x64", True)
 
 _M = (0, None, None)
 _calc_lgmet_weights_galpop = jjit(

--- a/diffsky/experimental/mc_diffsky_phot.py
+++ b/diffsky/experimental/mc_diffsky_phot.py
@@ -1,6 +1,9 @@
 """ """
 
-import jax
+from jax import config
+
+config.update("jax_enable_x64", True)
+
 from diffstarpop.defaults import DEFAULT_DIFFSTARPOP_PARAMS
 from dsps.cosmology.defaults import DEFAULT_COSMOLOGY
 from dsps.metallicity import umzr
@@ -18,8 +21,6 @@ from ..phot_utils import get_wave_eff_from_tcurves, load_interpolated_lsst_curve
 from ..ssp_err_model import ssp_err_model
 from . import precompute_ssp_phot as psp
 from .scatter import DEFAULT_SCATTER_PARAMS
-
-jax.config.update("jax_enable_x64", True)
 
 # gal_t_table, gal_sfr_table, ssp_lg_age_gyr, t_obs, sfr_min
 _A = (None, 0, None, None, None)

--- a/diffsky/experimental/mc_lightcone_halos.py
+++ b/diffsky/experimental/mc_lightcone_halos.py
@@ -1,5 +1,9 @@
 """Functions to generate Monte Carlo realizations of galaxies on a lightcone"""
 
+from jax import config
+
+config.update("jax_enable_x64", True)
+
 import numpy as np
 from diffmah.diffmah_kernels import _log_mah_kern
 from diffmah.diffmahpop_kernels.bimod_censat_params import DEFAULT_DIFFMAHPOP_PARAMS
@@ -13,7 +17,7 @@ from dsps.cosmology import flat_wcdm
 from dsps.metallicity import umzr
 from dsps.sed import metallicity_weights as zmetw
 from dsps.sed.stellar_age_weights import calc_age_weights_from_sfh_table
-from jax import config, grad
+from jax import grad
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import random as jran
@@ -27,8 +31,6 @@ from ..ssp_err_model import ssp_err_model
 from . import photometry_interpolation as photerp
 from . import precompute_ssp_phot as psp
 from .scatter import DEFAULT_SCATTER_PARAMS
-
-config.update("jax_enable_x64", True)
 
 N_HMF_GRID = 2_000
 N_SFH_TABLE = 100

--- a/diffsky/experimental/photometry_interpolation.py
+++ b/diffsky/experimental/photometry_interpolation.py
@@ -1,13 +1,14 @@
 """ """
 
-import jax
+from jax import config
+
+config.update("jax_enable_x64", True)
+
 from dsps.cosmology import age_at_z
 from dsps.sed import calc_ssp_weights_sfh_table_lognormal_mdf
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import vmap
-
-jax.config.update("jax_enable_x64", True)
 
 _a = (None, 0, 0, None, None, None, 0)
 calc_ssp_weights_sfh_table_lognormal_mdf_vmap = jjit(

--- a/diffsky/merging/fitmerge_multi_redshift.py
+++ b/diffsky/merging/fitmerge_multi_redshift.py
@@ -1,21 +1,20 @@
-"""Functions related to calibrating the merging model.
-"""
+"""Functions related to calibrating the merging model."""
 
+from jax import config
+
+config.update("jax_enable_x64", True)
+
+from dsps.utils import _tw_cuml_kern
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import vmap
-from jax import config
-
-from dsps.utils import _tw_cuml_kern
 
 from .merging_model import merge_model_with_preprocessing
-
-config.update("jax_enable_x64", True)
 
 
 @jjit
 def triweighted_histogram(X, sigma, lobins, bin_width):
-    """ Triweighted histogram
+    """Triweighted histogram
 
     Parameters
     ----------
@@ -46,7 +45,7 @@ def triweighted_histogram(X, sigma, lobins, bin_width):
 
 @jjit
 def weighted_tw_histogram(X, sigma, y, lobins, bin_width):
-    """ Triweighted histogram
+    """Triweighted histogram
 
     Parameters
     ----------
@@ -128,14 +127,7 @@ mapped_histogram = vmap(scalar_smf, in_axes=(None, 0, None, None, None, None))
 
 # Conditional stellar mass function
 def csmf_sats_cens_all(
-    all_sm_no_zero,
-    host_lgmp,
-    upid,
-    a,
-    lobins,
-    sigma,
-    bin_width,
-    comoving_volume
+    all_sm_no_zero, host_lgmp, upid, a, lobins, sigma, bin_width, comoving_volume
 ):
     """Conditional stellar mass function
 
@@ -244,15 +236,7 @@ def condition(host_lgmp):
 
 
 # Conditional stellar mass function
-def csmf(
-    all_sm_no_zero,
-    host_lgmp,
-    a,
-    lobins,
-    sigma,
-    bin_width,
-    comoving_volume
-):
+def csmf(all_sm_no_zero, host_lgmp, a, lobins, sigma, bin_width, comoving_volume):
 
     low = [12, 13, 14]
     high = [13, 14, 18]
@@ -261,7 +245,12 @@ def csmf(
     for i in range(3):
         smf_all = mapped_histogram(
             jnp.log10(all_sm_no_zero[(host_lgmp > low[i]) & (host_lgmp < high[i])]),
-            lobins, a, sigma, bin_width, comoving_volume)
+            lobins,
+            a,
+            sigma,
+            bin_width,
+            comoving_volume,
+        )
         smf.append(smf_all)
 
     return smf
@@ -288,7 +277,7 @@ def model_histogram(
     sigma,
     bin_width,
     comoving_volume,
-    lobins
+    lobins,
 ):
 
     SFR = merge_model_with_preprocessing(
@@ -304,15 +293,19 @@ def model_histogram(
         sfr,
         penultimate_dump,
         ultimate_dump,
-        MC)
+        MC,
+    )
 
     M = jnp.cumsum(SFR * dT, axis=1)
 
     M_interest = M[:, i_interest]
 
-    hist = scalar_smf(
-        jnp.log10(M_interest), lobins, a_interest,
-        sigma, bin_width, comoving_volume) + 1e-10
+    hist = (
+        scalar_smf(
+            jnp.log10(M_interest), lobins, a_interest, sigma, bin_width, comoving_volume
+        )
+        + 1e-10
+    )
 
     return hist
 
@@ -339,7 +332,7 @@ def conditional_model_histogram(
     bin_width,
     comoving_volume,
     lobins,
-    keep
+    keep,
 ):
 
     SFR = merge_model_with_preprocessing(
@@ -355,7 +348,8 @@ def conditional_model_histogram(
         sfr,
         penultimate_dump,
         ultimate_dump,
-        MC)
+        MC,
+    )
 
     M = jnp.cumsum(SFR * dT, axis=1)
 
@@ -363,9 +357,12 @@ def conditional_model_histogram(
 
     M_keep = M_interest[keep] + 1e-10
 
-    hist = scalar_smf(
-        jnp.log10(M_keep), lobins, a_interest,
-        sigma, bin_width, comoving_volume) + 1e-10
+    hist = (
+        scalar_smf(
+            jnp.log10(M_keep), lobins, a_interest, sigma, bin_width, comoving_volume
+        )
+        + 1e-10
+    )
 
     return hist
 
@@ -373,8 +370,29 @@ def conditional_model_histogram(
 mapped_model_csmf = vmap(
     conditional_model_histogram,
     in_axes=(
-        None, None, None, None, None, None, None, None, None, None,
-        None, None, None, None, None, None, None, None, None, 0, None))
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        0,
+        None,
+    ),
+)
 
 
 @jjit
@@ -393,7 +411,7 @@ def model_mass(
     ultimate_dump,
     MC,
     dT,
-    i_interest
+    i_interest,
 ):
 
     SFR = merge_model_with_preprocessing(
@@ -409,7 +427,8 @@ def model_mass(
         sfr,
         penultimate_dump,
         ultimate_dump,
-        MC)
+        MC,
+    )
 
     M = jnp.cumsum(SFR * dT, axis=1)
 
@@ -436,7 +455,7 @@ def sat_frac(
     dT,
     i_interest,
     bins,
-    bin_width
+    bin_width,
 ):
 
     stellar_mass = model_mass(
@@ -454,7 +473,8 @@ def sat_frac(
         ultimate_dump,
         MC,
         dT,
-        i_interest)
+        i_interest,
+    )
 
     logsm = jnp.log10(stellar_mass)
     sats_logsm = jnp.where(upids != -1, logsm, 0)

--- a/diffsky/merging/merging_model.py
+++ b/diffsky/merging/merging_model.py
@@ -2,17 +2,16 @@
 probability and applying the merging model.
 """
 
-from collections import OrderedDict, namedtuple
-
 from jax import config
-from jax import jit as jjit
-from jax import numpy as jnp
-from jax import random, vmap
-
-from dsps.utils import _inverse_sigmoid, _sigmoid
 
 config.update("jax_enable_x64", True)
 
+from collections import OrderedDict, namedtuple
+
+from dsps.utils import _inverse_sigmoid, _sigmoid
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import random, vmap
 
 DEFAULT_MERGE_PDICT = OrderedDict(
     t_delay_min=12.018,  # 2.563,
@@ -129,7 +128,7 @@ def p_infall(t_interest, k_infall, t_infall, t_delay, p_max):
     """
     t_start = t_infall + t_delay
     s = _sigmoid(t_interest, t_start, k_infall, -0.999999, p_max)
-    ss = jnp.sqrt(s * s) * _sigmoid(s, 0.05, 20., 0.0, 1.0)
+    ss = jnp.sqrt(s * s) * _sigmoid(s, 0.05, 20.0, 0.0, 1.0)
     return ss
 
 
@@ -178,11 +177,7 @@ def get_p_merge_from_merging_params(
 
     # There is a period of rapid merging where things reach p_max more quickly
     k_infall = _sigmoid(
-        t_infall,
-        t_crit,
-        merging_params.k_k,
-        merging_params.k_min,
-        merging_params.k_max
+        t_infall, t_crit, merging_params.k_k, merging_params.k_min, merging_params.k_max
     )
 
     # Galaxies in larger hosts experience a longer delay time
@@ -211,12 +206,7 @@ def get_p_merge_from_merging_u_params(
 ):
     merging_params = get_bounded_merge_params(merging_u_params)
     p_merge = get_p_merge_from_merging_params(
-        merging_params,
-        log_mpeak_infall,
-        log_mhost_infall,
-        t_interest,
-        t_infall,
-        upids
+        merging_params, log_mpeak_infall, log_mhost_infall, t_interest, t_infall, upids
     )
 
     return p_merge

--- a/diffsky/param_utils/spspop_param_utils.py
+++ b/diffsky/param_utils/spspop_param_utils.py
@@ -1,8 +1,11 @@
 """ """
 
+from jax import config
+
+config.update("jax_enable_x64", True)
+
 from collections import namedtuple
 
-from jax import config
 from jax import jit as jjit
 
 from ..burstpop.diffqburstpop_mono import DiffburstPopParams, DiffburstPopUParams
@@ -39,9 +42,6 @@ from ..dustpop.funopop_ssfr import (
     get_unbounded_funopop_params,
 )
 from ..dustpop.tw_dustpop_new import DustPopParams, DustPopUParams
-
-config.update("jax_enable_x64", True)
-
 
 DEFAULT_DIFFBURSTPOP_PARAMS = DiffburstPopParams(
     DEFAULT_FREQBURST_PARAMS, DEFAULT_FBURSTPOP_PARAMS, DEFAULT_TBURSTPOP_PARAMS


### PR DESCRIPTION
Using double precision needs to happen at the very top of the module, not below other jax imports. This was not done correctly in https://github.com/ArgonneCPAC/dsps/pull/107 nor in #151.