### PR TITLE
Increase galaxy sizes by 20%

### DIFF
--- a/diffsky/experimental/size_modeling/disk_bulge_sizes.py
+++ b/diffsky/experimental/size_modeling/disk_bulge_sizes.py
@@ -25,7 +25,7 @@ SizeParamsDisk = ["a_{}", "alpha_{}"]
 NamesDisk = [p.format("disk") for p in SizeParamsDisk]
 DiskSizeParameters = namedtuple("DiskSizeParameters", NamesDisk)
 
-a_disk = SigmoidParameters(0.908, 2.42, 5.94, 3.82)
+a_disk = SigmoidParameters(1.108, 2.42, 5.94, 3.82)
 alpha_disk = SigmoidParameters(0.519, 56.4, 0.207, 0.181)
 
 DISK_SIZE_PARAMETERS = DiskSizeParameters(a_disk, alpha_disk)
@@ -36,7 +36,7 @@ SizeParamsBulge = ["rp_{}", "alpha_{}", "beta_{}", "logmp_{}"]
 NamesBulge = [p.format("bulge") for p in SizeParamsBulge]
 BulgeSizeParameters = namedtuple("BulgeSizeParameters", NamesBulge)
 
-rp_bulge = LinearParameters(2.04, -0.030)
+rp_bulge = LinearParameters(2.44, -0.030)
 alpha_bulge = LinearParameters(0.130, -0.0218)
 beta_bulge = LinearParameters(0.71, 0.055)
 logmp_bulge = LinearParameters(10.0, 0.40)


### PR DESCRIPTION
First-order improvement to address shortcoming identified by Federico, Tae-hyeon, and Rachel (their figure copied below), who reported that there is a clear over abundance of small galaxies in the simulated catalogs compared to the ECDFS field.

<img width="745" height="559" alt="Screenshot 2026-01-29 at 12 41 08 PM" src="https://github.com/user-attachments/assets/5de1cbb0-6f19-4f8b-971a-15e3d8a21868" />
<img width="599" height="566" alt="Screenshot 2026-01-29 at 12 41 19 PM" src="https://github.com/user-attachments/assets/19a77512-0444-4484-9bc4-7acf52e81baf" />
