### PR TITLE
Fix error in docstring

### DIFF
--- a/diffsky/mass_functions/hmf_model.py
+++ b/diffsky/mass_functions/hmf_model.py
@@ -108,10 +108,10 @@ def predict_differential_hmf(params, logmp, redshift):
 
     Returns
     -------
-    lg_hmf : array, shape (n_halos, )
-        Base-10 log of differential comoving number density dn(logmp)/dlogmp
+    hmf : array, shape (n_halos, )
+        Differential comoving number density dn(logmp)/dlogmp
         in units of comoving (h/Mpc)**3 / dex
 
     """
-    lg_hmf = _predict_differential_hmf(params, logmp, redshift)
-    return lg_hmf
+    hmf = _predict_differential_hmf(params, logmp, redshift)
+    return hmf


### PR DESCRIPTION
In the docstring to `hmf_model.predict_differential_hmf`, it was previously stated that the returned quantity is the base-10 log of the differential HMF. This PR corrects the docstring to read that the returned quantity is the differential HMF itself (no log).