### PR TITLE
Change default SPS parameters in SFH-specific models

### DIFF
--- a/scripts/LJ_LC_MOCKS/make_dbk_sed_lc_mock_lj.py
+++ b/scripts/LJ_LC_MOCKS/make_dbk_sed_lc_mock_lj.py
@@ -180,6 +180,14 @@ if __name__ == "__main__":
         param_collection = dpw.get_param_collection_from_u_param_collection(
             *u_param_collection
         )
+        if True:  # always do this for now
+            print("Ignoring pre-computed fit of SPS parameters")
+            diffstarpop_sfh_model = param_collection[0]
+            param_collection = (
+                diffstarpop_sfh_model,
+                *dpw.DEFAULT_PARAM_COLLECTION[1:],
+            )
+
     else:
         print(f"Reading diffsky parameter array from disk. Filename = {fn_u_params}")
         u_param_arr = np.loadtxt(fn_u_params)


### PR DESCRIPTION
This PR changes the population-level SPS parameters that will be produced with the `-sfh_model` argument in the `make_dbk_sed_lc_mock_lj.py` script. All such models will be made using the same SPS-pop parameters, the default ones. Previously, the SPS-pop params were different for each model.