### PR TITLE
Weighted grid of synthetic lightcone halos

### DIFF
--- a/diffsky/experimental/mc_lightcone_halos.py
+++ b/diffsky/experimental/mc_lightcone_halos.py
@@ -383,8 +383,8 @@ def get_weighted_lightcone_grid_host_halo_diffmah(
         logmp0 : narray, shape (n_z*n_m, )
             Halo mass at z=0
 
-    nhalo_weighted_lc_grid : array, shape (n_z*n_m, )
-        Counts of each halo
+        nhalos : array, shape (n_z*n_m, )
+            Number of halos of this mass and redshift
 
     """
     nhalo_weighted_lc_grid = get_nhalo_weighted_lc_grid(
@@ -422,8 +422,9 @@ def get_weighted_lightcone_grid_host_halo_diffmah(
     cenpop_out = dict()
     for key, value in zip(fields, values):
         cenpop_out[key] = value
+    cenpop_out["nhalos"] = nhalo_weights
 
-    return cenpop_out, nhalo_weights
+    return cenpop_out
 
 
 def mc_lightcone_diffstar_cens(

--- a/diffsky/experimental/tests/test_mc_lightcone_halos.py
+++ b/diffsky/experimental/tests/test_mc_lightcone_halos.py
@@ -147,9 +147,10 @@ def test_get_weighted_lightcone_grid_host_halo_diffmah():
         lgmp_grid = np.linspace(lgmp_min, 15, n_m)
         z_grid = np.linspace(z_min, z_max, n_z)
 
-        cenpop, nhalo_weights = mclh.get_weighted_lightcone_grid_host_halo_diffmah(
+        cenpop = mclh.get_weighted_lightcone_grid_host_halo_diffmah(
             ran_key, lgmp_grid, z_grid, sky_area_degsq
         )
+        assert "nhalos" in cenpop.keys()
 
 
 def test_mc_lightcone_host_halo_diffmah():


### PR DESCRIPTION
This PR implements an alternative algorithm for generating synthetic lightcones of halos that is complementary to the `mc_lightcone_host_halo_diffmah` function. The new function, `get_weighted_lightcone_grid_host_halo_diffmah`, accepts as input a regular grid of halo mass and redshift, and returns the expected counts of halos on each grid point. The plots below show that the two functions give consistent results.

<img width="1042" height="766" alt="logmh_hist_lc_grid_test" src="https://github.com/user-attachments/assets/8397aa79-849e-40d9-b816-fd793cffc0b7" />
<img width="1070" height="764" alt="redshift_hist_lc_grid_test" src="https://github.com/user-attachments/assets/6089a201-7814-4de8-9116-9db36a5af7eb" />
