### PR TITLE
Retune bulge axis ratios so bulges are rounder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,6 @@
 0.3.5 (unreleased)
 -------------------
+- Retune bulge shapes to be rounder (https://github.com/ArgonneCPAC/diffsky/pull/386)
 - Retune galaxy sizes vs LSST-DP1 (https://github.com/ArgonneCPAC/diffsky/pull/385)
 - Implement bimodal distribution of B/T and correlated bulge/disk orientations (https://github.com/ArgonneCPAC/diffsky/pull/380)
 - Improve agreement between ellipticity distribution and LSST-DP1 (https://github.com/ArgonneCPAC/diffsky/pull/345)

--- a/diffsky/ellipsoidal_shapes/bulge_shapes.py
+++ b/diffsky/ellipsoidal_shapes/bulge_shapes.py
@@ -14,7 +14,7 @@ BulgeAxisRatioParams = namedtuple(
     "BulgeAxisRatioParams", ("ba_peak", "ba_sigma", "ba_min", "ba_max", "c_min")
 )
 DEFAULT_BULGE_PARAMS = BulgeAxisRatioParams(
-    ba_peak=1.2, ba_sigma=0.9, ba_min=0.05, ba_max=1.0, c_min=0.5
+    ba_peak=2.0, ba_sigma=0.9, ba_min=0.5, ba_max=1.0, c_min=0.5
 )
 
 


### PR DESCRIPTION
The ellipticity distribution of diffsky bulges has a long high-ellipticity tail that this PR removes.
<img width="1060" height="818" alt="bulge_ellipticity_recalibration_0407" src="https://github.com/user-attachments/assets/25adb9a2-a6f9-42c1-be88-4e0121236791" />
