### PR TITLE
Cleanup internals of Monte Carlo lightcone code

### DIFF
--- a/diffsky/experimental/mc_lightcone_halos.py
+++ b/diffsky/experimental/mc_lightcone_halos.py
@@ -52,7 +52,7 @@ _B = (None, None, 1)
 interp_vmap2 = jjit(vmap(jnp.interp, in_axes=_B, out_axes=1))
 
 
-_G = (0, None, None, 0, 0, None)
+_G = (0, None, None, 0, None)
 mc_logmp_vmap = jjit(vmap(mc_hosts._mc_host_halos_singlez_kern, in_axes=_G))
 
 _LCA = (None, 0, None, None)
@@ -216,14 +216,8 @@ def mc_lightcone_host_halo_mass_function(
     # Randoms used in inverse transformation sampling halo mass
     uran_m = jran.uniform(m_key, minval=0, maxval=1, shape=(nhalos_tot,))
 
-    # Compute the effective volume of each halo according to its redshift
-    vol_galpop_mpc = jnp.interp(z_halopop, z_grid, vol_shell_grid_mpc)
-    vol_galpop_mpch = vol_galpop_mpc * (cosmo_params.h**3)
-
     # Draw a halo mass from the HMF at the particular redshift of each halo
-    logmp_halopop = mc_logmp_vmap(
-        uran_m, hmf_params, lgmp_min, z_halopop, vol_galpop_mpch, lgmp_max
-    )
+    logmp_halopop = mc_logmp_vmap(uran_m, hmf_params, lgmp_min, z_halopop, lgmp_max)
 
     return z_halopop, logmp_halopop
 

--- a/diffsky/mass_functions/mc_hosts.py
+++ b/diffsky/mass_functions/mc_hosts.py
@@ -20,13 +20,11 @@ def _compute_nhalos_tot(hmf_params, lgmp_min, redshift, volume_com_mpch):
 
 
 @jjit
-def _get_hmf_cdf_interp_tables(
-    hmf_params, lgmp_min, redshift, volume_com, lgmp_max=LGMH_MAX
-):
+def _get_hmf_cdf_interp_tables(hmf_params, lgmp_min, redshift, lgmp_max=LGMH_MAX):
     dlgmp = lgmp_max - lgmp_min
     lgmp_table = U_TABLE * dlgmp + lgmp_min
 
-    cdf_table = volume_com * 10 ** predict_cuml_hmf(hmf_params, lgmp_table, redshift)
+    cdf_table = 10 ** predict_cuml_hmf(hmf_params, lgmp_table, redshift)
     cdf_table = cdf_table - cdf_table[0]
     cdf_table = cdf_table / cdf_table[-1]
 
@@ -35,10 +33,10 @@ def _get_hmf_cdf_interp_tables(
 
 @jjit
 def _mc_host_halos_singlez_kern(
-    uran, hmf_params, lgmp_min, redshift, volume_com, lgmp_max=LGMH_MAX
+    uran, hmf_params, lgmp_min, redshift, lgmp_max=LGMH_MAX
 ):
     lgmp_table, cdf_table = _get_hmf_cdf_interp_tables(
-        hmf_params, lgmp_min, redshift, volume_com, lgmp_max=lgmp_max
+        hmf_params, lgmp_min, redshift, lgmp_max=lgmp_max
     )
     mc_lg_mp = jnp.interp(uran, cdf_table, lgmp_table)
     return mc_lg_mp
@@ -87,6 +85,6 @@ def mc_host_halos_singlez(
     nhalos = jran.poisson(counts_key, mean_nhalos)
     uran = jran.uniform(u_key, minval=0, maxval=1, shape=(nhalos,))
     lgmp_halopop = _mc_host_halos_singlez_kern(
-        uran, hmf_params, lgmp_min, redshift, volume_com_mpch, lgmp_max=lgmp_max
+        uran, hmf_params, lgmp_min, redshift, lgmp_max=lgmp_max
     )
     return np.array(lgmp_halopop)


### PR DESCRIPTION
When double-checking for correctness of the treatment of little h by the `mc_lightcone_host_halo_mass_function` function, I noticed that `mc_hosts._get_hmf_cdf_interp_tables` accepts an argument of cosmological volume, even though this function returns a unit-normalized CDF. So this PR does a minor refactoring of the internals to eliminate this unnecessary variable. There is no change at all to the behavior of the `mc_lightcone_host_halo_mass_function` function, which I have verified in a notebook enforcing that the same exact arrays are returned before and after this PR. But I think the `mc_lightcone_host_halo_mass_function` is easier to read now.