### PR TITLE
Implement forest-complete chunked reader of `lc_cores.hdf5`

### DIFF
--- a/diffsky/data_loaders/hacc_utils/load_lc_cf.py
+++ b/diffsky/data_loaders/hacc_utils/load_lc_cf.py
@@ -167,8 +167,8 @@ def _chunked_read_kernel(fobj, nchunks, chunknum, keys_to_read):
         read_end = fobj["index"]["offset"][nend]
 
     lc_cores_chunk = {}
-    for k in keys_to_read:
-        lc_cores_chunk[k] = fobj["data"]["k"][read_start:read_end]
+    for key in keys_to_read:
+        lc_cores_chunk[key] = fobj["data"][key][read_start:read_end]
 
     # shift look-up-indices for the chunk
     lc_cores_chunk["top_host_idx"] -= read_start

--- a/diffsky/data_loaders/hacc_utils/load_lc_cf.py
+++ b/diffsky/data_loaders/hacc_utils/load_lc_cf.py
@@ -3,6 +3,7 @@
 import os
 from collections import namedtuple
 
+import h5py
 import numpy as np
 from diffmah import DEFAULT_MAH_PARAMS
 from diffmah.diffmahpop_kernels.bimod_censat_params import DEFAULT_DIFFMAHPOP_PARAMS
@@ -173,4 +174,26 @@ def _chunked_read_kernel(fobj, nchunks, chunknum, keys_to_read):
     lc_cores_chunk["top_host_idx"] -= read_start
     lc_cores_chunk["secondary_top_host_idx"] -= read_start
 
-    return lc_cores_chunk
+    return lc_cores_chunk, (read_start, read_end)
+
+
+def load_lc_cf_chunk(fn_lc_cf, drn_lc_cores, *, nchunks, chunknum, lc_cores_keys=None):
+    bn_lc_cf = os.path.basename(fn_lc_cf)
+    bn_lc_cores = os.path.basename(bn_lc_cf).replace(".diffsky_data.hdf5", ".hdf5")
+    fn_lc_cores = os.path.join(drn_lc_cores, bn_lc_cores)
+
+    with h5py.File(fn_lc_cores, "r") as hdf:
+        if lc_cores_keys is None:
+            lc_cores_keys = list(hdf["data"].keys())
+
+        lc_data, (istart, iend) = _chunked_read_kernel(
+            hdf, nchunks, chunknum, lc_cores_keys
+        )
+
+    diffsky_data = load_flat_hdf5(fn_lc_cf, istart=istart, iend=iend)
+
+    lc_data["redshift_true"] = 1.0 / lc_data["scale_factor"] - 1.0
+
+    assert lc_data["redshift_true"].shape[0] == diffsky_data["logm0"].shape[0]
+
+    return lc_data, diffsky_data

--- a/diffsky/data_loaders/hacc_utils/load_lc_cf.py
+++ b/diffsky/data_loaders/hacc_utils/load_lc_cf.py
@@ -171,8 +171,10 @@ def _chunked_read_kernel(fobj, nchunks, chunknum, keys_to_read):
         lc_cores_chunk[key] = fobj["data"][key][read_start:read_end]
 
     # shift look-up-indices for the chunk
-    lc_cores_chunk["top_host_idx"] -= read_start
-    lc_cores_chunk["secondary_top_host_idx"] -= read_start
+    lc_cores_chunk["top_host_idx_chunk"] = lc_cores_chunk["top_host_idx"] - read_start
+    lc_cores_chunk["secondary_top_host_idx_chunk"] = (
+        lc_cores_chunk["secondary_top_host_idx"] - read_start
+    )
 
     return lc_cores_chunk, (read_start, read_end)
 

--- a/diffsky/data_loaders/hacc_utils/load_lc_cf.py
+++ b/diffsky/data_loaders/hacc_utils/load_lc_cf.py
@@ -150,3 +150,27 @@ def generate_fake_mah_params(ran_key, t_obs, lgmp_obs, is_central, lgt0):
     fake_mah_params = DEFAULT_MAH_PARAMS._make(_mah_params)
 
     return fake_mah_params
+
+
+def _chunked_read_kernel(fobj, nchunks, chunknum, keys_to_read):
+    """Read a forest-complete chunk of data from lc_cores"""
+
+    nindex = len(fobj["index"]["offset"])
+    nstart = (nindex // nchunks) * chunknum
+    nend = (nindex // nchunks) * (chunknum + 1)
+
+    read_start = fobj["index"]["offset"][nstart]
+    if chunknum == nchunks - 1:
+        read_end = fobj["index"]["offset"][-1] + fobj["index"]["count"][-1]
+    else:
+        read_end = fobj["index"]["offset"][nend]
+
+    lc_cores_chunk = {}
+    for k in keys_to_read:
+        lc_cores_chunk[k] = fobj["data"]["k"][read_start:read_end]
+
+    # shift look-up-indices for the chunk
+    lc_cores_chunk["top_host_idx"] -= read_start
+    lc_cores_chunk["secondary_top_host_idx"] -= read_start
+
+    return lc_cores_chunk

--- a/scripts/LJ_CROSSX/lc_cf_crossmatch_script.py
+++ b/scripts/LJ_CROSSX/lc_cf_crossmatch_script.py
@@ -35,7 +35,7 @@ DRN_LJ_LC_POBOY = "/Users/aphearin/work/DATA/LastJourney/lc_cores"
 DRN_LJ_DIFFMAH_LCRC = "/lcrc/project/halotools/LastJourney/diffmah_fits"
 DRN_LJ_DIFFMAH_POBOY = "/Users/aphearin/work/DATA/LastJourney/diffmah_fits"
 
-DRN_LJ_CROSSX_OUT_LCRC = "/lcrc/project/halotools/LastJourney/lc-7-cf-diffsky"
+DRN_LJ_CROSSX_OUT_LCRC = "/lcrc/project/cosmo_ai/ahearin/LastJourney/lc-7-cf-diffsky"
 DRN_LC_CF_XDATA_LCRC = os.path.join(DRN_LJ_CROSSX_OUT_LCRC, "LC_CF_XDATA")
 DRN_LJ_CROSSX_OUT_POBOY = "/Users/aphearin/work/DATA/LastJourney/lc-cf-diffsky"
 DRN_LC_CF_XDATA_POBOY = os.path.join(DRN_LJ_CROSSX_OUT_POBOY, "LC_CF_XDATA")

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -272,20 +272,18 @@ if __name__ == "__main__":
             tcurves, ssp_data, z_phot_table, sim_info.cosmo_params
         )
 
-        print(f"Looping over {nhalos_estimate} halos with batch_size={batch_size}")
-        for istart in range(0, nhalos_estimate, batch_size):
+        nchunks = nhalos_estimate // batch_size
+        msg = f"Loading {nhalos_estimate} halos in {nchunks} chunks with batch_size={batch_size}"
+        print(msg)
+        for chunknum in range(0, nchunks):
             jax.clear_caches()
             gc.collect()
-
-            iend = min(istart + batch_size, nhalos_estimate)
 
             patch_key, batch_key = jran.split(patch_key)
 
             if synthetic_cores == 0:
-                lc_data_batch, diffsky_data_batch = (
-                    load_lc_cf.load_lc_diffsky_patch_data(
-                        fn_lc_diffsky, indir_lc_data, istart=istart, iend=iend
-                    )
+                lc_data_batch, diffsky_data_batch = load_lc_cf.load_lc_cf_chunk(
+                    fn_lc_diffsky, indir_lc_data, nchunks=nchunks, chunknum=chunknum
                 )
             else:
                 downsample_factor = nhalos_estimate / batch_size

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -6,6 +6,7 @@ To run a unit test of this script:
 
 To run a local test on poboy:
     python scripts/LJ_LC_MOCKS/make_lj_mock.py scripts/LJ_LC_MOCKS/poboy_testing_lj_mock_config.yaml
+    python scripts/LJ_LC_MOCKS/inspect_lc_mock.py ci_test_output/dummy_version_name
 
 """
 

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -5,7 +5,7 @@ To run a unit test of this script:
     python scripts/LJ_LC_MOCKS/inspect_lc_mock.py ci_test_output/dummy_version_name
 
 To run a local test on poboy:
-    python scripts/LJ_LC_MOCKS/make_lj_mock.py scripts/LJ_LC_MOCKS/poboy_testing_lj_mock_config.yaml
+    mpiexec -n 2 python scripts/LJ_LC_MOCKS/make_lj_mock.py scripts/LJ_LC_MOCKS/poboy_testing_lj_mock_config.yaml
     python scripts/LJ_LC_MOCKS/inspect_lc_mock.py ci_test_output/dummy_version_name
 
 """

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -272,9 +272,13 @@ if __name__ == "__main__":
             tcurves, ssp_data, z_phot_table, sim_info.cosmo_params
         )
 
-        nchunks = nhalos_estimate // batch_size
+        if batch_size >= nhalos_estimate:
+            nchunks = 1
+        else:
+            nchunks = nhalos_estimate // batch_size
         msg = f"Loading {nhalos_estimate} halos in {nchunks} chunks with batch_size={batch_size}"
         print(msg)
+
         for chunknum in range(0, nchunks):
             jax.clear_caches()
             gc.collect()

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -1,9 +1,11 @@
 """Script to make an SED mock to populate a Last Journey lightcone
 
 To run a unit test of this script:
+    python scripts/LJ_LC_MOCKS/make_lj_mock.py scripts/LJ_LC_MOCKS/testing_lj_mock_config.yaml
+    python scripts/LJ_LC_MOCKS/inspect_lc_mock.py ci_test_output/dummy_version_name
 
-python scripts/LJ_LC_MOCKS/make_lj_mock.py scripts/LJ_LC_MOCKS/testing_lj_mock_config.yaml
-python scripts/LJ_LC_MOCKS/inspect_lc_mock.py ci_test_output/dummy_version_name
+To run a local test on poboy:
+    python scripts/LJ_LC_MOCKS/make_lj_mock.py scripts/LJ_LC_MOCKS/poboy_testing_lj_mock_config.yaml
 
 """
 

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -43,10 +43,10 @@ DRN_LJ_CF_POBOY = "/Users/aphearin/work/DATA/LastJourney/coretrees"
 DRN_LJ_LC_LCRC = (
     "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/core-lc-7/output"
 )
-DRN_LJ_LC_POBOY = "/Users/aphearin/work/DATA/LastJourney/core-lc-6"
+DRN_LJ_LC_POBOY = "/Users/aphearin/work/DATA/LastJourney/core-lc-7"
 
 DRN_LJ_CROSSX_OUT_LCRC = "/lcrc/project/cosmo_ai/ahearin/LastJourney/lc-7-cf-diffsky"
-DRN_LJ_CROSSX_OUT_POBOY = "/Users/aphearin/work/DATA/LastJourney/lc-cf-diffsky"
+DRN_LJ_CROSSX_OUT_POBOY = "/Users/aphearin/work/DATA/LastJourney/lc-7-cf-diffsky"
 
 
 SIM_NAME = "LastJourney"

--- a/scripts/LJ_LC_MOCKS/poboy_testing_lj_mock_config.yaml
+++ b/scripts/LJ_LC_MOCKS/poboy_testing_lj_mock_config.yaml
@@ -2,7 +2,8 @@ machine: "poboy"
 z_min: 0.0
 z_max: 0.06
 istart: 0
-iend: 1
+iend: 2
+batch_size: 200
 drn_out: "ci_test_output"
 mock_nickname: "ci_test_mock"
 cosmos_fit: "cosmos_260215"

--- a/scripts/LJ_LC_MOCKS/poboy_testing_lj_mock_config.yaml
+++ b/scripts/LJ_LC_MOCKS/poboy_testing_lj_mock_config.yaml
@@ -1,0 +1,12 @@
+machine: "poboy"
+z_min: 0.0
+z_max: 0.06
+istart: 0
+iend: 1
+drn_out: "ci_test_output"
+mock_nickname: "ci_test_mock"
+cosmos_fit: "cosmos_260215"
+synthetic_cores: 0
+mock_version_name: "dummy_version_name"
+lsst_only: 1
+bn_ssp_data: "fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.sparse.h5"


### PR DESCRIPTION
This PR introduces the `hacc_utils.load_lc_cf.load_lc_cf_chunk` function, which utilizes the new `index` metadata attached to the updated `LastJourney/core-lc-7` dataset. There are no other changes to the mock, in particular, merging has not been implemented yet, only the chunked reader necessary to implement merging.