### PR TITLE
Fix bug in weights used in plot_cosmos_merging

### DIFF
--- a/diffsky/diagnostics/plot_cosmos_merging.py
+++ b/diffsky/diagnostics/plot_cosmos_merging.py
@@ -528,7 +528,13 @@ def plot_app_mag_func(
     msk_z = np.abs(pdata.cosmos["photoz"] - z_bin) < dz
     msk_z_pred = np.abs(pdata.lc_data.z_obs - z_bin) < dz
 
-    w_pred = pdata.lc_data.nhalos[msk_z_pred]
+    weights = np.where(
+        pdata.lc_data.is_central == 1,
+        pdata.lc_data.nhalos,
+        pdata.lc_data.nhalos * pdata.lc_data.nhalos_host,
+    )
+
+    w_pred = weights[msk_z_pred]
     pred_norm_factor = pdata.diffsky_data["sky_area_degsq"] * dmagbins * 2 * dz
     target_norm_factor = c20.SKY_AREA * dmagbins * 2 * dz
 
@@ -697,6 +703,12 @@ def plot_ex_situ_fraction(*, pdata, model_nickname, drn_out=""):
     x_collector = []
     y_collector = []
 
+    weights = np.where(
+        pdata.lc_data.is_central == 1,
+        pdata.lc_data.nhalos,
+        pdata.lc_data.nhalos * pdata.lc_data.nhalos_host,
+    )
+
     for logsm_bin in logsm_bins:
         msk_cen = pdata.lc_data.is_central == 1
         msk_logsm = np.abs(pdata.diffsky_data["logsm_obs"] - logsm_bin) < dlogsm
@@ -706,7 +718,7 @@ def plot_ex_situ_fraction(*, pdata, model_nickname, drn_out=""):
             x_collector.append(logsm_bin)
             avg_cen = np.average(
                 x[msk_cen & msk_logsm],
-                weights=pdata.lc_data.nhalos[msk_cen & msk_logsm],
+                weights=weights[msk_cen & msk_logsm],
             )
             y_collector.append(float(avg_cen))
 


### PR DESCRIPTION
Previously, the weights used to compute histograms were computed as `lc_data.nhalos`, but this is incorrect for subhalos because the HMF weight is not included. This PR updates the weights to include the effect of the HMF.