### PR TITLE
Clean up temporary figures made during unit testing

### DIFF
--- a/diffsky/data_loaders/hacc_utils/tests/test_lc_mock.py
+++ b/diffsky/data_loaders/hacc_utils/tests/test_lc_mock.py
@@ -42,7 +42,7 @@ POBOY_MSG = "This test only runs on poboy machine with haccytrees installed"
 _THIS_DRNAME = os.path.dirname(os.path.abspath(__file__))
 
 
-def test_load_diffsky_param_collection():
+def test_load_diffsky_param_collection(tmp_path):
     all_params_flat = dpw.unroll_param_collection_into_flat_array(
         *dpw.DEFAULT_PARAM_COLLECTION
     )
@@ -51,13 +51,13 @@ def test_load_diffsky_param_collection():
     Params = namedtuple("Params", all_pnames)
     all_named_params = Params(*all_params_flat)
 
-    drn_mock = ""
     mock_version_name = "unit_testing"
-    fn = lcmp_repro.BNPAT_PARAM_COLLECTION.format(mock_version_name)
+    bn = lcmp_repro.BNPAT_PARAM_COLLECTION.format(mock_version_name)
+    fn = os.path.join(tmp_path, bn)
     iou.write_namedtuple_to_hdf5(all_named_params, fn)
 
     param_collection = lcmp_repro.load_diffsky_param_collection(
-        drn_mock, mock_version_name
+        tmp_path, mock_version_name
     )
     all_params_flat2 = dpw.unroll_param_collection_into_flat_array(*param_collection)
 

--- a/diffsky/data_loaders/tests/test_io_utils.py
+++ b/diffsky/data_loaders/tests/test_io_utils.py
@@ -1,5 +1,6 @@
 """ """
 
+import os
 from collections import namedtuple
 
 import numpy as np
@@ -8,7 +9,7 @@ from jax import random as jran
 from .. import io_utils as iou
 
 
-def test_namedtuple_to_hdf5():
+def test_namedtuple_to_hdf5(tmp_path):
     ran_key = jran.key(0)
     KEYS = ("a", "b", "c", "d", "e", "f", "g")
     NDIM = len(KEYS)
@@ -24,7 +25,7 @@ def test_namedtuple_to_hdf5():
         Params = namedtuple("Params", pnames)
         params = Params(*pvals)
 
-        fn = "dummy.hdf5"
+        fn = os.path.join(tmp_path, "dummy.hdf5")
         iou.write_namedtuple_to_hdf5(params, fn)
 
         params2 = iou.load_namedtuple_from_hdf5(fn)

--- a/diffsky/diagnostics/tests/test_plot_diffstar_fq.py
+++ b/diffsky/diagnostics/tests/test_plot_diffstar_fq.py
@@ -1,5 +1,7 @@
 """ """
 
+import os
+
 import pytest
 
 from .. import plot_diffstar_fq as pdq
@@ -9,5 +11,8 @@ MSG_DEPS = "Must have matplotlib and scipy installed to run this test"
 
 
 @pytest.mark.skipif(not HAS_DEPENDENCIES, reason=MSG_DEPS)
-def test_plot_diffstar_frac_quenched():
-    pdq.plot_diffstar_frac_quenched(n_halos=2_000)
+def test_plot_diffstar_frac_quenched(tmp_path):
+    pdq.plot_diffstar_frac_quenched(
+        n_halos=2_000,
+        fname=os.path.join(tmp_path, "prob_quenched_vs_mstar_diffstarpop_cens.png"),
+    )

--- a/diffsky/experimental/diagnostics/tests/test_check_smhm.py
+++ b/diffsky/experimental/diagnostics/tests/test_check_smhm.py
@@ -1,5 +1,7 @@
 """ """
 
+import os
+
 import pytest
 
 from .. import check_smhm
@@ -9,5 +11,6 @@ MSG_DEPS = "Must have matplotlib and scipy installed to run this test"
 
 
 @pytest.mark.skipif(not HAS_DEPENDENCIES, reason=MSG_DEPS)
-def test_plot_diffstarpop_insitu_smhm():
-    check_smhm.plot_diffstarpop_insitu_smhm()
+def test_plot_diffstarpop_insitu_smhm(tmp_path):
+    fname = os.path.join(tmp_path, "diffstarpop_insitu_smhm_lc_kern_check.png")
+    check_smhm.plot_diffstarpop_insitu_smhm(fname=fname)

--- a/diffsky/mass_functions/fitting_utils/diagnostics/hmf_fit_diagnostics.py
+++ b/diffsky/mass_functions/fitting_utils/diagnostics/hmf_fit_diagnostics.py
@@ -18,7 +18,7 @@ MRED = "#d62728"
 MBLUE = "#1f77b4"
 
 
-def make_hmf_fit_plot(loss_data_collector, p_best, figname="hmf_diagnostic.png"):
+def make_hmf_fit_plot(loss_data_collector, p_best, fname="hmf_diagnostic.png"):
     """"""
     assert HAS_MATPLOTLIB, MATPLOTLIB_MSG
 
@@ -47,5 +47,5 @@ def make_hmf_fit_plot(loss_data_collector, p_best, figname="hmf_diagnostic.png")
     ax.legend(handles=[solid_line, dashed_line], loc="lower left", frameon=False)
 
     fig.savefig(
-        figname, bbox_extra_artists=[xlabel, ylabel], bbox_inches="tight", dpi=200
+        fname, bbox_extra_artists=[xlabel, ylabel], bbox_inches="tight", dpi=200
     )

--- a/diffsky/mass_functions/fitting_utils/diagnostics/tests/test_hmf_fit_diagnostics.py
+++ b/diffsky/mass_functions/fitting_utils/diagnostics/tests/test_hmf_fit_diagnostics.py
@@ -20,7 +20,8 @@ DRN_TESTING_DATA = os.path.join(ROOT_DRN, "hmf_calibrations", "tests", "testing_
 
 
 @pytest.mark.skipif("not HAS_MATPLOTLIB")
-def test_make_hmf_fit_plot():
+def test_make_hmf_fit_plot(tmp_path):
     loss_data = smdpl_hmf_fitting_helpers.get_loss_data(DRN_TESTING_DATA, "hosthalos")
     p_best = smdpl_hmf.HMF_PARAMS
-    hmf_fit_diagnostics.make_hmf_fit_plot(loss_data, p_best)
+    fname = os.path.join(tmp_path, "hmf_diagnostic.png")
+    hmf_fit_diagnostics.make_hmf_fit_plot(loss_data, p_best, fname=fname)


### PR DESCRIPTION
Uses pytest `tmp_path` mechanism. Closes #309. 