### PR TITLE
WIP: Update t_quench for satellites

### DIFF
--- a/diffsky/experimental/mc_diffstarpop_wrappers.py
+++ b/diffsky/experimental/mc_diffstarpop_wrappers.py
@@ -142,6 +142,20 @@ def mc_diffstarpop_wrapper(
         ran_key,
     )
     sfh_params_ms, sfh_params_q, frac_q, mc_is_q = _res
+
+    """Modify sat quench model here"""
+    t_peak = mah_params.t_peak
+    t_q = 10**sfh_params_q.lg_qt
+
+    is_sat = upid != -1
+
+    clipped_t_q = jnp.minimum(t_peak, t_q)  # whichever comes first
+    t_q = jnp.where(is_sat, clipped_t_q, t_q)
+
+    sfh_params_q = sfh_params_q._replace(lg_qt=jnp.log10(t_q))
+
+    """ end Modify sat quench model"""
+
     sfh_params = mc_select_diffstar_params(sfh_params_q, sfh_params_ms, mc_is_q)
 
     DiffstarPopResults = namedtuple(


### PR DESCRIPTION
We tried a satellite quenching model modification to prevent blue satellites from merging into massive centrals, making them bluer. In this modification, we replaced the quenching time for satellites, `tq` with `tpeak` if `tpeak < tq`. 

However, we quickly realized that with this change implemented, satellites were quenching too early, which is likely unphysical. The figure below demonstrates this. The top row shows `tq` relative to `tpeak` before and after the model change. 

Consequently, the bottom-right panel shows that the effect of quenching too early is that many satellites end up with much lower `logsm_obs`. Therefore, by decreasing the `logsm_obs` in general, the net effect of this is to boost the `logssfr` as `logssfr = logsfr - logsm` as seen in the bottom-left panel. This is the opposite of increased quenching, an effect we were after. Here, I only show `logsm_obs > 6` to ensure that this effect is not limited to really low mass satellites. 

Upon consultation with @aphearin, we have now decided to implement alternative strategies to mitigate "blue merging".

<img width="694" height="679" alt="tquench_test" src="https://github.com/user-attachments/assets/ad387432-912c-448d-848e-8f56d290437d" />

