### PR TITLE
Fix bookkeeping bug in disk/bulge/knot SED mocks

### DIFF
--- a/diffsky/data_loaders/hacc_utils/lc_mock_production.py
+++ b/diffsky/data_loaders/hacc_utils/lc_mock_production.py
@@ -178,12 +178,14 @@ def write_lc_dbk_sed_mock_to_disk(
 
 
 def add_sfh_quantities_to_mock(sim_info, lc_data, diffsky_data, ran_key):
+    mah_key, sfh_key = jran.split(ran_key, 2)
+
     lc_data["t_obs"] = flat_wcdm.age_at_z(
         lc_data["redshift_true"], *sim_info.cosmo_params
     )
 
     mah_params, msk_has_diffmah_fit = load_lc_cf.get_imputed_mah_params(
-        ran_key, diffsky_data, lc_data, sim_info.lgt0
+        mah_key, diffsky_data, lc_data, sim_info.lgt0
     )
     for pname, pval in zip(mah_params._fields, mah_params):
         diffsky_data[pname] = pval
@@ -214,7 +216,7 @@ def add_sfh_quantities_to_mock(sim_info, lc_data, diffsky_data, ran_key):
         lgmu_infall,
         logmhost_infall,
         gyr_since_infall,
-        ran_key,
+        sfh_key,
         t_table,
     )
 

--- a/diffsky/data_loaders/hacc_utils/tests/test_lc_mock_production.py
+++ b/diffsky/data_loaders/hacc_utils/tests/test_lc_mock_production.py
@@ -99,7 +99,6 @@ def test_add_dbk_sed_quantities_to_mock():
     lc_data, diffsky_data = lcmp.add_sfh_quantities_to_mock(
         diffsky_info, deepcopy(lc_data), deepcopy(diffsky_data), ran_key
     )
-    diffsky_data_with_sfh = deepcopy(diffsky_data)
 
     z_phot_table = np.linspace(lc_data["z_obs"].min(), lc_data["z_obs"].max(), 15)
     t0 = age_at_z0(*diffsky_info.cosmo_params)
@@ -125,14 +124,6 @@ def test_add_dbk_sed_quantities_to_mock():
 
     _res = lcmp.add_dbk_sed_quantities_to_mock(*args)
     phot_info, lc_data, diffsky_data = _res
-
-    # assert np.allclose(
-    #     diffsky_data_with_sfh["sfh_table"], diffsky_data["sfh_table"], rtol=0.01
-    # )
-
-    # assert np.allclose(
-    #     phot_info["sfh_table"], diffsky_data_with_sfh["sfh_table"], rtol=0.01
-    # )
 
     fbulge_params = dbk.DEFAULT_FBULGE_PARAMS._make(
         (phot_info["fbulge_tcrit"], phot_info["fbulge_early"], phot_info["fbulge_late"])

--- a/diffsky/data_loaders/hacc_utils/tests/test_lc_mock_production.py
+++ b/diffsky/data_loaders/hacc_utils/tests/test_lc_mock_production.py
@@ -131,30 +131,29 @@ def test_add_dbk_sed_quantities_to_mock():
         diffsky_data_with_sfh["sfh_table"], diffsky_data["sfh_table"], rtol=0.01
     )
 
-    return phot_info, diffsky_data, t_table
     assert np.allclose(phot_info["sfh_table"], diffsky_data["sfh_table"], rtol=0.01)
 
-    # fbulge_params = dbk.DEFAULT_FBULGE_PARAMS._make(
-    #     (phot_info["fbulge_tcrit"], phot_info["fbulge_early"], phot_info["fbulge_late"])
-    # )
+    fbulge_params = dbk.DEFAULT_FBULGE_PARAMS._make(
+        (phot_info["fbulge_tcrit"], phot_info["fbulge_early"], phot_info["fbulge_late"])
+    )
 
-    # t_obs = age_at_z(lc_data["redshift_true"], *diffsky_info.cosmo_params)
+    t_obs = age_at_z(lc_data["redshift_true"], *diffsky_info.cosmo_params)
 
-    # _res = dbk._bulge_sfh_vmap(t_table, phot_info["sfh_table"], fbulge_params)
-    # bth = _res[-1]
-    # bulge_to_total_recomputed = vmap_interp(t_obs, t_table, bth)
-    # bulge_to_total_recomputed2 = vmap_interp(
-    #     t_obs, t_table, phot_info["bulge_to_total_history"]
-    # )
-    # assert np.allclose(bulge_to_total_recomputed, bulge_to_total_recomputed2, rtol=0.01)
+    _res = dbk._bulge_sfh_vmap(t_table, phot_info["sfh_table"], fbulge_params)
+    bth = _res[-1]
+    bulge_to_total_recomputed = vmap_interp(t_obs, t_table, bth)
+    bulge_to_total_recomputed2 = vmap_interp(
+        t_obs, t_table, phot_info["bulge_to_total_history"]
+    )
+    assert np.allclose(bulge_to_total_recomputed, bulge_to_total_recomputed2, rtol=0.01)
 
-    # disk_bulge_history = mcdb.decompose_sfh_into_disk_bulge_sfh(
-    #     t_table, diffsky_data["sfh_table"]
-    # )
+    disk_bulge_history = mcdb.decompose_sfh_into_disk_bulge_sfh(
+        t_table, diffsky_data["sfh_table"]
+    )
 
-    # for pname in disk_bulge_history.fbulge_params._fields:
-    #     assert np.allclose(
-    #         getattr(disk_bulge_history.fbulge_params, pname),
-    #         getattr(fbulge_params, pname),
-    #         rtol=0.01,
-    #     )
+    for pname in disk_bulge_history.fbulge_params._fields:
+        assert np.allclose(
+            getattr(disk_bulge_history.fbulge_params, pname),
+            getattr(fbulge_params, pname),
+            rtol=0.01,
+        )

--- a/diffsky/data_loaders/hacc_utils/tests/test_lc_mock_production.py
+++ b/diffsky/data_loaders/hacc_utils/tests/test_lc_mock_production.py
@@ -131,27 +131,30 @@ def test_add_dbk_sed_quantities_to_mock():
         diffsky_data_with_sfh["sfh_table"], diffsky_data["sfh_table"], rtol=0.01
     )
 
-    fbulge_params = dbk.DEFAULT_FBULGE_PARAMS._make(
-        (phot_info["fbulge_tcrit"], phot_info["fbulge_early"], phot_info["fbulge_late"])
-    )
+    return phot_info, diffsky_data, t_table
+    assert np.allclose(phot_info["sfh_table"], diffsky_data["sfh_table"], rtol=0.01)
 
-    t_obs = age_at_z(lc_data["redshift_true"], *diffsky_info.cosmo_params)
+    # fbulge_params = dbk.DEFAULT_FBULGE_PARAMS._make(
+    #     (phot_info["fbulge_tcrit"], phot_info["fbulge_early"], phot_info["fbulge_late"])
+    # )
 
-    _res = dbk._bulge_sfh_vmap(t_table, phot_info["sfh_table"], fbulge_params)
-    bth = _res[-1]
-    bulge_to_total_recomputed = vmap_interp(t_obs, t_table, bth)
-    bulge_to_total_recomputed2 = vmap_interp(
-        t_obs, t_table, phot_info["bulge_to_total_history"]
-    )
-    assert np.allclose(bulge_to_total_recomputed, bulge_to_total_recomputed2, rtol=0.01)
+    # t_obs = age_at_z(lc_data["redshift_true"], *diffsky_info.cosmo_params)
 
-    disk_bulge_history = mcdb.decompose_sfh_into_disk_bulge_sfh(
-        t_table, diffsky_data["sfh_table"]
-    )
+    # _res = dbk._bulge_sfh_vmap(t_table, phot_info["sfh_table"], fbulge_params)
+    # bth = _res[-1]
+    # bulge_to_total_recomputed = vmap_interp(t_obs, t_table, bth)
+    # bulge_to_total_recomputed2 = vmap_interp(
+    #     t_obs, t_table, phot_info["bulge_to_total_history"]
+    # )
+    # assert np.allclose(bulge_to_total_recomputed, bulge_to_total_recomputed2, rtol=0.01)
 
-    for pname in disk_bulge_history.fbulge_params._fields:
-        assert np.allclose(
-            getattr(disk_bulge_history.fbulge_params, pname),
-            getattr(fbulge_params, pname),
-            rtol=0.01,
-        )
+    # disk_bulge_history = mcdb.decompose_sfh_into_disk_bulge_sfh(
+    #     t_table, diffsky_data["sfh_table"]
+    # )
+
+    # for pname in disk_bulge_history.fbulge_params._fields:
+    #     assert np.allclose(
+    #         getattr(disk_bulge_history.fbulge_params, pname),
+    #         getattr(fbulge_params, pname),
+    #         rtol=0.01,
+    #     )

--- a/diffsky/data_loaders/hacc_utils/tests/test_lc_mock_production.py
+++ b/diffsky/data_loaders/hacc_utils/tests/test_lc_mock_production.py
@@ -2,9 +2,17 @@
 
 import os
 
+import numpy as np
 import pytest
+from diffmah import DEFAULT_MAH_PARAMS
+from dsps.data_loaders import load_ssp_templates
 from jax import random as jran
 
+from diffsky.param_utils import diffsky_param_wrapper as dpw
+
+from ....experimental import precompute_ssp_phot as psspp
+from ....experimental.lc_phot_kern import get_wave_eff_table
+from ....experimental.tests import test_lc_phot_kern as tlcphk
 from .. import lc_mock_production as lcmp
 from .. import load_lc_cf
 
@@ -33,3 +41,52 @@ def test_add_sfh_quantities_to_mock():
 
     args = (sim_info, lc_data, diffsky_data, ran_key)
     lc_data, diffsky_data = lcmp.add_sfh_quantities_to_mock(*args)
+
+
+def _prepare_input_catalogs(n_gals=500):
+    lc_data, tcurves = tlcphk._get_weighted_lc_data_for_unit_testing(num_halos=n_gals)
+    lc_data = lc_data._asdict()
+    lc_data["redshift_true"] = lc_data["z_obs"]
+
+    ZZ = np.zeros(n_gals).astype(int)
+
+    diffsky_data = dict()
+    diffsky_data["n_points_per_fit"] = ZZ + 100
+    diffsky_data["loss"] = 1e-9
+
+    for key in DEFAULT_MAH_PARAMS._fields:
+        diffsky_data[key] = getattr(lc_data["mah_params"], key)
+
+    lc_data["central"] = ZZ + 1
+
+    return lc_data, diffsky_data, tcurves
+
+
+def test_add_dbk_sed_quantities_to_mock():
+    ran_key = jran.key(0)
+    diffsky_info = load_lc_cf.get_diffsky_info_from_hacc_sim("LastJourney")
+
+    ssp_data = load_ssp_templates()
+
+    lc_data, diffsky_data, tcurves = _prepare_input_catalogs()
+
+    z_phot_table = np.linspace(lc_data["z_obs"].min(), lc_data["z_obs"].max(), 15)
+
+    precomputed_ssp_mag_table = psspp.get_precompute_ssp_mag_redshift_table(
+        tcurves, ssp_data, z_phot_table, diffsky_info.cosmo_params
+    )
+    wave_eff_table = get_wave_eff_table(z_phot_table, tcurves)
+
+    args = (
+        diffsky_info,
+        lc_data,
+        diffsky_data,
+        ssp_data,
+        dpw.DEFAULT_PARAM_COLLECTION,
+        precomputed_ssp_mag_table,
+        z_phot_table,
+        wave_eff_table,
+        ran_key,
+    )
+    _res = lcmp.add_dbk_sed_quantities_to_mock(*args)
+    phot_info, lc_data, diffsky_data = _res

--- a/diffsky/data_loaders/hacc_utils/tests/test_lc_mock_production.py
+++ b/diffsky/data_loaders/hacc_utils/tests/test_lc_mock_production.py
@@ -8,7 +8,7 @@ import pytest
 from diffmah import DEFAULT_MAH_PARAMS
 from dsps.constants import T_TABLE_MIN
 from dsps.cosmology.flat_wcdm import age_at_z, age_at_z0
-from dsps.data_loaders import load_ssp_templates
+from dsps.data_loaders.retrieve_fake_fsps_data import load_fake_ssp_data
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import random as jran
@@ -91,7 +91,7 @@ def test_add_sfh_quantities_to_mock():
 def test_add_dbk_sed_quantities_to_mock():
     diffsky_info = load_lc_cf.get_diffsky_info_from_hacc_sim("LastJourney")
 
-    ssp_data = load_ssp_templates()
+    ssp_data = load_fake_ssp_data()
 
     lc_data, diffsky_data, tcurves = _prepare_input_catalogs()
 

--- a/diffsky/data_loaders/hacc_utils/tests/test_lc_mock_production.py
+++ b/diffsky/data_loaders/hacc_utils/tests/test_lc_mock_production.py
@@ -94,11 +94,10 @@ def test_add_dbk_sed_quantities_to_mock():
     ssp_data = load_ssp_templates()
 
     lc_data, diffsky_data, tcurves = _prepare_input_catalogs()
-    diffsky_data_orig = deepcopy(diffsky_data)
 
-    __, sfh_key = jran.split(jran.key(0), 2)
+    ran_key = jran.key(0)
     lc_data, diffsky_data = lcmp.add_sfh_quantities_to_mock(
-        diffsky_info, deepcopy(lc_data), deepcopy(diffsky_data), sfh_key
+        diffsky_info, deepcopy(lc_data), deepcopy(diffsky_data), ran_key
     )
     diffsky_data_with_sfh = deepcopy(diffsky_data)
 
@@ -127,11 +126,13 @@ def test_add_dbk_sed_quantities_to_mock():
     _res = lcmp.add_dbk_sed_quantities_to_mock(*args)
     phot_info, lc_data, diffsky_data = _res
 
-    assert np.allclose(
-        diffsky_data_with_sfh["sfh_table"], diffsky_data["sfh_table"], rtol=0.01
-    )
+    # assert np.allclose(
+    #     diffsky_data_with_sfh["sfh_table"], diffsky_data["sfh_table"], rtol=0.01
+    # )
 
-    assert np.allclose(phot_info["sfh_table"], diffsky_data["sfh_table"], rtol=0.01)
+    # assert np.allclose(
+    #     phot_info["sfh_table"], diffsky_data_with_sfh["sfh_table"], rtol=0.01
+    # )
 
     fbulge_params = dbk.DEFAULT_FBULGE_PARAMS._make(
         (phot_info["fbulge_tcrit"], phot_info["fbulge_early"], phot_info["fbulge_late"])
@@ -148,7 +149,7 @@ def test_add_dbk_sed_quantities_to_mock():
     assert np.allclose(bulge_to_total_recomputed, bulge_to_total_recomputed2, rtol=0.01)
 
     disk_bulge_history = mcdb.decompose_sfh_into_disk_bulge_sfh(
-        t_table, diffsky_data["sfh_table"]
+        t_table, phot_info["sfh_table"]
     )
 
     for pname in disk_bulge_history.fbulge_params._fields:

--- a/diffsky/data_loaders/io_utils.py
+++ b/diffsky/data_loaders/io_utils.py
@@ -1,6 +1,9 @@
 """Utility functions for reading and writing data"""
 
+from collections import namedtuple
+
 import h5py
+import numpy as np
 
 
 def load_flat_hdf5(fn, istart=0, iend=None, keys=None, dataset=None):
@@ -54,3 +57,23 @@ def load_flat_hdf5(fn, istart=0, iend=None, keys=None, dataset=None):
                 data[key_out] = hdf[key_in][istart:iend]
 
     return data
+
+
+def write_namedtuple_to_hdf5(named_params, fn_out):
+    """"""
+    with h5py.File(fn_out, "w") as hdf:
+        for pname, pval in zip(named_params._fields, named_params):
+            hdf[pname] = pval
+        hdf.attrs["_fields"] = np.array(named_params._fields, dtype="S")
+
+
+def load_namedtuple_from_hdf5(fn):
+    """"""
+    with h5py.File(fn, "r") as hdf:
+        pnames = [
+            f.decode() if isinstance(f, bytes) else f for f in hdf.attrs["_fields"]
+        ]
+        values = [hdf[pname][()] for pname in pnames]
+    Params = namedtuple("Params", pnames)
+    params = Params(*values)
+    return params

--- a/diffsky/data_loaders/io_utils.py
+++ b/diffsky/data_loaders/io_utils.py
@@ -60,7 +60,7 @@ def load_flat_hdf5(fn, istart=0, iend=None, keys=None, dataset=None):
 
 
 def write_namedtuple_to_hdf5(named_params, fn_out):
-    """"""
+    """Write an hdf5 file to a namedtuple"""
     with h5py.File(fn_out, "w") as hdf:
         for pname, pval in zip(named_params._fields, named_params):
             hdf[pname] = pval
@@ -68,7 +68,7 @@ def write_namedtuple_to_hdf5(named_params, fn_out):
 
 
 def load_namedtuple_from_hdf5(fn):
-    """"""
+    """Load an hdf5 file storing a namedtuple"""
     with h5py.File(fn, "r") as hdf:
         pnames = [
             f.decode() if isinstance(f, bytes) else f for f in hdf.attrs["_fields"]

--- a/diffsky/data_loaders/tests/test_io_utils.py
+++ b/diffsky/data_loaders/tests/test_io_utils.py
@@ -1,0 +1,32 @@
+""" """
+
+from collections import namedtuple
+
+import numpy as np
+from jax import random as jran
+
+from .. import io_utils as iou
+
+
+def test_namedtuple_to_hdf5():
+    ran_key = jran.key(0)
+    KEYS = ("a", "b", "c", "d", "e", "f", "g")
+    NDIM = len(KEYS)
+    INDX = np.arange(NDIM).astype(int)
+
+    n_tests = 10
+    for __ in range(n_tests):
+        ran_key, pname_key, pval_key = jran.split(ran_key, 3)
+        indx = jran.choice(pname_key, INDX, shape=(NDIM,), replace=False)
+        pnames = [KEYS[i] for i in indx]
+        pvals = jran.uniform(pval_key, shape=(NDIM,))
+
+        Params = namedtuple("Params", pnames)
+        params = Params(*pvals)
+
+        fn = "dummy.hdf5"
+        iou.write_namedtuple_to_hdf5(params, fn)
+
+        params2 = iou.load_namedtuple_from_hdf5(fn)
+
+        assert np.allclose(params, params2)

--- a/diffsky/experimental/tests/test_dbk_from_mock.py
+++ b/diffsky/experimental/tests/test_dbk_from_mock.py
@@ -12,6 +12,7 @@ from . import test_lc_phot_kern as tlcphk
 
 
 def test_disk_bulge_knot_phot_from_mock():
+    """Enforce that recomputed mock photometry agrees with original"""
     ran_key = jran.key(0)
 
     lc_data, tcurves = tlcphk._get_weighted_lc_data_for_unit_testing(num_halos=500)

--- a/diffsky/param_utils/diffsky_param_wrapper.py
+++ b/diffsky/param_utils/diffsky_param_wrapper.py
@@ -98,6 +98,85 @@ def unroll_param_collection_into_flat_array(
 
 
 @jjit
+def get_param_collection_from_flat_array(all_params_flat):
+    all_pnames_flat = get_flat_param_names()
+    DiffskyParams = namedtuple("DiffskyParams", all_pnames_flat)
+    named_params = DiffskyParams(*all_params_flat)
+
+    diffstarpop_params = [
+        getattr(named_params, pname) for pname in DEFAULT_DIFFSTARPOP_PARAMS._fields
+    ]
+    mzr_params = [
+        getattr(named_params, pname) for pname in umzr.DEFAULT_MZR_PARAMS._fields
+    ]
+
+    freqburst_params = spspu.DEFAULT_SPSPOP_PARAMS.burstpop_params.freqburst_params._make(
+        [
+            getattr(named_params, pname)
+            for pname in spspu.DEFAULT_SPSPOP_PARAMS.burstpop_params.freqburst_params._fields
+        ]
+    )
+    fburstpop_params = spspu.DEFAULT_SPSPOP_PARAMS.burstpop_params.fburstpop_params._make(
+        [
+            getattr(named_params, pname)
+            for pname in spspu.DEFAULT_SPSPOP_PARAMS.burstpop_params.fburstpop_params._fields
+        ]
+    )
+    tburstpop_params = spspu.DEFAULT_SPSPOP_PARAMS.burstpop_params.tburstpop_params._make(
+        [
+            getattr(named_params, pname)
+            for pname in spspu.DEFAULT_SPSPOP_PARAMS.burstpop_params.tburstpop_params._fields
+        ]
+    )
+    burstpop_params = spspu.DEFAULT_SPSPOP_PARAMS.burstpop_params._make(
+        (freqburst_params, fburstpop_params, tburstpop_params)
+    )
+
+    avpop_params = spspu.DEFAULT_SPSPOP_PARAMS.dustpop_params.avpop_params._make(
+        [
+            getattr(named_params, pname)
+            for pname in spspu.DEFAULT_SPSPOP_PARAMS.dustpop_params.avpop_params._fields
+        ]
+    )
+
+    deltapop_params = spspu.DEFAULT_SPSPOP_PARAMS.dustpop_params.deltapop_params._make(
+        [
+            getattr(named_params, pname)
+            for pname in spspu.DEFAULT_SPSPOP_PARAMS.dustpop_params.deltapop_params._fields
+        ]
+    )
+
+    funopop_params = spspu.DEFAULT_SPSPOP_PARAMS.dustpop_params.funopop_params._make(
+        [
+            getattr(named_params, pname)
+            for pname in spspu.DEFAULT_SPSPOP_PARAMS.dustpop_params.funopop_params._fields
+        ]
+    )
+    dustpop_params = spspu.DEFAULT_SPSPOP_PARAMS.dustpop_params._make(
+        (avpop_params, deltapop_params, funopop_params)
+    )
+    spspop_params = spspu.DEFAULT_SPSPOP_PARAMS._make((burstpop_params, dustpop_params))
+
+    scatter_params = [
+        getattr(named_params, pname) for pname in DEFAULT_SCATTER_PARAMS._fields
+    ]
+    ssp_err_params = [
+        getattr(named_params, pname)
+        for pname in ssp_err_model.DEFAULT_SSPERR_PARAMS._fields
+    ]
+
+    param_collection = (
+        diffstarpop_params,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssp_err_params,
+    )
+
+    return param_collection
+
+
+@jjit
 def unroll_u_param_collection_into_flat_array(
     diffstarpop_u_params,
     mzr_u_params,

--- a/diffsky/param_utils/param_loader.py
+++ b/diffsky/param_utils/param_loader.py
@@ -1,22 +1,11 @@
 """"""
 
-from collections import namedtuple
-
-import numpy as np
-
+from ..data_loaders import io_utils as iou
 from . import diffsky_param_wrapper as dpw
 
 
 def load_diffsky_param_collection(fn):
-    diffsky_params_str_arr = np.load(fn)
-
-    param_names = dpw.get_flat_param_names()
-    DiffskyParams = namedtuple("DiffskyParams", param_names)
-
-    reloaded_params = DiffskyParams(
-        *[diffsky_params_str_arr[key] for key in DiffskyParams._fields]
-    )
-
-    param_collection = dpw.get_param_collection_from_flat_array(reloaded_params)
-
+    """"""
+    flat_diffsky_params = iou.load_namedtuple_from_hdf5(fn)
+    param_collection = dpw.get_param_collection_from_flat_array(flat_diffsky_params)
     return param_collection

--- a/diffsky/param_utils/param_loader.py
+++ b/diffsky/param_utils/param_loader.py
@@ -1,0 +1,22 @@
+""""""
+
+from collections import namedtuple
+
+import numpy as np
+
+from . import diffsky_param_wrapper as dpw
+
+
+def load_diffsky_param_collection(fn):
+    diffsky_params_str_arr = np.load(fn)
+
+    param_names = dpw.get_flat_param_names()
+    DiffskyParams = namedtuple("DiffskyParams", param_names)
+
+    reloaded_params = DiffskyParams(
+        *[diffsky_params_str_arr[key] for key in DiffskyParams._fields]
+    )
+
+    param_collection = dpw.get_param_collection_from_flat_array(reloaded_params)
+
+    return param_collection

--- a/diffsky/param_utils/tests/test_diffsky_param_wrapper.py
+++ b/diffsky/param_utils/tests/test_diffsky_param_wrapper.py
@@ -1,6 +1,7 @@
 """ """
 
 # flake8: noqa
+from copy import deepcopy
 
 import numpy as np
 
@@ -21,6 +22,47 @@ def test_default_param_collection_fields():
         "ssperr_params",
     )
     assert dpw.DEFAULT_PARAM_COLLECTION._fields == pnames
+
+
+def test_get_param_collection_from_flat_array():
+    """Enforce agreement when we roll up a flat array and then repack it"""
+    default_param_collection = deepcopy(dpw.DEFAULT_PARAM_COLLECTION)
+
+    all_params_flat = dpw.unroll_param_collection_into_flat_array(
+        *default_param_collection
+    )
+    param_collection = dpw.get_param_collection_from_flat_array(all_params_flat)
+
+    assert np.allclose(param_collection[0], default_param_collection[0])
+    assert np.allclose(param_collection[1], default_param_collection[1])
+    assert np.allclose(
+        param_collection[2].burstpop_params.freqburst_params,
+        default_param_collection[2].burstpop_params.freqburst_params,
+    )
+    assert np.allclose(
+        param_collection[2].burstpop_params.fburstpop_params,
+        default_param_collection[2].burstpop_params.fburstpop_params,
+    )
+    assert np.allclose(
+        param_collection[2].burstpop_params.tburstpop_params,
+        default_param_collection[2].burstpop_params.tburstpop_params,
+    )
+
+    assert np.allclose(
+        param_collection[2].dustpop_params.avpop_params,
+        default_param_collection[2].dustpop_params.avpop_params,
+    )
+    assert np.allclose(
+        param_collection[2].dustpop_params.deltapop_params,
+        default_param_collection[2].dustpop_params.deltapop_params,
+    )
+    assert np.allclose(
+        param_collection[2].dustpop_params.funopop_params,
+        default_param_collection[2].dustpop_params.funopop_params,
+    )
+
+    assert np.allclose(param_collection[3], default_param_collection[3])
+    assert np.allclose(param_collection[4], default_param_collection[4])
 
 
 def test_unroll_u_param_collection_into_flat_array():

--- a/diffsky/param_utils/tests/test_param_loader.py
+++ b/diffsky/param_utils/tests/test_param_loader.py
@@ -1,0 +1,24 @@
+""""""
+
+import numpy as np
+
+from .. import diffsky_param_wrapper as dpw
+from .. import param_loader
+
+
+def test_load_diffsky_param_collection():
+    all_params_flat = dpw.unroll_param_collection_into_flat_array(
+        *dpw.DEFAULT_PARAM_COLLECTION
+    )
+    all_pnames = dpw.get_flat_param_names()
+    dtype = [
+        (name, np.array(val).dtype, np.array(val).shape)
+        for name, val in zip(all_pnames, all_params_flat)
+    ]
+    all_params_flat_structured = np.array([all_params_flat], dtype=dtype)
+
+    np.save("all_params_flat", all_params_flat_structured)
+    param_collection = param_loader.load_diffsky_param_collection("all_params_flat.npy")
+    all_params_flat2 = dpw.unroll_param_collection_into_flat_array(*param_collection)
+
+    assert np.allclose(all_params_flat, all_params_flat2, rtol=1e-5)

--- a/diffsky/param_utils/tests/test_param_loader.py
+++ b/diffsky/param_utils/tests/test_param_loader.py
@@ -1,7 +1,10 @@
 """"""
 
+from collections import namedtuple
+
 import numpy as np
 
+from ...data_loaders import io_utils as iou
 from .. import diffsky_param_wrapper as dpw
 from .. import param_loader
 
@@ -11,14 +14,14 @@ def test_load_diffsky_param_collection():
         *dpw.DEFAULT_PARAM_COLLECTION
     )
     all_pnames = dpw.get_flat_param_names()
-    dtype = [
-        (name, np.array(val).dtype, np.array(val).shape)
-        for name, val in zip(all_pnames, all_params_flat)
-    ]
-    all_params_flat_structured = np.array([all_params_flat], dtype=dtype)
 
-    np.save("all_params_flat", all_params_flat_structured)
-    param_collection = param_loader.load_diffsky_param_collection("all_params_flat.npy")
+    Params = namedtuple("Params", all_pnames)
+    all_named_params = Params(*all_params_flat)
+
+    fn = "diffsky_unit_testing_params.hdf5"
+    iou.write_namedtuple_to_hdf5(all_named_params, fn)
+
+    param_collection = param_loader.load_diffsky_param_collection(fn)
     all_params_flat2 = dpw.unroll_param_collection_into_flat_array(*param_collection)
 
     assert np.allclose(all_params_flat, all_params_flat2, rtol=1e-5)

--- a/scripts/LJ_LC_MOCKS/make_dbk_sed_lc_mock_lj.py
+++ b/scripts/LJ_LC_MOCKS/make_dbk_sed_lc_mock_lj.py
@@ -357,7 +357,7 @@ if __name__ == "__main__":
         )
 
         diffsky_data = lcmp.add_black_hole_quantities_to_diffsky_data(
-            lc_data, diffsky_data
+            lc_data, diffsky_data, phot_info
         )
 
         patch_key, nfw_key = jran.split(patch_key, 2)


### PR DESCRIPTION
The `add_dbk_sed_quantities_to_mock` function began by calling `add_sfh_quantities_to_mock` unnecessarily, leading to an inconsistency between the SFH used throughout mock production.