### PR TITLE
Update docs to use model `cosmos_260210` to populate a weighted lightcone

### DIFF
--- a/docs/source/demo_diffsky_lightcone.ipynb
+++ b/docs/source/demo_diffsky_lightcone.ipynb
@@ -224,7 +224,7 @@
    "source": [
     "### Choosing an alternative set of diffsky model parameters\n",
     "\n",
-    "There are several choices for diffsky parameters that are based on ongoing work calibrating Diffsky to the COSMOS dataset. Below we show how to check which parameters are available, and then select the `cosmos_260120_UM` calibration to populate the lightcone."
+    "There are several choices for diffsky parameters that are based on ongoing work calibrating Diffsky to the COSMOS dataset. Below we show how to check which parameters are available, and then select the `cosmos_260210` calibration to populate the lightcone."
    ]
   },
   {
@@ -246,7 +246,7 @@
    "outputs": [],
    "source": [
     "from diffsky.param_utils.get_mock_params import get_param_collection_for_mock\n",
-    "param_collection = get_param_collection_for_mock(cosmos_fit='cosmos_260120_UM')"
+    "param_collection = get_param_collection_for_mock(cosmos_fit='cosmos_260210')"
    ]
   },
   {
@@ -326,7 +326,7 @@
    "source": [
     "fig, ax = plt.subplots(1, 1)\n",
     "yscale = ax.set_yscale('log')\n",
-    "ylim = ax.set_ylim(8e-3, 5e2)\n",
+    "ylim = ax.set_ylim(8e-4, 5e2)\n",
     "xscale = ax.set_xscale('log')\n",
     "xlim = ax.set_xlim(1, 15)\n",
     "\n",
@@ -357,7 +357,8 @@
    "source": [
     "fig, ax = plt.subplots(1, 1)\n",
     "xlim = ax.set_xlim(-14, -7)\n",
-    "__=ax.hist(phot_info['logssfr_obs'], bins=150, alpha=0.7, weights=lc_data.nhalos)\n",
+    "yscale = ax.set_yscale('log')\n",
+    "__=ax.hist(phot_info['logssfr_obs'], bins=70, alpha=0.7, weights=lc_data.nhalos)\n",
     "xlabel = ax.set_xlabel(r'${\\rm log_{10}(sSFR)}$')"
    ]
   },


### PR DESCRIPTION
Update docs to use model `cosmos_260210` to populate a weighted lightcone

@gbeltzmo this update to the notebook shows how to use the current best-fit parameters. Later this month, the API for weighted lightcones will change, since we will switch to using diffhalos. But whenever that changes, the demo notebooks will also be updated to show how to use the updated version.