### PR TITLE
`z_obs --> z_true`

### DIFF
--- a/diffsky/data_loaders/hacc_utils/lc_mock_production.py
+++ b/diffsky/data_loaders/hacc_utils/lc_mock_production.py
@@ -34,14 +34,14 @@ def write_lc_sfh_mock_to_disk(fnout, lc_data, diffsky_data):
         hdf_out["logsm_obs"] = diffsky_data["logsm_obs"]
         hdf_out["logssfr_obs"] = diffsky_data["logssfr_obs"]
 
-        hdf_out["z_obs"] = lc_data["z_obs"]
+        hdf_out["z_true"] = lc_data["z_true"]
         hdf_out["ra"] = lc_data["phi"]
         hdf_out["dec"] = np.pi / 2.0 - lc_data["theta"]
         hdf_out["snapnum"] = lc_data["snapnum"]
 
 
 def add_sfh_quantities_to_mock(sim_info, lc_data, diffsky_data, ran_key):
-    lc_data["t_obs"] = flat_wcdm.age_at_z(lc_data["z_obs"], *sim_info.cosmo_params)
+    lc_data["t_obs"] = flat_wcdm.age_at_z(lc_data["z_true"], *sim_info.cosmo_params)
 
     mah_params, msk_has_diffmah_fit = load_lc_cf.get_imputed_mah_params(
         ran_key, diffsky_data, lc_data, sim_info.lgt0

--- a/diffsky/data_loaders/hacc_utils/load_lc_cf.py
+++ b/diffsky/data_loaders/hacc_utils/load_lc_cf.py
@@ -51,9 +51,9 @@ def load_lc_diffsky_patch_data(fn_lc_diffsky, indir_lc_data):
     fn_lc = os.path.join(indir_lc_data, bn_lc)
     lc_data = load_flat_hdf5(fn_lc)
 
-    lc_data["z_obs"] = 1 / lc_data["scale_factor"] - 1
+    lc_data["z_true"] = 1 / lc_data["scale_factor"] - 1
 
-    assert lc_data["z_obs"].shape[0] == diffsky_data["logm0"].shape[0]
+    assert lc_data["z_true"].shape[0] == diffsky_data["logm0"].shape[0]
 
     return lc_data, diffsky_data
 
@@ -82,9 +82,9 @@ def collect_lc_diffsky_data(fn_list, drn_lc_data=None):
     for key in lc_data_collector[0].keys():
         lc_data[key] = np.concatenate([x[key] for x in lc_data_collector])
 
-    lc_data["z_obs"] = 1 / lc_data["scale_factor"] - 1
+    lc_data["z_true"] = 1 / lc_data["scale_factor"] - 1
 
-    assert lc_data["z_obs"].shape[0] == diffsky_data["logm0"].shape[0]
+    assert lc_data["z_true"].shape[0] == diffsky_data["logm0"].shape[0]
 
     return lc_data, diffsky_data
 


### PR DESCRIPTION
The value of `scale_factor` stored in the `lc_cores` files does not include the effect of peculiar velocity, so the column named `z_obs` in the output Diffsky mocks was misnamed. This PR fixes this for future mocks.