### PR TITLE
Include parameter writing and loading tools for models that include diffmerge

### DIFF
--- a/diffsky/data_loaders/hacc_utils/lc_mock.py
+++ b/diffsky/data_loaders/hacc_utils/lc_mock.py
@@ -38,6 +38,7 @@ from ...fake_sats import halo_boundary_functions as hbf
 from ...fake_sats import nfw_config_space as nfwcs
 from ...fake_sats import vector_utilities as vecu
 from ...param_utils import diffsky_param_wrapper as dpw
+from ...param_utils import diffsky_param_wrapper_merging as dpwm
 from .. import io_utils as iou
 from . import lightcone_utils as hlu
 from . import load_lc_cf
@@ -203,12 +204,32 @@ def load_diffsky_param_collection(drn_mock, mock_version_name):
     return param_collection
 
 
+def load_diffsky_param_collection_merging(drn_mock, mock_version_name):
+    """"""
+    bn = BNPAT_PARAM_COLLECTION.format(mock_version_name)
+    fn = os.path.join(drn_mock, bn)
+    flat_diffsky_params = iou.load_namedtuple_from_hdf5(fn)
+    param_collection = dpwm.get_param_collection_from_flat_array(flat_diffsky_params)
+    return param_collection
+
+
 def write_diffsky_param_collection(drn_mock, mock_version_name, param_collection):
     """"""
     bn = BNPAT_PARAM_COLLECTION.format(mock_version_name)
     fn_out = os.path.join(drn_mock, bn)
     flat_diffsky_params = dpw.unroll_param_collection_into_flat_array(*param_collection)
     DiffskyParams = namedtuple("DiffskyParams", dpw.get_flat_param_names())
+    flat_diffsky_params = DiffskyParams(*flat_diffsky_params)
+
+    iou.write_namedtuple_to_hdf5(flat_diffsky_params, fn_out)
+
+
+def write_diffsky_param_collection_merging(drn_mock, mock_version_name, param_collection):
+    """"""
+    bn = BNPAT_PARAM_COLLECTION.format(mock_version_name)
+    fn_out = os.path.join(drn_mock, bn)
+    flat_diffsky_params = dpwm.unroll_param_collection_into_flat_array(*param_collection)
+    DiffskyParams = namedtuple("DiffskyParams", dpwm.get_flat_param_names())
     flat_diffsky_params = DiffskyParams(*flat_diffsky_params)
 
     iou.write_namedtuple_to_hdf5(flat_diffsky_params, fn_out)

--- a/diffsky/data_loaders/hacc_utils/tests/test_lc_mock.py
+++ b/diffsky/data_loaders/hacc_utils/tests/test_lc_mock.py
@@ -68,28 +68,29 @@ def test_load_diffsky_param_collection(tmp_path):
 
 
 def test_load_diffsky_param_collection_merging(tmp_path):
-    all_params_flat = dpwm.unroll_param_collection_into_flat_array(
-        *dpwm.DEFAULT_PARAM_COLLECTION
-    )
-    all_pnames = dpwm.get_flat_param_names()
-
-    Params = namedtuple("Params", all_pnames)
-    all_named_params = Params(*all_params_flat)
-
     mock_version_name = "unit_testing"
-    bn = lcmp_repro.BNPAT_PARAM_COLLECTION.format(mock_version_name)
-    fn = os.path.join(tmp_path, bn)
-    iou.write_namedtuple_to_hdf5(all_named_params, fn)
 
-    param_collection = lcmp_repro.load_diffsky_param_collection_merging(
+    # Get default param. collection
+    param_collection = dpwm.DEFAULT_PARAM_COLLECTION
+    all_params_flat = dpwm.unroll_param_collection_into_flat_array(*param_collection)
+
+    # Write to disk
+    lcmp_repro.write_diffsky_param_collection_merging(
+        tmp_path, mock_version_name, param_collection
+    )
+
+    # Load param. collection from disk
+    param_collection_loaded = lcmp_repro.load_diffsky_param_collection_merging(
         tmp_path, mock_version_name
     )
-    for params in param_collection:
+    for params in param_collection_loaded:
         pnames = list(params._fields)  # enforce each params is actually a namedtuple
         assert len(pnames) == len(params)
-    all_params_flat2 = dpwm.unroll_param_collection_into_flat_array(*param_collection)
-
-    assert np.allclose(all_params_flat, all_params_flat2, rtol=1e-5)
+    all_params_flat_loaded = dpwm.unroll_param_collection_into_flat_array(
+        *param_collection_loaded
+    )
+    # Compare written and loaded
+    assert np.allclose(all_params_flat, all_params_flat_loaded, rtol=1e-5)
 
 
 def _prepare_input_catalogs(n_gals=20):

--- a/diffsky/data_loaders/hacc_utils/tests/test_lc_mock.py
+++ b/diffsky/data_loaders/hacc_utils/tests/test_lc_mock.py
@@ -18,6 +18,7 @@ from ....experimental.disk_bulge_modeling import disk_bulge_kernels as dbk
 from ....experimental.lc_phot_kern import get_wave_eff_table
 from ....experimental.tests import test_mc_lightcone_halos as tmclh
 from ....param_utils import diffsky_param_wrapper as dpw
+from ....param_utils import diffsky_param_wrapper_merging as dpwm
 from ... import io_utils as iou
 from ...load_ssp_data import load_fake_ssp_data
 from .. import lc_mock as lcmp_repro
@@ -56,6 +57,31 @@ def test_load_diffsky_param_collection(tmp_path):
     iou.write_namedtuple_to_hdf5(all_named_params, fn)
 
     param_collection = lcmp_repro.load_diffsky_param_collection(
+        tmp_path, mock_version_name
+    )
+    for params in param_collection:
+        pnames = list(params._fields)  # enforce each params is actually a namedtuple
+        assert len(pnames) == len(params)
+    all_params_flat2 = dpw.unroll_param_collection_into_flat_array(*param_collection)
+
+    assert np.allclose(all_params_flat, all_params_flat2, rtol=1e-5)
+
+
+def test_load_diffsky_param_collection_merging(tmp_path):
+    all_params_flat = dpwm.unroll_param_collection_into_flat_array(
+        *dpwm.DEFAULT_PARAM_COLLECTION
+    )
+    all_pnames = dpwm.get_flat_param_names()
+
+    Params = namedtuple("Params", all_pnames)
+    all_named_params = Params(*all_params_flat)
+
+    mock_version_name = "unit_testing"
+    bn = lcmp_repro.BNPAT_PARAM_COLLECTION.format(mock_version_name)
+    fn = os.path.join(tmp_path, bn)
+    iou.write_namedtuple_to_hdf5(all_named_params, fn)
+
+    param_collection = lcmp_repro.load_diffsky_param_collection_merging(
         tmp_path, mock_version_name
     )
     for params in param_collection:

--- a/diffsky/data_loaders/hacc_utils/tests/test_lc_mock.py
+++ b/diffsky/data_loaders/hacc_utils/tests/test_lc_mock.py
@@ -87,7 +87,7 @@ def test_load_diffsky_param_collection_merging(tmp_path):
     for params in param_collection:
         pnames = list(params._fields)  # enforce each params is actually a namedtuple
         assert len(pnames) == len(params)
-    all_params_flat2 = dpw.unroll_param_collection_into_flat_array(*param_collection)
+    all_params_flat2 = dpwm.unroll_param_collection_into_flat_array(*param_collection)
 
     assert np.allclose(all_params_flat, all_params_flat2, rtol=1e-5)
 


### PR DESCRIPTION
This PR adds the functions `load_diffsky_param_collection_merging` and `write_diffsky_param_collection_merging`, and corresponding tests.  They are similar to the [existing functions](https://github.com/ArgonneCPAC/diffsky/blob/7f050c71bf5242bafa55c1d38e8c26e64eff4ea2/diffsky/data_loaders/hacc_utils/lc_mock.py#L197)  `load_diffsky_param_collection` and `write_diffsky_param_collection`, but are adapted to write and load diffmerge parameters.