### PR TITLE
Add new `merging_kernels.py` module

### DIFF
--- a/diffsky/experimental/kernels/mc_phot_kernels.py
+++ b/diffsky/experimental/kernels/mc_phot_kernels.py
@@ -9,7 +9,7 @@ from jax import random as jran
 from jax import vmap
 
 from ...dustpop.tw_dust import DEFAULT_DUST_PARAMS
-from ...merging import merging_model
+from ...merging import compute_x_tot_from_x_in_situ, merging_model
 from ...ssp_err_model import ssp_err_model
 from .. import mc_diffstarpop_wrappers as mcdw
 from .. import photometry_interpolation as photerp
@@ -596,30 +596,26 @@ def _specphot_kern_merging(
     merge_prob = merging_model.get_p_merge_from_merging_params(
         merge_params, logmp_infall, logmhost_infall, t_obs, t_infall, upids
     )
-    ngals = logmp_infall.shape[0]
-    indx_to_keep = jnp.arange(ngals).astype("i8")
 
-    merge_weight = merge_prob * nhalos_weights
     mstar_in_situ = 10**phot_kern_results.logsm_obs
-    mstar_to_keep = mstar_in_situ * (1 - merge_prob)
-    mstar_to_deposit = mstar_in_situ * merge_weight
-    mstar_obs = jnp.zeros_like(mstar_in_situ)
-    mstar_obs = mstar_obs.at[halo_indx].add(mstar_to_deposit)
-    mstar_obs = mstar_obs.at[indx_to_keep].add(mstar_to_keep)
+    mstar_obs = compute_x_tot_from_x_in_situ(
+        mstar_in_situ, merge_prob, nhalos_weights, halo_indx
+    )
 
-    merge_weight = merge_weight[:, jnp.newaxis]
     flux_in_situ = 10 ** (-0.4 * phot_kern_results.obs_mags)
-    flux_to_keep = flux_in_situ * (1 - merge_prob)[:, jnp.newaxis]
-    flux_to_deposit = flux_in_situ * merge_weight
-    flux_obs = jnp.zeros_like(flux_in_situ)
-    flux_obs = flux_obs.at[halo_indx].add(flux_to_deposit)
-    flux_obs = flux_obs.at[indx_to_keep].add(flux_to_keep)
+    flux_obs = compute_x_tot_from_x_in_situ(
+        flux_in_situ,
+        merge_prob[:, jnp.newaxis],
+        nhalos_weights[:, jnp.newaxis],
+        halo_indx,
+    )
 
-    linelums_to_keep = linelums_in_situ * (1 - merge_prob)[:, jnp.newaxis]
-    linelums_to_deposit = linelums_in_situ * merge_weight
-    linelums_obs = jnp.zeros_like(linelums_in_situ)
-    linelums_obs = linelums_obs.at[halo_indx].add(linelums_to_deposit)
-    linelums_obs = linelums_obs.at[indx_to_keep].add(linelums_to_keep)
+    linelums_obs = compute_x_tot_from_x_in_situ(
+        linelums_in_situ,
+        merge_prob[:, jnp.newaxis],
+        nhalos_weights[:, jnp.newaxis],
+        halo_indx,
+    )
 
     return (
         phot_kern_results,

--- a/diffsky/experimental/kernels/mc_phot_kernels.py
+++ b/diffsky/experimental/kernels/mc_phot_kernels.py
@@ -345,24 +345,19 @@ def _phot_kern_merging(
     merge_prob = merging_model.get_p_merge_from_merging_params(
         merge_params, logmp_infall, logmhost_infall, t_obs, t_infall, upids
     )
-    ngals = logmp_infall.shape[0]
-    indx_to_keep = jnp.arange(ngals).astype("i8")
 
-    merge_weight = merge_prob * nhalos_weights
     mstar_in_situ = 10**phot_kern_results.logsm_obs
-    mstar_to_keep = mstar_in_situ * (1 - merge_prob)
-    mstar_to_deposit = mstar_in_situ * merge_weight
-    mstar_obs = jnp.zeros_like(mstar_in_situ)
-    mstar_obs = mstar_obs.at[halo_indx].add(mstar_to_deposit)
-    mstar_obs = mstar_obs.at[indx_to_keep].add(mstar_to_keep)
+    mstar_obs = compute_x_tot_from_x_in_situ(
+        mstar_in_situ, merge_prob, nhalos_weights, halo_indx
+    )
 
-    merge_weight = merge_weight[:, jnp.newaxis]
     flux_in_situ = 10 ** (-0.4 * phot_kern_results.obs_mags)
-    flux_to_keep = flux_in_situ * (1 - merge_prob)[:, jnp.newaxis]
-    flux_to_deposit = flux_in_situ * merge_weight
-    flux_obs = jnp.zeros_like(flux_in_situ)
-    flux_obs = flux_obs.at[halo_indx].add(flux_to_deposit)
-    flux_obs = flux_obs.at[indx_to_keep].add(flux_to_keep)
+    flux_obs = compute_x_tot_from_x_in_situ(
+        flux_in_situ,
+        merge_prob[:, jnp.newaxis],
+        nhalos_weights[:, jnp.newaxis],
+        halo_indx,
+    )
 
     return phot_kern_results, flux_obs, merge_prob, mstar_obs
 

--- a/diffsky/merging/__init__.py
+++ b/diffsky/merging/__init__.py
@@ -1,0 +1,3 @@
+""""""
+
+from .merging_kernels import compute_x_tot_from_x_in_situ  # noqa

--- a/diffsky/merging/merging_kernels.py
+++ b/diffsky/merging/merging_kernels.py
@@ -1,0 +1,48 @@
+""" """
+
+from jax import jit as jjit
+from jax import numpy as jnp
+
+
+@jjit
+def compute_x_tot_from_x_in_situ(
+    x_in_situ, p_merge, nsat_weights, halo_indx, frac_receive=1.0
+):
+    """Compute quantity X after including effects from merging
+
+    Parameters
+    ----------
+    x_in_situ : array of shape (n, )
+
+    p_merge : array of shape (n, )
+        Probability that the object merges into its associated central
+        0<=p_merge<=1, with p_merge=0 for centrals
+
+    nsat_weights : array of shape (n, )
+        Multiplicity factor for satellites
+
+    halo_indx : array of shape (n, )
+        Index to deposit quantity X
+
+    frac_receive : float or array of shape (n, ), optional
+        Fraction of X that the associated central receives from a merged satellite
+        frac_receive < 1 ==> X is not conserved
+
+    Returns
+    -------
+    x_tot : array, shape (n, )
+
+    """
+    ngals = x_in_situ.shape[0]
+    indx_to_keep = jnp.arange(ngals).astype("i8")
+
+    merge_weight = p_merge * nsat_weights
+
+    x_to_keep = x_in_situ * (1 - p_merge)
+    x_to_receive = x_in_situ * merge_weight * frac_receive
+
+    x_tot = jnp.zeros_like(x_in_situ)
+    x_tot = x_tot.at[halo_indx].add(x_to_receive)
+    x_tot = x_tot.at[indx_to_keep].add(x_to_keep)
+
+    return x_tot

--- a/diffsky/merging/merging_kernels.py
+++ b/diffsky/merging/merging_kernels.py
@@ -28,6 +28,10 @@ def compute_x_tot_from_x_in_situ(
         Fraction of X that the associated central receives from a merged satellite
         frac_receive < 1 ==> X is not conserved
 
+        Example use-case: satellite emission lines may be partially or entirely
+            extinguished upon merging, in which case merged satellites will still vanish
+            but their associated central will not receive boosted emission line flux
+
     Returns
     -------
     x_tot : array, shape (n, )

--- a/diffsky/merging/tests/test_merging_kernels.py
+++ b/diffsky/merging/tests/test_merging_kernels.py
@@ -1,0 +1,52 @@
+""""""
+
+import numpy as np
+
+from .. import merging_kernels as mk
+
+
+def test_compute_x_tot_from_x_in_situ_hard_coded_example_0():
+    x_cen0, x_cen1, x_cen2 = 4.0, 3.0, 2.0
+    x_sat00, x_sat10, x_sat11 = 0.2, 0.4, 0.6
+
+    x_in_situ = np.array((x_cen0, x_sat00, x_cen1, x_sat10, x_sat11, x_cen2))
+    p_merge = np.array((0, 1, 0, 1, 1, 0)).astype("float")
+    nsat_weights = np.ones_like(x_in_situ)
+    halo_indx = np.array((0, 0, 2, 2, 2, 5)).astype("int")
+
+    args = x_in_situ, p_merge, nsat_weights, halo_indx
+    x_tot = mk.compute_x_tot_from_x_in_situ(*args)
+
+    x_tot_correct = np.array((4.2, 0.0, 4.0, 0, 0, 2))
+    assert np.allclose(x_tot, x_tot_correct, rtol=1e-4)
+
+    _F = 0.2
+    x_tot = mk.compute_x_tot_from_x_in_situ(*args, frac_receive=_F)
+    x_tot_correct = np.array(
+        (x_cen0 + _F * x_sat00, 0.0, x_cen1 + _F * (x_sat10 + x_sat11), 0, 0, x_cen2)
+    )
+    assert np.allclose(x_tot, x_tot_correct, rtol=1e-4)
+
+
+def test_compute_x_tot_from_x_in_situ_hard_coded_example_1():
+    """Same as test_compute_x_tot_from_x_in_situ_hard_coded_example_0 but different array indexing"""
+    x_cen0, x_cen1, x_cen2 = 4.0, 3.0, 2.0
+    x_sat00, x_sat10, x_sat11 = 0.2, 0.4, 0.6
+
+    x_in_situ = np.array((x_cen0, x_cen1, x_cen2, x_sat00, x_sat10, x_sat11))
+    p_merge = np.array((0, 0, 0, 1, 1, 1)).astype("float")
+    nsat_weights = np.ones_like(x_in_situ)
+    halo_indx = np.array((0, 1, 2, 0, 1, 1)).astype("int")
+
+    args = x_in_situ, p_merge, nsat_weights, halo_indx
+    x_tot = mk.compute_x_tot_from_x_in_situ(*args)
+
+    x_tot_correct = np.array((4.2, 4.0, 2.0, 0, 0, 0))
+    assert np.allclose(x_tot, x_tot_correct, rtol=1e-4)
+
+    _F = 0.2
+    x_tot = mk.compute_x_tot_from_x_in_situ(*args, frac_receive=_F)
+    x_tot_correct = np.array(
+        (x_cen0 + _F * x_sat00, x_cen1 + _F * (x_sat10 + x_sat11), x_cen2, 0, 0, 0)
+    )
+    assert np.allclose(x_tot, x_tot_correct, rtol=1e-4)


### PR DESCRIPTION
New module implements the `compute_x_tot_from_x_in_situ` function. The transfer of some quantity X from in-situ to ex-situ now happens all in one place, saving some copy-paste that was proliferating.