### PR TITLE
Add unit test of `core_tag` uniqueness and `top_host_tag` agreement with `diffsky.utils.crossmatch`

### DIFF
--- a/diffsky/data_loaders/hacc_utils/data_validation/tests/test_validate_lc_cores.py
+++ b/diffsky/data_loaders/hacc_utils/data_validation/tests/test_validate_lc_cores.py
@@ -38,11 +38,11 @@ def test_check_zrange_passes_for_all_last_journey_data_on_poboy():
 
 @pytest.mark.skipif(not CAN_RUN_LJ_DATA_TESTS, reason=POBOY_MSG)
 def test_check_core_tag_uniqueness():
-    """This test is marked xfail since a small number of repeats is allowed"""
+    """Every core_tag should be unique. A very small number of repeats is allowed."""
     bnpat = vlcc.BNPAT_LC_CORES.format("*", "*")
     fn_list = glob(os.path.join(DRN_LC_CORES_POBOY, bnpat))
     for fn_lc_cores in fn_list:
-        msg = vlcc.check_core_tag_uniqueness(fn_lc_cores, "LastJourney")
+        msg = vlcc.check_core_tag_uniqueness(fn_lc_cores)
 
         if len(msg) > 0:
             # No more than 10 core tags that have a repetition
@@ -54,3 +54,24 @@ def test_check_core_tag_uniqueness():
             s = msg[2]
             max_repetitions = int(s.split("=")[-1])
             assert max_repetitions == 2
+
+
+@pytest.mark.skipif(not CAN_RUN_LJ_DATA_TESTS, reason=POBOY_MSG)
+def test_check_top_host_tag_has_match():
+    """top_host_tag should always agree with the result recalculated by diffsky
+
+    In the current implementation, this test is skipped for lc_cores in which
+    there is a repeated entry of core_tag
+
+    """
+    bnpat = vlcc.BNPAT_LC_CORES.format("*", "*")
+    fn_list = glob(os.path.join(DRN_LC_CORES_POBOY, bnpat))
+    for fn_lc_cores in fn_list:
+        msg = vlcc.check_top_host_tag_has_match(fn_lc_cores)
+        if len(msg) > 0:
+            s = msg[0]
+            if "Could not run test" in s:
+                pass
+            else:
+                bn = os.path.basename(fn_lc_cores)
+                raise ValueError(f"{bn} has mismatching top_host_idx")

--- a/diffsky/data_loaders/hacc_utils/data_validation/tests/test_validate_lc_cores.py
+++ b/diffsky/data_loaders/hacc_utils/data_validation/tests/test_validate_lc_cores.py
@@ -34,3 +34,23 @@ def test_check_zrange_passes_for_all_last_journey_data_on_poboy():
     for fn_lc_cores in fn_list:
         msg = vlcc.check_zrange(fn_lc_cores, "LastJourney")
         assert len(msg) == 0
+
+
+@pytest.mark.skipif(not CAN_RUN_LJ_DATA_TESTS, reason=POBOY_MSG)
+def test_check_core_tag_uniqueness():
+    """This test is marked xfail since a small number of repeats is allowed"""
+    bnpat = vlcc.BNPAT_LC_CORES.format("*", "*")
+    fn_list = glob(os.path.join(DRN_LC_CORES_POBOY, bnpat))
+    for fn_lc_cores in fn_list:
+        msg = vlcc.check_core_tag_uniqueness(fn_lc_cores, "LastJourney")
+
+        if len(msg) > 0:
+            # No more than 10 core tags that have a repetition
+            s = msg[1]
+            n_distinct_repeats = int(s.split("=")[-1])
+            assert n_distinct_repeats < 10
+
+            # Only a single repetition is allowed
+            s = msg[2]
+            max_repetitions = int(s.split("=")[-1])
+            assert max_repetitions == 2

--- a/diffsky/data_loaders/hacc_utils/data_validation/validate_lc_cores.py
+++ b/diffsky/data_loaders/hacc_utils/data_validation/validate_lc_cores.py
@@ -2,6 +2,8 @@
 
 import os
 
+import numpy as np
+
 from .. import lightcone_utils as lcu
 from .. import load_flat_hdf5
 
@@ -28,4 +30,22 @@ def check_zrange(fn_lc_cores, sim_name, tol=0.0002, lc_cores=None):
     if a_max_data > a_max_expected + tol:
         msg.append(f"a_max_data={a_max_data} > a_max_expected={a_max_expected}\n")
 
+    return msg
+
+
+def check_core_tag_uniqueness(fn_lc_cores, sim_name, tol=0.0002, lc_cores=None):
+    msg = []
+    if lc_cores is None:
+        lc_cores = load_flat_hdf5(fn_lc_cores)
+        u_core_tags, counts = np.unique(lc_cores["core_tag"], return_counts=True)
+        if u_core_tags.size < lc_cores["core_tag"].size:
+            example_repeated_core_tag = u_core_tags[counts > 1][0]
+            s = f"repeated core tag = {example_repeated_core_tag}"
+            msg.append(s)
+            n_distinct_repeats = np.sum(counts > 1)
+            max_repetitions = counts.max()
+            s = f"Number of distinct repeats = {n_distinct_repeats}"
+            msg.append(s)
+            s = f"Max num repetitions = {max_repetitions}"
+            msg.append(s)
     return msg

--- a/diffsky/data_loaders/hacc_utils/data_validation/validate_lc_cores.py
+++ b/diffsky/data_loaders/hacc_utils/data_validation/validate_lc_cores.py
@@ -4,6 +4,7 @@ import os
 
 import numpy as np
 
+from ....utils import crossmatch
 from .. import lightcone_utils as lcu
 from .. import load_flat_hdf5
 
@@ -33,19 +34,53 @@ def check_zrange(fn_lc_cores, sim_name, tol=0.0002, lc_cores=None):
     return msg
 
 
-def check_core_tag_uniqueness(fn_lc_cores, sim_name, tol=0.0002, lc_cores=None):
-    msg = []
+def check_core_tag_uniqueness(fn_lc_cores, lc_cores=None):
     if lc_cores is None:
         lc_cores = load_flat_hdf5(fn_lc_cores)
-        u_core_tags, counts = np.unique(lc_cores["core_tag"], return_counts=True)
-        if u_core_tags.size < lc_cores["core_tag"].size:
-            example_repeated_core_tag = u_core_tags[counts > 1][0]
-            s = f"repeated core tag = {example_repeated_core_tag}"
+
+    msg = []
+    u_core_tags, counts = np.unique(lc_cores["core_tag"], return_counts=True)
+    if u_core_tags.size < lc_cores["core_tag"].size:
+        example_repeated_core_tag = u_core_tags[counts > 1][0]
+        s = f"repeated core_tag = {example_repeated_core_tag}"
+        msg.append(s)
+        n_distinct_repeats = np.sum(counts > 1)
+        max_repetitions = counts.max()
+        s = f"Number of distinct repeats = {n_distinct_repeats}"
+        msg.append(s)
+        s = f"Max num repetitions = {max_repetitions}"
+        msg.append(s)
+    return msg
+
+
+def check_top_host_tag_has_match(fn_lc_cores, lc_cores=None):
+
+    if lc_cores is None:
+        lc_cores = load_flat_hdf5(fn_lc_cores)
+
+    u_core_tag, u_indx, counts = np.unique(
+        lc_cores["core_tag"], return_counts=True, return_index=True
+    )
+
+    msg = []
+    if u_core_tag.size < lc_cores["core_tag"].size:
+        s = "Could not run test of top_host_tag due to repeated values of core_tag"
+        msg.append(s)
+    else:
+        idxA, idxB = crossmatch(lc_cores["top_host_tag"], lc_cores["core_tag"])
+        indarr = np.arange(len(u_core_tag)).astype(int)
+        indarr[idxA] = indarr[idxB]
+
+        if not np.allclose(indarr, lc_cores["top_host_idx"]):
+            msk = indarr != lc_cores["top_host_idx"]
+            example_core_tag = lc_cores["core_tag"][msk][0]
+            example_top_host_tag = lc_cores["top_host_tag"][msk][0]
+            s = f"core_tag = {example_core_tag} has top_host_tag={example_top_host_tag} "
+            s += "which disagrees with diffsky.utils.crossmatch"
             msg.append(s)
-            n_distinct_repeats = np.sum(counts > 1)
-            max_repetitions = counts.max()
-            s = f"Number of distinct repeats = {n_distinct_repeats}"
+
+            n_mismatches = msk.sum()
+            s = f"Number of discrepancies between top_host_tag and diffsky = {n_mismatches}"
             msg.append(s)
-            s = f"Max num repetitions = {max_repetitions}"
-            msg.append(s)
+
     return msg


### PR DESCRIPTION
Add unit test of `core_tag` uniqueness and `top_host_tag` agreement with `diffsky.utils.crossmatch`.

Note that with the current code, for lightcone files in which there is a repeated value of `core_tag` (about 2% of the files), we skip the test of `top_host_tag` agreement with `diffsky.utils.crossmatch`. The reason is that in this case, the bookkeeping is a little complicated since `diffsky.utils.crossmatch` does not run on arrays with a repeated entry for the `core_tag`.