### PR TITLE
Update LastJourney cross-matching script to use core-lc-7

### DIFF
--- a/diffsky/data_loaders/hacc_utils/load_lc_cf.py
+++ b/diffsky/data_loaders/hacc_utils/load_lc_cf.py
@@ -59,7 +59,7 @@ def load_lc_diffsky_patch_data(fn_lc_diffsky, indir_lc_data, *, istart=0, iend=N
     bn_in = os.path.basename(fn_lc_diffsky)
     bn_lc = os.path.basename(bn_in).replace(".diffsky_data.hdf5", ".hdf5")
     fn_lc = os.path.join(indir_lc_data, bn_lc)
-    lc_data = load_flat_hdf5(fn_lc, istart=istart, iend=iend)
+    lc_data = load_flat_hdf5(fn_lc, istart=istart, iend=iend, dataset="data")
 
     lc_data["redshift_true"] = 1 / lc_data["scale_factor"] - 1
 

--- a/scripts/LJ_CROSSX/check_lc_cf_completeness.py
+++ b/scripts/LJ_CROSSX/check_lc_cf_completeness.py
@@ -13,7 +13,7 @@ from diffsky.data_loaders.hacc_utils import lightcone_utils as hlu
 BNPAT = "lc_cores-{0}.{1}.diffsky_data.hdf5"
 
 SIM_NAME = "LastJourney"
-DRN_LC_CF = "/lcrc/project/cosmo_ai/ahearin/LastJourney/lc-cf-diffsky"
+DRN_LC_CF = "/lcrc/project/cosmo_ai/ahearin/LastJourney/lc-7-cf-diffsky"
 DRN_LC_CORES = (
     "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-7/output"
 )

--- a/scripts/LJ_CROSSX/check_lc_cf_completeness.py
+++ b/scripts/LJ_CROSSX/check_lc_cf_completeness.py
@@ -15,7 +15,7 @@ BNPAT = "lc_cores-{0}.{1}.diffsky_data.hdf5"
 SIM_NAME = "LastJourney"
 DRN_LC_CF = "/lcrc/project/cosmo_ai/ahearin/LastJourney/lc-cf-diffsky"
 DRN_LC_CORES = (
-    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-6/output"
+    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-7/output"
 )
 FN_LC_CORES = os.path.join(DRN_LC_CORES, "lc_cores-decomposition.txt")
 

--- a/scripts/LJ_CROSSX/generate_lj_cf_crossmatch_jobs.py
+++ b/scripts/LJ_CROSSX/generate_lj_cf_crossmatch_jobs.py
@@ -13,6 +13,7 @@ import subprocess
 import numpy as np
 
 BN_JOB = "run_lc_cf_crossx_{0}.sh"
+BN_CFG = "lc_patch_list_{0}.cfg"
 BN_SCRIPT = "lc_cf_crossmatch_script.py"
 
 if __name__ == "__main__":
@@ -98,7 +99,7 @@ if __name__ == "__main__":
         "",
     )
 
-    line_pat = "python {0} {1:.3f} {2:.3f} -istart {3} -iend {4} -drn_out {5} "
+    line_pat = "python {0} {1:.3f} {2:.3f} -lc_patch_list_cfg {3} -drn_out {4} "
 
     if submit_job:
         print("\nSubmitting jobs to queue\n")
@@ -107,10 +108,8 @@ if __name__ == "__main__":
 
     for ijob, job_info in enumerate(job_list):
 
-        i = job_info[0]
-        j = job_info[-1]
-        ibn = f"{i:0{nchar}d}"
-        jbn = f"{j:0{nchar}d}"
+        fnout_cfg = os.path.join(drn_script, BN_CFG.format(ijob))
+        np.savetxt(fnout_cfg, job_info)
 
         fn_submit_script = os.path.join(drn_script, BN_JOB.format(ijob))
 
@@ -118,7 +117,7 @@ if __name__ == "__main__":
             for line_out in header_lines:
                 fout.write(line_out + "\n")
 
-            line_out = line_pat.format(BN_SCRIPT, z_min, z_max, i, j, drn_out)
+            line_out = line_pat.format(BN_SCRIPT, z_min, z_max, fnout_cfg, drn_out)
             fout.write(line_out + "\n")
 
         if submit_job:

--- a/scripts/LJ_CROSSX/generate_lj_cf_crossmatch_jobs.py
+++ b/scripts/LJ_CROSSX/generate_lj_cf_crossmatch_jobs.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
     for ijob, job_info in enumerate(job_list):
 
         fnout_cfg = os.path.join(drn_script, BN_CFG.format(ijob))
-        np.savetxt(fnout_cfg, job_info)
+        np.savetxt(fnout_cfg, job_info, fmt="%d")
 
         fn_submit_script = os.path.join(drn_script, BN_JOB.format(ijob))
 

--- a/scripts/LJ_CROSSX/generate_lj_cf_crossmatch_jobs.py
+++ b/scripts/LJ_CROSSX/generate_lj_cf_crossmatch_jobs.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     parser.add_argument("-drn_script", help="Directory to write scripts", default="")
 
     parser.add_argument(
-        "-conda_env", help="conda environment to activate", default="improv311"
+        "-conda_env", help="conda environment to activate", default="diffhacc_py312"
     )
 
     args = parser.parse_args()

--- a/scripts/LJ_CROSSX/generate_lj_cf_crossmatch_jobs.py
+++ b/scripts/LJ_CROSSX/generate_lj_cf_crossmatch_jobs.py
@@ -12,7 +12,7 @@ import subprocess
 
 import numpy as np
 
-BN_JOB = "run_lc_cf_crossx_{0}_to_{1}.sh"
+BN_JOB = "run_lc_cf_crossx_{0}.sh"
 BN_SCRIPT = "lc_cf_crossmatch_script.py"
 
 if __name__ == "__main__":
@@ -105,14 +105,14 @@ if __name__ == "__main__":
     else:
         print("\nDry run: jobs not submitted\n")
 
-    for job_info in job_list:
+    for ijob, job_info in enumerate(job_list):
 
         i = job_info[0]
         j = job_info[-1]
         ibn = f"{i:0{nchar}d}"
         jbn = f"{j:0{nchar}d}"
 
-        fn_submit_script = os.path.join(drn_script, BN_JOB.format(ibn, jbn))
+        fn_submit_script = os.path.join(drn_script, BN_JOB.format(ijob))
 
         with open(fn_submit_script, "w") as fout:
             for line_out in header_lines:

--- a/scripts/LJ_CROSSX/inspect_lc_crossx_data.py
+++ b/scripts/LJ_CROSSX/inspect_lc_crossx_data.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
         "-n_matchup_test",
         help="Number of files to check n_cf_match=1",
         type=int,
-        default=100,
+        default=500,
     )
 
     start = time()
@@ -113,7 +113,11 @@ if __name__ == "__main__":
 
     # Sanity check the matchup
     indx_all = np.arange(len(fn_lc_cf_list)).astype(int)
-    indx_test = np.random.choice(indx_all, n_matchup_test, replace=False)
+    if indx_all.size <= n_matchup_test:
+        indx_test = np.copy(indx_all)
+    else:
+        indx_test = np.random.choice(indx_all, n_matchup_test, replace=False)
+
     all_good = True
     failure_collector = []
     for indx in indx_test:

--- a/scripts/LJ_CROSSX/inspect_lc_crossx_data.py
+++ b/scripts/LJ_CROSSX/inspect_lc_crossx_data.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 from glob import glob
+from time import time
 
 import numpy as np
 
@@ -51,9 +52,10 @@ if __name__ == "__main__":
         "-n_matchup_test",
         help="Number of files to check n_cf_match=1",
         type=int,
-        default=10,
+        default=100,
     )
 
+    start = time()
     args = parser.parse_args()
     drn_lc_cf = args.drn_lc_cf
     z_min = args.z_min
@@ -125,6 +127,9 @@ if __name__ == "__main__":
             print(f"{bname} fails readiness test")
             failure_collector.append(bname)
 
+    end = time()
+    runtime = end - start
+    print(f"Runtime to check files = {runtime:.1f} seconds")
     if all_good:
         print("All lightcone patches pass all tests")
     else:

--- a/scripts/LJ_CROSSX/inspect_lc_crossx_data.py
+++ b/scripts/LJ_CROSSX/inspect_lc_crossx_data.py
@@ -118,6 +118,7 @@ if __name__ == "__main__":
     else:
         indx_test = np.random.choice(indx_all, n_matchup_test, replace=False)
 
+    print(f"\nChecking n_cf_match=1 for {n_matchup_test} randomly selected files...")
     all_good = True
     failure_collector = []
     for indx in indx_test:
@@ -135,8 +136,8 @@ if __name__ == "__main__":
     runtime = end - start
     print(f"Runtime to check files = {runtime:.1f} seconds")
     if all_good:
-        print("All lightcone patches pass all tests")
+        print("A\nll lightcone patches pass all tests\n")
     else:
-        print("Some failures in the following lightcone patches:\n")
+        print("\nSome failures in the following lightcone patches:\n")
         for failing_bn in failure_collector:
             print(f"{failing_bn}")

--- a/scripts/LJ_CROSSX/inspect_lc_crossx_data.py
+++ b/scripts/LJ_CROSSX/inspect_lc_crossx_data.py
@@ -7,6 +7,7 @@ from glob import glob
 import numpy as np
 
 from diffsky.data_loaders.hacc_utils import hacc_core_utils as hcu
+from diffsky.data_loaders.hacc_utils import lightcone_utils as hlu
 
 BN_GLOBPAT_LC_CORES = "lc_cores-{0}.{1}.hdf5"
 BN_GLOBPAT_LC_CF = "lc_cores-{0}.{1}.diffsky_data.hdf5"
@@ -28,6 +29,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "patch_max", help="Maximum lc_patch to check for matches", type=int
     )
+    parser.add_argument(
+        "-patch_min", help="Minimum lc_patch to check for matches", type=int, default=0
+    )
 
     parser.add_argument(
         "-bnpat_lc_cf",
@@ -43,12 +47,20 @@ if __name__ == "__main__":
         help="Basename pattern for lc_cores",
         default=BN_GLOBPAT_LC_CORES.format("*", "*"),
     )
+    parser.add_argument(
+        "-n_matchup_test",
+        help="Number of files to check n_cf_match=1",
+        type=int,
+        default=10,
+    )
 
     args = parser.parse_args()
     drn_lc_cf = args.drn_lc_cf
     z_min = args.z_min
     z_max = args.z_max
     patch_max = args.patch_max
+    patch_min = args.patch_min
+    n_matchup_test = args.n_matchup_test
 
     bnpat_lc_cf = args.bnpat_lc_cf
     drn_lc_cores = args.drn_lc_cores
@@ -76,6 +88,7 @@ if __name__ == "__main__":
             (stepnum >= timestep_min)
             & (stepnum <= timestep_max)
             & (lc_patch <= patch_max)
+            & (lc_patch >= patch_min)
         ):
 
             matching_bn_lc_cf = bn_lc_cores.replace(".hdf5", ".diffsky_data.hdf5")
@@ -97,22 +110,24 @@ if __name__ == "__main__":
         np.savetxt(fn_incompl_out, incomplete_patch_collector, fmt="%i")
 
     # Sanity check the matchup
+    indx_all = np.arange(len(fn_lc_cf_list)).astype(int)
+    indx_test = np.random.choice(indx_all, n_matchup_test, replace=False)
+    all_good = True
+    failure_collector = []
+    for indx in indx_test:
+        fn = fn_lc_cf_list[indx]
+        report = hlu.check_lc_cores_diffsky_data(fn)
+        fn_report = fn.replace(".hdf5", ".report.txt")
+        all_good_fn = hlu.write_lc_cores_diffsky_data_report_to_disk(report, fn_report)
+        all_good = all_good & all_good_fn
+        if not all_good_fn:
+            bname = os.path.basename(fn)
+            print(f"{bname} fails readiness test")
+            failure_collector.append(bname)
 
-    # all_good = True
-    # failure_collector = []
-    # for fn in fn_list:
-    #     report = check_lc_cores_diffsky_data(fn)
-    #     fn_report = fn.replace(".hdf5", ".report.txt")
-    #     all_good_fn = write_lc_cores_diffsky_data_report_to_disk(report, fn_report)
-    #     all_good = all_good & all_good_fn
-    #     if not all_good_fn:
-    #         bname = os.path.basename(fn)
-    #         print(f"{bname} fails readiness test")
-    #         failure_collector.append(bname)
-
-    # if all_good:
-    #     print("All lightcone patches pass all tests")
-    # else:
-    #     print("Some failures in the following lightcone patches:\n")
-    #     for failing_bn in failure_collector:
-    #         print(f"{failing_bn}")
+    if all_good:
+        print("All lightcone patches pass all tests")
+    else:
+        print("Some failures in the following lightcone patches:\n")
+        for failing_bn in failure_collector:
+            print(f"{failing_bn}")

--- a/scripts/LJ_CROSSX/inspect_lc_crossx_data.py
+++ b/scripts/LJ_CROSSX/inspect_lc_crossx_data.py
@@ -11,7 +11,7 @@ from diffsky.data_loaders.hacc_utils import hacc_core_utils as hcu
 BN_GLOBPAT_LC_CORES = "lc_cores-{0}.{1}.hdf5"
 BN_GLOBPAT_LC_CF = "lc_cores-{0}.{1}.diffsky_data.hdf5"
 DRN_LJ_LC_LCRC = (
-    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-6/output"
+    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-7/output"
 )
 
 

--- a/scripts/LJ_CROSSX/inspect_lc_crossx_data.py
+++ b/scripts/LJ_CROSSX/inspect_lc_crossx_data.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
     runtime = end - start
     print(f"Runtime to check files = {runtime:.1f} seconds")
     if all_good:
-        print("A\nll lightcone patches pass all tests\n")
+        print("\nAll lightcone patches pass all tests\n")
     else:
         print("\nSome failures in the following lightcone patches:\n")
         for failing_bn in failure_collector:

--- a/scripts/LJ_CROSSX/lc_cf_crossmatch_script.py
+++ b/scripts/LJ_CROSSX/lc_cf_crossmatch_script.py
@@ -35,7 +35,7 @@ DRN_LJ_LC_POBOY = "/Users/aphearin/work/DATA/LastJourney/lc_cores"
 DRN_LJ_DIFFMAH_LCRC = "/lcrc/project/halotools/LastJourney/diffmah_fits"
 DRN_LJ_DIFFMAH_POBOY = "/Users/aphearin/work/DATA/LastJourney/diffmah_fits"
 
-DRN_LJ_CROSSX_OUT_LCRC = "/lcrc/project/halotools/LastJourney/lc-cf-diffsky"
+DRN_LJ_CROSSX_OUT_LCRC = "/lcrc/project/halotools/LastJourney/lc-7-cf-diffsky"
 DRN_LC_CF_XDATA_LCRC = os.path.join(DRN_LJ_CROSSX_OUT_LCRC, "LC_CF_XDATA")
 DRN_LJ_CROSSX_OUT_POBOY = "/Users/aphearin/work/DATA/LastJourney/lc-cf-diffsky"
 DRN_LC_CF_XDATA_POBOY = os.path.join(DRN_LJ_CROSSX_OUT_POBOY, "LC_CF_XDATA")

--- a/scripts/LJ_CROSSX/lc_cf_crossmatch_script.py
+++ b/scripts/LJ_CROSSX/lc_cf_crossmatch_script.py
@@ -28,7 +28,7 @@ DRN_LJ_CF_LCRC = "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/forest
 DRN_LJ_CF_POBOY = "/Users/aphearin/work/DATA/LastJourney/coretrees"
 
 DRN_LJ_LC_LCRC = (
-    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-6/output"
+    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-7/output"
 )
 DRN_LJ_LC_POBOY = "/Users/aphearin/work/DATA/LastJourney/lc_cores"
 

--- a/scripts/LJ_CROSSX/lc_cf_crossmatch_script.py
+++ b/scripts/LJ_CROSSX/lc_cf_crossmatch_script.py
@@ -208,7 +208,7 @@ if __name__ == "__main__":
                     ishell, ipatch = olap_patch_id
                     bn_patch_in = LC_PATCH_BNPAT.format(ishell, ipatch)
                     fn_patch_in = os.path.join(drn_lc, bn_patch_in)
-                    lc_patch_data = load_flat_hdf5(fn_patch_in)
+                    lc_patch_data = load_flat_hdf5(fn_patch_in, dataset="data")
                     n_patch = len(lc_patch_data["coreforest_file_idx"])
 
                     try:

--- a/scripts/LJ_CROSSX/run_tabulate_coreforest_overlap.sh
+++ b/scripts/LJ_CROSSX/run_tabulate_coreforest_overlap.sh
@@ -13,6 +13,7 @@
 
 # Load software
 source ~/.bash_profile
+conda activate diffsky_oc311
 cd $PBS_O_WORKDIR
 
 rsync /home/ahearin/work/repositories/python/diffsky/scripts/LJ_CROSSX/tabulate_coreforest_overlap.py ./

--- a/scripts/LJ_CROSSX/run_tabulate_coreforest_overlap.sh
+++ b/scripts/LJ_CROSSX/run_tabulate_coreforest_overlap.sh
@@ -16,5 +16,4 @@ source ~/.bash_profile
 conda activate diffsky_oc311
 cd $PBS_O_WORKDIR
 
-rsync /home/ahearin/work/repositories/python/diffsky/scripts/LJ_CROSSX/tabulate_coreforest_overlap.py ./
-python tabulate_coreforest_overlap.py
+python /home/ahearin/work/repositories/python/diffsky/scripts/LJ_CROSSX/tabulate_coreforest_overlap.py

--- a/scripts/LJ_CROSSX/tabulate_coreforest_overlap.py
+++ b/scripts/LJ_CROSSX/tabulate_coreforest_overlap.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
         stepnum, skypatch = hlu.get_stepnum_and_skypatch_from_lc_bname(lc_bn)
 
         with h5py.File(lc_fn, "r") as hdf:
-            file_idx = hdf["coreforest_file_idx"][...]
+            file_idx = hdf["data"]["coreforest_file_idx"][...]
         corefile_indices = np.unique(file_idx).astype(int)
 
         lc_xdict[(stepnum, skypatch)] = corefile_indices

--- a/scripts/LJ_CROSSX/tabulate_coreforest_overlap.py
+++ b/scripts/LJ_CROSSX/tabulate_coreforest_overlap.py
@@ -13,7 +13,7 @@ from diffsky.data_loaders.hacc_utils import get_diffsky_info_from_hacc_sim
 from diffsky.data_loaders.hacc_utils import lightcone_utils as hlu
 
 DRN_LJ_LC_LCRC = (
-    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-6/output"
+    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-7/output"
 )
 
 

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -41,7 +41,7 @@ DRN_LJ_CF_LCRC = "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/forest
 DRN_LJ_CF_POBOY = "/Users/aphearin/work/DATA/LastJourney/coretrees"
 
 DRN_LJ_LC_LCRC = (
-    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-6/output"
+    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-7/output"
 )
 DRN_LJ_LC_POBOY = "/Users/aphearin/work/DATA/LastJourney/core-lc-6"
 

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -240,9 +240,9 @@ if __name__ == "__main__":
 
         if synthetic_cores == 0:
             with h5py.File(fn_lc_cores, "r") as hdf:
-                nhalos_estimate = hdf["core_tag"].shape[0]
-                z_min_shell = 1.0 / hdf["scale_factor"][:].max() - 1
-                z_max_shell = 1.0 / hdf["scale_factor"][:].min() - 1
+                nhalos_estimate = hdf["data"]["core_tag"].shape[0]
+                z_min_shell = 1.0 / hdf["data"]["scale_factor"][:].max() - 1
+                z_max_shell = 1.0 / hdf["data"]["scale_factor"][:].min() - 1
         elif synthetic_cores == 1:
             mean_nhalos = mclh.estimate_nhalos_in_lightcone(
                 lgmp_min,

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -41,7 +41,7 @@ DRN_LJ_CF_LCRC = "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/forest
 DRN_LJ_CF_POBOY = "/Users/aphearin/work/DATA/LastJourney/coretrees"
 
 DRN_LJ_LC_LCRC = (
-    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-7/output"
+    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-6/output"
 )
 DRN_LJ_LC_POBOY = "/Users/aphearin/work/DATA/LastJourney/core-lc-6"
 

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -41,11 +41,11 @@ DRN_LJ_CF_LCRC = "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/forest
 DRN_LJ_CF_POBOY = "/Users/aphearin/work/DATA/LastJourney/coretrees"
 
 DRN_LJ_LC_LCRC = (
-    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-6/output"
+    "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-7/output"
 )
 DRN_LJ_LC_POBOY = "/Users/aphearin/work/DATA/LastJourney/core-lc-6"
 
-DRN_LJ_CROSSX_OUT_LCRC = "/lcrc/project/cosmo_ai/ahearin/LastJourney/lc-cf-diffsky"
+DRN_LJ_CROSSX_OUT_LCRC = "/lcrc/project/cosmo_ai/ahearin/LastJourney/lc-7-cf-diffsky"
 DRN_LJ_CROSSX_OUT_POBOY = "/Users/aphearin/work/DATA/LastJourney/lc-cf-diffsky"
 
 


### PR DESCRIPTION
This PR updates the lc_cf cross-matching script to be consistent with `core-lc-7`. The cross-matching successfully terminates for 100 patches. The scripts `check_lc_cf_completeness.py` and `inspect_lc_crossx_data.py` have been updated and the 100 generated patches pass all checks. The mock-generation script also successfully terminates when run on these new data.

Note that the `index` feature is not inherited by the cross-matched `lc_cf` file. This will need to be inherited by the dataset containing the mock galaxies.