### PR TITLE
Include `index` metadata in output mock for real halos

### DIFF
--- a/diffsky/data_loaders/hacc_utils/data_validation/validate_lc_mock.py
+++ b/diffsky/data_loaders/hacc_utils/data_validation/validate_lc_mock.py
@@ -15,7 +15,7 @@ from ....experimental import dbk_phot_from_mock
 from ....experimental import precompute_ssp_phot as psspp
 from ....param_utils import diffsky_param_wrapper as dpw
 from .. import lc_mock as lcmp
-from .. import load_flat_hdf5, load_lc_cf
+from .. import load_flat_hdf5, load_lc_cf, load_lc_mock
 
 REQUIRED_METADATA_ATTRS = ("creation_date", "README", "mock_version_name")
 REQUIRED_SOFTWARE_VERSION_INFO = (
@@ -176,6 +176,32 @@ def check_all_data_columns_have_metadata(fn_lc_mock):
 
 def check_metadata(fn_lc_mock):
     msg = []
+
+    # Check if the load_mock_metadata function works
+    try:
+        all_metadata = load_lc_mock.load_mock_metadata(fn_lc_mock)
+    except:  # noqa
+        s = f"load_mock_metadata function fails on {fn_lc_mock}"
+        msg.append(s)
+        return msg
+
+    bn_lc_mock = os.path.basename(fn_lc_mock)
+    # Check for `index` in metadata of real halos
+    if "synthetic" not in bn_lc_mock:
+        try:
+            assert "index" in all_metadata.keys()
+        except AssertionError:
+            s = f"metadata is missing `index` info for {fn_lc_mock}"
+            msg.append(s)
+            return msg
+    else:
+        try:
+            assert "index" not in all_metadata.keys()
+        except AssertionError:
+            s = f"metadata contains `index` info for {fn_lc_mock} - unexpected for synthetic halos"
+            msg.append(s)
+            return msg
+
     with h5py.File(fn_lc_mock, "r") as hdf:
         try:
             # Check all scalar metadata

--- a/diffsky/data_loaders/hacc_utils/load_lc_mock.py
+++ b/diffsky/data_loaders/hacc_utils/load_lc_mock.py
@@ -55,6 +55,7 @@ def load_mock_metadata(fn_mock):
     hacc_cosmology = dict()
     nbody_info = dict()
     software_info = dict()
+    index_data = dict()
 
     with h5py.File(fn_mock, "r") as hdf:
         for key, val in hdf["metadata"].attrs.items():
@@ -76,6 +77,11 @@ def load_mock_metadata(fn_mock):
 
             z_phot_table = hdf["metadata"]["z_phot_table"][...]
             metadata_dict["z_phot_table"] = z_phot_table
+
+            if "index" in hdf["metadata"].keys():
+                for indx_name, indx_val in hdf["metadata"]["index"].attrs.items():
+                    index_data[indx_name] = indx_val
+                metadata_dict["index"] = index_data
 
     drn_mock = os.path.dirname(fn_mock)
 

--- a/diffsky/data_loaders/hacc_utils/metadata_mock.py
+++ b/diffsky/data_loaders/hacc_utils/metadata_mock.py
@@ -1,10 +1,11 @@
 """"""
 
+import os
 from datetime import datetime
 
 import h5py
 
-from . import load_lc_cf
+from . import load_flat_hdf5, load_lc_cf
 
 try:
     from astropy import units as u
@@ -589,6 +590,19 @@ def append_metadata(
 
             hdf_out[key_out].attrs["unit"] = str(u.erg / u.s)
             hdf_out[key_out].attrs["description"] = LINELUM_MSG
+
+
+def append_index_metadata(fnout, drn_lc_cores):
+    """Copy the index metadata from lc_cores to the output mock data"""
+    bn_lc_cores = os.path.basename(fnout).replace(".diffsky_gals.hdf5", ".hdf5")
+    fn_lc_cores = os.path.join(drn_lc_cores, bn_lc_cores)
+    index_data = load_flat_hdf5(fn_lc_cores, dataset="index")
+
+    with h5py.File(fnout, "r+") as hdf_out:
+        metadata_group = hdf_out.require_group("metadata")
+        index_group = metadata_group.require_group("index")
+        for key, val in index_data.items():
+            index_group.attrs[key] = val
 
 
 def get_dependency_versions():

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -393,6 +393,8 @@ if __name__ == "__main__":
                 )
 
         if synthetic_cores == 0:
+            metadata_mock.append_index_metadata(fn_out, indir_lc_data)
+
             lc_cores_poskeys = (
                 "x",
                 "y",

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -446,6 +446,11 @@ if __name__ == "__main__":
         if rank == 0:
             print("All ranks completing file operations...", flush=True)
 
+            if synthetic_cores == 0:
+                bn_sky_decomp = "lc_cores-decomposition.txt"
+                fn_sky_decomp = os.path.join(indir_lc_data, bn_sky_decomp)
+                shutil.copy2(fn_sky_decomp, drn_out)
+
             lcmp_repro.write_ancillary_data(
                 drn_out,
                 mock_version_name,


### PR DESCRIPTION
This PR implements the `append_index_metadata` for real halos only, and include new test that this column exists in  `check_metadata`