### PR TITLE
Incorporate differentiable satellite quenching into all photometry kernels

### DIFF
--- a/diffsky/experimental/kernels/dbk_specphot_kernels_merging.py
+++ b/diffsky/experimental/kernels/dbk_specphot_kernels_merging.py
@@ -152,18 +152,18 @@ def _dbk_specphot_kern_merging(
     args = dbk_specphot_info, dbk_specphot_info, sat_weights, halo_indx
     linelums_obs, linelum_in_situ = spkm._get_linelum_kern_merging_quantities(*args)
 
-    dbk_specphot_info = spkm._get_linelum_results_with_merging(
+    dbk_specphot_info = spkm._update_linelum_results_with_merging(
         dbk_specphot_info, linelums_obs, linelum_in_situ
     )
 
-    dbk_specphot_info, dbk_weights = _get_dbk_specphot_info_with_merging(
+    dbk_specphot_info, dbk_weights = _update_dbk_specphot_info_with_merging(
         dbk_specphot_info, dbk_weights, mstar_in_situ, mstar_obs, flux_in_situ, flux_obs
     )
     return dbk_specphot_info, dbk_weights
 
 
 @jjit
-def _get_dbk_specphot_info_with_merging(
+def _update_dbk_specphot_info_with_merging(
     dbk_specphot_info, dbk_weights, mstar_in_situ, mstar_obs, flux_in_situ, flux_obs
 ):
     n_gals = dbk_specphot_info.logsm_obs.size

--- a/diffsky/experimental/kernels/gd_dbk_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_kernels.py
@@ -1,0 +1,100 @@
+""""""
+
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import vmap
+
+from . import dbk_kernels
+from . import rapid_quenching as rq
+from . import ssp_weight_kernels as sspwk
+
+interp_vmap = jjit(vmap(jnp.interp, in_axes=(0, None, 0)))
+
+
+@jjit
+def get_dbk_weights_rq(
+    t_obs,
+    ssp_data,
+    t_table,
+    burst_params,
+    lgmet_weights,
+    disk_bulge_history,
+    fknot,
+    logsm_obs,
+    ssp_weights,
+    p_merge_smooth,
+):
+    age_weights_bulge, mstar_bulge = get_bulge_age_weights_rq(
+        t_obs, ssp_data, t_table, disk_bulge_history, p_merge_smooth
+    )
+
+    mstar_tot = 10**logsm_obs  # total stellar mass in galaxy
+    mstar_burst = mstar_tot * 10**burst_params.lgfburst  # mass in burst
+    mstar_ddk = mstar_tot - mstar_bulge  # mass of diffuse disk + knots
+    mstar_knots = fknot * mstar_ddk  # mass of knots
+    mstar_dd = mstar_ddk - mstar_knots  # mass of diffuse disk
+
+    # m_ddk*W_ddk = m_dd*W_dd + m_k*W_k
+    _A = mstar_tot * ssp_weights.age_weights
+    _B = mstar_bulge * age_weights_bulge
+    age_weights_ddk = (_A - _B) / mstar_ddk
+
+    ssp_lg_age_yr = ssp_data.ssp_lg_age_gyr + 9.0
+    age_weights_pureburst = dbk_kernels.get_pureburst_age_weights(
+        ssp_lg_age_yr, burst_params.lgyr_peak, burst_params.lgyr_max
+    )
+
+    # m_ddk*W_ddk = m_ddk_smooth*W_ddk_smooth + m_burst*W_burst
+    _C = mstar_ddk * age_weights_ddk
+    _D = mstar_burst * age_weights_pureburst
+    mstar_ddk_smooth = mstar_ddk - mstar_burst
+    age_weights_ddk_smooth = (_C - _D) / mstar_ddk_smooth
+
+    # m_k*W_k = m_ks_smooth*W_ddk_smooth + m_burst_knot*W_burst
+    mburst_by_mknot = mstar_burst / mstar_knots
+    mstar_knots_burst = jnp.where(mburst_by_mknot > 1, mstar_knots, mstar_burst)
+    mstar_knots_smooth = mstar_knots - mstar_knots_burst  # possibly zero
+    _E = mstar_knots_smooth * age_weights_ddk_smooth
+    _F = mstar_knots_burst * age_weights_pureburst
+    age_weights_knots = (_E + _F) / mstar_knots
+
+    mstar_dd_burst = jnp.where(mburst_by_mknot > 1, mstar_burst - mstar_knots, 0.0)
+    mstar_dd_smooth = mstar_dd - mstar_dd_burst
+    _G = mstar_dd_smooth * age_weights_ddk_smooth
+    _H = mstar_dd_burst * age_weights_pureburst
+    age_weights_dd = (_G + _H) / mstar_dd
+
+    ssp_weights_bulge = sspwk.combine_age_met_weights(age_weights_bulge, lgmet_weights)
+    ssp_weights_disk = sspwk.combine_age_met_weights(age_weights_dd, lgmet_weights)
+    ssp_weights_knots = sspwk.combine_age_met_weights(age_weights_knots, lgmet_weights)
+
+    dbk_weights_rq = dbk_kernels.DBKWeights(
+        ssp_weights_bulge=ssp_weights_bulge,
+        ssp_weights_disk=ssp_weights_disk,
+        ssp_weights_knots=ssp_weights_knots,
+        mstar_bulge=mstar_bulge,
+        mstar_disk=mstar_dd,
+        mstar_knots=mstar_knots,
+    )
+    return dbk_weights_rq
+
+
+@jjit
+def get_bulge_age_weights_rq(
+    t_obs, ssp_data, t_table, disk_bulge_history, p_merge_smooth
+):
+    logsm_obs_bulge = interp_vmap(
+        t_obs, t_table, jnp.log10(disk_bulge_history.smh_bulge)
+    )
+    mstar_bulge = 10**logsm_obs_bulge
+    age_weights_bulge = sspwk.calc_age_weights_from_sfh_table_vmap(
+        t_table, disk_bulge_history.sfh_bulge, ssp_data.ssp_lg_age_gyr, t_obs
+    )
+    age_weights_bulge_rq, __ = rq.get_age_weights_rq_vmap(
+        age_weights_bulge,
+        p_merge_smooth,
+        ssp_data.ssp_lg_age_gyr,
+        rq.DEFAULT_RQ_PARAMS,
+    )
+
+    return age_weights_bulge_rq, mstar_bulge

--- a/diffsky/experimental/kernels/gd_dbk_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_kernels.py
@@ -4,11 +4,46 @@ from jax import jit as jjit
 from jax import numpy as jnp
 from jax import vmap
 
+from ..disk_bulge_modeling import dbpop
 from . import dbk_kernels
 from . import rapid_quenching as rq
 from . import ssp_weight_kernels as sspwk
 
 interp_vmap = jjit(vmap(jnp.interp, in_axes=(0, None, 0)))
+
+
+@jjit
+def _dbk_kern(
+    t_obs,
+    ssp_data,
+    t_table,
+    sfh_table,
+    burst_params,
+    lgmet_weights,
+    dbk_randoms,
+    logsm_obs,
+    age_weights,
+    p_merge_smooth,
+):
+    disk_bulge_history = dbpop.decompose_sfh_into_disk_bulge_sfh(
+        dbk_randoms.uran_fbulge, t_table, sfh_table, t_obs
+    )
+
+    args = (
+        t_obs,
+        ssp_data,
+        t_table,
+        burst_params,
+        lgmet_weights,
+        disk_bulge_history,
+        dbk_randoms.fknot,
+        logsm_obs,
+        age_weights,
+        p_merge_smooth,
+    )
+    dbk_weights = get_dbk_weights_rq(*args)
+
+    return dbk_weights, disk_bulge_history
 
 
 @jjit
@@ -21,12 +56,13 @@ def get_dbk_weights_rq(
     disk_bulge_history,
     fknot,
     logsm_obs,
-    ssp_weights,
+    age_weights_tot,
     p_merge_smooth,
 ):
     age_weights_bulge, mstar_bulge = get_bulge_age_weights_rq(
         t_obs, ssp_data, t_table, disk_bulge_history, p_merge_smooth
     )
+    n_gals = mstar_bulge.size
 
     mstar_tot = 10**logsm_obs  # total stellar mass in galaxy
     mstar_burst = mstar_tot * 10**burst_params.lgfburst  # mass in burst
@@ -35,9 +71,9 @@ def get_dbk_weights_rq(
     mstar_dd = mstar_ddk - mstar_knots  # mass of diffuse disk
 
     # m_ddk*W_ddk = m_dd*W_dd + m_k*W_k
-    _A = mstar_tot * ssp_weights.age_weights
-    _B = mstar_bulge * age_weights_bulge
-    age_weights_ddk = (_A - _B) / mstar_ddk
+    _A = mstar_tot.reshape((n_gals, 1)) * age_weights_tot
+    _B = mstar_bulge.reshape((n_gals, 1)) * age_weights_bulge
+    age_weights_ddk = (_A - _B) / mstar_ddk.reshape((n_gals, 1))
 
     ssp_lg_age_yr = ssp_data.ssp_lg_age_gyr + 9.0
     age_weights_pureburst = dbk_kernels.get_pureburst_age_weights(
@@ -45,24 +81,24 @@ def get_dbk_weights_rq(
     )
 
     # m_ddk*W_ddk = m_ddk_smooth*W_ddk_smooth + m_burst*W_burst
-    _C = mstar_ddk * age_weights_ddk
-    _D = mstar_burst * age_weights_pureburst
+    _C = mstar_ddk.reshape((n_gals, 1)) * age_weights_ddk
+    _D = mstar_burst.reshape((n_gals, 1)) * age_weights_pureburst
     mstar_ddk_smooth = mstar_ddk - mstar_burst
-    age_weights_ddk_smooth = (_C - _D) / mstar_ddk_smooth
+    age_weights_ddk_smooth = (_C - _D) / mstar_ddk_smooth.reshape((n_gals, 1))
 
     # m_k*W_k = m_ks_smooth*W_ddk_smooth + m_burst_knot*W_burst
     mburst_by_mknot = mstar_burst / mstar_knots
     mstar_knots_burst = jnp.where(mburst_by_mknot > 1, mstar_knots, mstar_burst)
     mstar_knots_smooth = mstar_knots - mstar_knots_burst  # possibly zero
-    _E = mstar_knots_smooth * age_weights_ddk_smooth
-    _F = mstar_knots_burst * age_weights_pureburst
-    age_weights_knots = (_E + _F) / mstar_knots
+    _E = mstar_knots_smooth.reshape((n_gals, 1)) * age_weights_ddk_smooth
+    _F = mstar_knots_burst.reshape((n_gals, 1)) * age_weights_pureburst
+    age_weights_knots = (_E + _F) / mstar_knots.reshape((n_gals, 1))
 
     mstar_dd_burst = jnp.where(mburst_by_mknot > 1, mstar_burst - mstar_knots, 0.0)
     mstar_dd_smooth = mstar_dd - mstar_dd_burst
-    _G = mstar_dd_smooth * age_weights_ddk_smooth
-    _H = mstar_dd_burst * age_weights_pureburst
-    age_weights_dd = (_G + _H) / mstar_dd
+    _G = mstar_dd_smooth.reshape((n_gals, 1)) * age_weights_ddk_smooth
+    _H = mstar_dd_burst.reshape((n_gals, 1)) * age_weights_pureburst
+    age_weights_dd = (_G + _H) / mstar_dd.reshape((n_gals, 1))
 
     ssp_weights_bulge = sspwk.combine_age_met_weights(age_weights_bulge, lgmet_weights)
     ssp_weights_disk = sspwk.combine_age_met_weights(age_weights_dd, lgmet_weights)

--- a/diffsky/experimental/kernels/gd_dbk_specphot_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_specphot_kernels.py
@@ -9,7 +9,13 @@ from jax import numpy as jnp
 from ...merging import merging_model
 from ...ssp_err_model import ssp_err_model
 from ..disk_bulge_modeling import disk_bulge_kernels as dbk
-from . import dbk_kernels, gd_linelum_kernels, gd_phot_kernels, mc_randoms
+from . import (
+    dbk_kernels,
+    gd_dbk_kernels,
+    gd_linelum_kernels,
+    gd_phot_kernels,
+    mc_randoms,
+)
 from . import ssp_weight_kernels as sspwk
 
 
@@ -120,7 +126,8 @@ def _dbk_phot_kern(
         lgyr_peak=phot_kern_results.lgyr_peak,
         lgyr_max=phot_kern_results.lgyr_max,
     )
-    dbk_weights, disk_bulge_history = dbk_kernels._dbk_kern(
+    age_weights = jnp.sum(phot_kern_results.ssp_weights, axis=1)
+    dbk_weights, disk_bulge_history = gd_dbk_kernels._dbk_kern(
         t_obs,
         ssp_data,
         phot_kern_results.t_table,
@@ -128,6 +135,9 @@ def _dbk_phot_kern(
         burst_params,
         phot_kern_results.lgmet_weights,
         dbk_randoms,
+        phot_kern_results.logsm_obs,
+        age_weights,
+        p_merge_smooth,
     )
 
     _ret3 = dbk_kernels._get_dbk_phot_from_dbk_weights(

--- a/diffsky/experimental/kernels/gd_dbk_specphot_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_specphot_kernels.py
@@ -1,0 +1,408 @@
+""""""
+
+from collections import namedtuple
+
+from dsps.sfh.diffburst import DEFAULT_BURST_PARAMS
+from jax import jit as jjit
+from jax import numpy as jnp
+
+from ...ssp_err_model import ssp_err_model
+from ..disk_bulge_modeling import disk_bulge_kernels as dbk
+from . import dbk_kernels, linelum_kernels, mc_randoms, phot_kernels
+from . import ssp_weight_kernels as sspwk
+
+
+@jjit
+def _mc_dbk_phot_kern(
+    ran_key,
+    z_obs,
+    t_obs,
+    mah_params,
+    ssp_data,
+    precomputed_ssp_mag_table,
+    z_phot_table,
+    wave_eff_table,
+    diffstarpop_params,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    cosmo_params,
+    fb,
+):
+    phot_randoms, sfh_params, dbk_randoms = mc_randoms.get_mc_dbk_phot_randoms(
+        ran_key, diffstarpop_params, mah_params, cosmo_params
+    )
+    dbk_phot_info, dbk_weights = _dbk_phot_kern(
+        phot_randoms,
+        sfh_params,
+        dbk_randoms,
+        z_obs,
+        t_obs,
+        mah_params,
+        ssp_data,
+        precomputed_ssp_mag_table,
+        z_phot_table,
+        wave_eff_table,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        cosmo_params,
+        fb,
+    )
+
+    return dbk_phot_info, dbk_weights
+
+
+@jjit
+def _dbk_phot_kern(
+    phot_randoms,
+    sfh_params,
+    dbk_randoms,
+    z_obs,
+    t_obs,
+    mah_params,
+    ssp_data,
+    precomputed_ssp_mag_table,
+    z_phot_table,
+    wave_eff_table,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    cosmo_params,
+    fb,
+):
+    phot_kern_results = phot_kernels._phot_kern(
+        phot_randoms,
+        sfh_params,
+        z_obs,
+        t_obs,
+        mah_params,
+        ssp_data,
+        precomputed_ssp_mag_table,
+        z_phot_table,
+        wave_eff_table,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        cosmo_params,
+        fb,
+    )
+
+    burst_params = DEFAULT_BURST_PARAMS._replace(
+        lgfburst=phot_kern_results.lgfburst,
+        lgyr_peak=phot_kern_results.lgyr_peak,
+        lgyr_max=phot_kern_results.lgyr_max,
+    )
+    dbk_weights, disk_bulge_history = dbk_kernels._dbk_kern(
+        t_obs,
+        ssp_data,
+        phot_kern_results.t_table,
+        phot_kern_results.sfh_table,
+        burst_params,
+        phot_kern_results.lgmet_weights,
+        dbk_randoms,
+    )
+
+    _ret3 = dbk_kernels._get_dbk_phot_from_dbk_weights(
+        phot_kern_results.ssp_photflux_table,
+        dbk_weights,
+        phot_kern_results.dust_frac_trans,
+        phot_kern_results.frac_ssp_errors,
+    )
+    obs_mags_bulge, obs_mags_disk, obs_mags_knots = _ret3
+
+    dbk_phot_info = MCDBKPhotInfo(
+        **phot_kern_results._asdict(),
+        **phot_randoms._asdict(),
+        **dbk_randoms._asdict(),
+        **disk_bulge_history.fbulge_params._asdict(),
+        bulge_to_total_history=disk_bulge_history.bulge_to_total_history,
+        logsm_bulge=jnp.log10(dbk_weights.mstar_bulge),
+        logsm_disk=jnp.log10(dbk_weights.mstar_disk),
+        logsm_knots=jnp.log10(dbk_weights.mstar_knots),
+        obs_mags_bulge=obs_mags_bulge,
+        obs_mags_disk=obs_mags_disk,
+        obs_mags_knots=obs_mags_knots,
+    )
+    return dbk_phot_info, dbk_weights
+
+
+@jjit
+def _mc_dbk_specphot_kern(
+    ran_key,
+    z_obs,
+    t_obs,
+    mah_params,
+    ssp_data,
+    precomputed_ssp_mag_table,
+    z_phot_table,
+    wave_eff_table,
+    line_wave_table,
+    diffstarpop_params,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    cosmo_params,
+    fb,
+):
+    phot_randoms, sfh_params, dbk_randoms = mc_randoms.get_mc_dbk_phot_randoms(
+        ran_key, diffstarpop_params, mah_params, cosmo_params
+    )
+    dbk_specphot_info, dbk_weights = _dbk_specphot_kern(
+        phot_randoms,
+        sfh_params,
+        dbk_randoms,
+        z_obs,
+        t_obs,
+        mah_params,
+        ssp_data,
+        precomputed_ssp_mag_table,
+        z_phot_table,
+        wave_eff_table,
+        line_wave_table,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        cosmo_params,
+        fb,
+    )
+    return dbk_specphot_info, dbk_weights
+
+
+@jjit
+def _dbk_specphot_kern(
+    phot_randoms,
+    sfh_params,
+    dbk_randoms,
+    z_obs,
+    t_obs,
+    mah_params,
+    ssp_data,
+    precomputed_ssp_mag_table,
+    z_phot_table,
+    wave_eff_table,
+    line_wave_table,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    cosmo_params,
+    fb,
+):
+    phot_kern_results, spec_kern_results = linelum_kernels._specphot_kern(
+        phot_randoms,
+        sfh_params,
+        z_obs,
+        t_obs,
+        mah_params,
+        ssp_data,
+        precomputed_ssp_mag_table,
+        z_phot_table,
+        wave_eff_table,
+        line_wave_table,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        cosmo_params,
+        fb,
+    )
+    dbk_phot_info, dbk_weights = _dbk_phot_kern(
+        phot_randoms,
+        sfh_params,
+        dbk_randoms,
+        z_obs,
+        t_obs,
+        mah_params,
+        ssp_data,
+        precomputed_ssp_mag_table,
+        z_phot_table,
+        wave_eff_table,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        cosmo_params,
+        fb,
+    )
+
+    _ret3 = dbk_kernels._get_dbk_phot_from_dbk_weights(
+        phot_kern_results.ssp_photflux_table,
+        dbk_weights,
+        phot_kern_results.dust_frac_trans,
+        phot_kern_results.frac_ssp_errors,
+    )
+    obs_mags_bulge, obs_mags_disk, obs_mags_knots = _ret3
+
+    _dbk_line_res = dbk_kernels._get_dbk_linelum_decomposition(
+        dbk_weights, spec_kern_results, ssp_data
+    )
+    linelum_bulge, linelum_disk, linelum_knots = _dbk_line_res
+
+    fbulge_params = dbk.FbulgeParams._make(
+        [getattr(dbk_phot_info, p) for p in dbk.FbulgeParams._fields]
+    )
+
+    dbk_specphot_info = MCDBKSpecPhotInfo(
+        **phot_kern_results._asdict(),
+        **phot_randoms._asdict(),
+        **dbk_randoms._asdict(),
+        **fbulge_params._asdict(),
+        bulge_to_total_history=dbk_phot_info.bulge_to_total_history,
+        logsm_bulge=jnp.log10(dbk_weights.mstar_bulge),
+        logsm_disk=jnp.log10(dbk_weights.mstar_disk),
+        logsm_knots=jnp.log10(dbk_weights.mstar_knots),
+        obs_mags_bulge=obs_mags_bulge,
+        obs_mags_disk=obs_mags_disk,
+        obs_mags_knots=obs_mags_knots,
+        linelum_gal=spec_kern_results.linelum_gal,
+        linelum_bulge=linelum_bulge,
+        linelum_disk=linelum_disk,
+        linelum_knots=linelum_knots,
+    )
+    return dbk_specphot_info, dbk_weights
+
+
+@jjit
+def _dbk_sed_kern(
+    mc_is_q,
+    uran_av,
+    uran_delta,
+    uran_funo,
+    uran_pburst,
+    delta_mag_ssp_scatter,
+    uran_fbulge,
+    fknot,
+    sfh_params,
+    z_obs,
+    t_obs,
+    mah_params,
+    ssp_data,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    cosmo_params,
+    fb,
+):
+    phot_randoms = mc_randoms.PhotRandoms(
+        mc_is_q,
+        uran_av,
+        uran_delta,
+        uran_funo,
+        uran_pburst,
+        delta_mag_ssp_scatter,
+    )
+    dbk_randoms = mc_randoms.DBKRandoms(fknot=fknot, uran_fbulge=uran_fbulge)
+    n_gals = z_obs.size
+    n_bands = 1
+    n_z = 2
+    z_phot_table = jnp.linspace(z_obs.min(), z_obs.max(), n_z)
+    n_met = ssp_data.ssp_lgmet.size
+    n_age = ssp_data.ssp_lg_age_gyr.size
+    precomputed_ssp_mag_table = jnp.ones((n_z, n_bands, n_met, n_age))
+    wave_eff_table = jnp.ones((n_z, n_bands))
+
+    dbk_phot_info, dbk_weights = _dbk_phot_kern(
+        phot_randoms,
+        sfh_params,
+        dbk_randoms,
+        z_obs,
+        t_obs,
+        mah_params,
+        ssp_data,
+        precomputed_ssp_mag_table,
+        z_phot_table,
+        wave_eff_table,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        cosmo_params,
+        fb,
+    )
+
+    n_gals = dbk_phot_info.logsm_obs.shape[0]
+    wave_eff_galpop = jnp.tile(ssp_data.ssp_wave, n_gals).reshape((n_gals, -1))
+
+    dust_frac_trans, __ = sspwk.compute_dust_attenuation(
+        dbk_phot_info.uran_av,
+        dbk_phot_info.uran_delta,
+        dbk_phot_info.uran_funo,
+        dbk_phot_info.logsm_obs,
+        dbk_phot_info.logssfr_obs,
+        ssp_data,
+        z_obs,
+        wave_eff_galpop,
+        spspop_params.dustpop_params,
+        scatter_params,
+    )
+
+    # Calculate mean fractional change to the SSP fluxes in each band for each galaxy
+    # L'_SSP(λ_eff) = L_SSP(λ_eff) & F_SSP(λ_eff)
+    frac_ssp_errors_nonoise = ssp_err_model.frac_ssp_err_at_z_obs_galpop(
+        ssperr_params, dbk_phot_info.logsm_obs, z_obs, wave_eff_galpop
+    )
+    frac_ssp_errors = ssp_err_model.get_noisy_frac_ssp_errors(
+        wave_eff_galpop, frac_ssp_errors_nonoise, dbk_phot_info.delta_mag_ssp_scatter
+    )
+
+    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+    dust_frac_trans = dust_frac_trans.swapaxes(1, 2)  # (n_gals, n_age, n_wave)
+
+    a = dust_frac_trans.reshape((n_gals, 1, n_age, n_wave))
+    b = frac_ssp_errors.reshape((n_gals, 1, 1, n_wave))
+    d = ssp_data.ssp_flux.reshape((1, n_met, n_age, n_wave))
+
+    _w_bulge = dbk_weights.ssp_weights_bulge.reshape((n_gals, n_met, n_age, 1))
+    _w_dd = dbk_weights.ssp_weights_disk.reshape((n_gals, n_met, n_age, 1))
+    _w_knot = dbk_weights.ssp_weights_knots.reshape((n_gals, n_met, n_age, 1))
+
+    mb = dbk_weights.mstar_bulge.reshape((n_gals, 1))
+    md = dbk_weights.mstar_disk.reshape((n_gals, 1))
+    mk = dbk_weights.mstar_knots.reshape((n_gals, 1))
+
+    sed_bulge = jnp.sum(a * b * _w_bulge * d, axis=(1, 2)) * mb
+    sed_disk = jnp.sum(a * b * _w_dd * d, axis=(1, 2)) * md
+    sed_knots = jnp.sum(a * b * _w_knot * d, axis=(1, 2)) * mk
+
+    sed_info = DBKSEDInfo(sed_bulge, sed_disk, sed_knots)
+
+    return sed_info, dbk_weights
+
+
+DBK_PHOT_EXTRA_FIELDS = (
+    *dbk.FbulgeParams._fields,
+    "bulge_to_total_history",
+    "logsm_bulge",
+    "logsm_disk",
+    "logsm_knots",
+    "obs_mags_bulge",
+    "obs_mags_disk",
+    "obs_mags_knots",
+)
+MCDBKPhotInfo = namedtuple(
+    "MCDBKPhotInfo",
+    (
+        *phot_kernels.PhotKernResults._fields,
+        *mc_randoms.PhotRandoms._fields,
+        *mc_randoms.DBKRandoms._fields,
+        *DBK_PHOT_EXTRA_FIELDS,
+    ),
+)
+
+_dbk_specphot_keys = (
+    *MCDBKPhotInfo._fields,
+    *("linelum_gal", "linelum_bulge", "linelum_disk", "linelum_knots"),
+)
+MCDBKSpecPhotInfo = namedtuple("MCDBKSpecPhotInfo", _dbk_specphot_keys)
+
+DBKSEDInfo = namedtuple(
+    "DBKSEDInfo", ("rest_sed_bulge", "rest_sed_disk", "rest_sed_knots")
+)

--- a/diffsky/experimental/kernels/gd_dbk_specphot_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_specphot_kernels.py
@@ -6,9 +6,10 @@ from dsps.sfh.diffburst import DEFAULT_BURST_PARAMS
 from jax import jit as jjit
 from jax import numpy as jnp
 
+from ...merging import merging_model
 from ...ssp_err_model import ssp_err_model
 from ..disk_bulge_modeling import disk_bulge_kernels as dbk
-from . import dbk_kernels, linelum_kernels, mc_randoms, phot_kernels
+from . import dbk_kernels, gd_linelum_kernels, gd_phot_kernels, mc_randoms
 from . import ssp_weight_kernels as sspwk
 
 
@@ -18,6 +19,10 @@ def _mc_dbk_phot_kern(
     z_obs,
     t_obs,
     mah_params,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
     ssp_data,
     precomputed_ssp_mag_table,
     z_phot_table,
@@ -27,19 +32,35 @@ def _mc_dbk_phot_kern(
     spspop_params,
     scatter_params,
     ssperr_params,
+    merging_params,
     cosmo_params,
     fb,
 ):
-    phot_randoms, sfh_params, dbk_randoms = mc_randoms.get_mc_dbk_phot_randoms(
-        ran_key, diffstarpop_params, mah_params, cosmo_params
+    phot_randoms, diffstarpop_results, dbk_randoms = mc_randoms.get_dbk_phot_randoms(
+        ran_key,
+        diffstarpop_params,
+        mah_params,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        cosmo_params,
     )
+
+    t_infall = t_obs - gyr_since_infall
+    logmp_infall = lgmu_infall + logmhost_infall
+    p_merge_smooth = merging_model.get_p_merge_from_merging_params(
+        merging_params, logmp_infall, logmhost_infall, t_obs, t_infall, upid
+    )
+
     dbk_phot_info, dbk_weights = _dbk_phot_kern(
         phot_randoms,
-        sfh_params,
+        diffstarpop_results,
         dbk_randoms,
         z_obs,
         t_obs,
         mah_params,
+        p_merge_smooth,
         ssp_data,
         precomputed_ssp_mag_table,
         z_phot_table,
@@ -58,11 +79,12 @@ def _mc_dbk_phot_kern(
 @jjit
 def _dbk_phot_kern(
     phot_randoms,
-    sfh_params,
+    diffstarpop_results,
     dbk_randoms,
     z_obs,
     t_obs,
     mah_params,
+    p_merge_smooth,
     ssp_data,
     precomputed_ssp_mag_table,
     z_phot_table,
@@ -74,12 +96,13 @@ def _dbk_phot_kern(
     cosmo_params,
     fb,
 ):
-    phot_kern_results = phot_kernels._phot_kern(
+    phot_kern_results = gd_phot_kernels._phot_kern(
         phot_randoms,
-        sfh_params,
+        diffstarpop_results,
         z_obs,
         t_obs,
         mah_params,
+        p_merge_smooth,
         ssp_data,
         precomputed_ssp_mag_table,
         z_phot_table,
@@ -137,6 +160,10 @@ def _mc_dbk_specphot_kern(
     z_obs,
     t_obs,
     mah_params,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
     ssp_data,
     precomputed_ssp_mag_table,
     z_phot_table,
@@ -147,19 +174,35 @@ def _mc_dbk_specphot_kern(
     spspop_params,
     scatter_params,
     ssperr_params,
+    merging_params,
     cosmo_params,
     fb,
 ):
-    phot_randoms, sfh_params, dbk_randoms = mc_randoms.get_mc_dbk_phot_randoms(
-        ran_key, diffstarpop_params, mah_params, cosmo_params
+    phot_randoms, diffstarpop_results, dbk_randoms = mc_randoms.get_dbk_phot_randoms(
+        ran_key,
+        diffstarpop_params,
+        mah_params,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        cosmo_params,
     )
+
+    t_infall = t_obs - gyr_since_infall
+    logmp_infall = lgmu_infall + logmhost_infall
+    p_merge_smooth = merging_model.get_p_merge_from_merging_params(
+        merging_params, logmp_infall, logmhost_infall, t_obs, t_infall, upid
+    )
+
     dbk_specphot_info, dbk_weights = _dbk_specphot_kern(
         phot_randoms,
-        sfh_params,
+        diffstarpop_results,
         dbk_randoms,
         z_obs,
         t_obs,
         mah_params,
+        p_merge_smooth,
         ssp_data,
         precomputed_ssp_mag_table,
         z_phot_table,
@@ -178,11 +221,12 @@ def _mc_dbk_specphot_kern(
 @jjit
 def _dbk_specphot_kern(
     phot_randoms,
-    sfh_params,
+    diffstarpop_results,
     dbk_randoms,
     z_obs,
     t_obs,
     mah_params,
+    p_merge_smooth,
     ssp_data,
     precomputed_ssp_mag_table,
     z_phot_table,
@@ -195,12 +239,13 @@ def _dbk_specphot_kern(
     cosmo_params,
     fb,
 ):
-    phot_kern_results, spec_kern_results = linelum_kernels._specphot_kern(
+    phot_kern_results, spec_kern_results = gd_linelum_kernels._specphot_kern(
         phot_randoms,
-        sfh_params,
+        diffstarpop_results,
         z_obs,
         t_obs,
         mah_params,
+        p_merge_smooth,
         ssp_data,
         precomputed_ssp_mag_table,
         z_phot_table,
@@ -215,11 +260,12 @@ def _dbk_specphot_kern(
     )
     dbk_phot_info, dbk_weights = _dbk_phot_kern(
         phot_randoms,
-        sfh_params,
+        diffstarpop_results,
         dbk_randoms,
         z_obs,
         t_obs,
         mah_params,
+        p_merge_smooth,
         ssp_data,
         precomputed_ssp_mag_table,
         z_phot_table,
@@ -279,7 +325,7 @@ def _dbk_sed_kern(
     delta_mag_ssp_scatter,
     uran_fbulge,
     fknot,
-    sfh_params,
+    diffstarpop_results,
     z_obs,
     t_obs,
     mah_params,
@@ -311,11 +357,12 @@ def _dbk_sed_kern(
 
     dbk_phot_info, dbk_weights = _dbk_phot_kern(
         phot_randoms,
-        sfh_params,
+        diffstarpop_results,
         dbk_randoms,
         z_obs,
         t_obs,
         mah_params,
+        p_merge_smooth,
         ssp_data,
         precomputed_ssp_mag_table,
         z_phot_table,
@@ -390,7 +437,7 @@ DBK_PHOT_EXTRA_FIELDS = (
 MCDBKPhotInfo = namedtuple(
     "MCDBKPhotInfo",
     (
-        *phot_kernels.PhotKernResults._fields,
+        *gd_phot_kernels.PhotKernResults._fields,
         *mc_randoms.PhotRandoms._fields,
         *mc_randoms.DBKRandoms._fields,
         *DBK_PHOT_EXTRA_FIELDS,

--- a/diffsky/experimental/kernels/gd_dbk_specphot_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_specphot_kernels.py
@@ -318,6 +318,7 @@ def _dbk_specphot_kern(
         obs_mags_disk=obs_mags_disk,
         obs_mags_knots=obs_mags_knots,
         linelum_gal=spec_kern_results.linelum_gal,
+        linelum_weighted=spec_kern_results.linelum_weighted,
         linelum_bulge=linelum_bulge,
         linelum_disk=linelum_disk,
         linelum_knots=linelum_knots,
@@ -467,7 +468,13 @@ MCDBKPhotInfo = namedtuple(
 
 _dbk_specphot_keys = (
     *MCDBKPhotInfo._fields,
-    *("linelum_gal", "linelum_bulge", "linelum_disk", "linelum_knots"),
+    *(
+        "linelum_gal",
+        "linelum_weighted",
+        "linelum_bulge",
+        "linelum_disk",
+        "linelum_knots",
+    ),
 )
 MCDBKSpecPhotInfo = namedtuple("MCDBKSpecPhotInfo", _dbk_specphot_keys)
 

--- a/diffsky/experimental/kernels/gd_dbk_specphot_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_specphot_kernels.py
@@ -329,11 +329,16 @@ def _dbk_sed_kern(
     z_obs,
     t_obs,
     mah_params,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
     ssp_data,
     mzr_params,
     spspop_params,
     scatter_params,
     ssperr_params,
+    merging_params,
     cosmo_params,
     fb,
 ):
@@ -354,6 +359,12 @@ def _dbk_sed_kern(
     n_age = ssp_data.ssp_lg_age_gyr.size
     precomputed_ssp_mag_table = jnp.ones((n_z, n_bands, n_met, n_age))
     wave_eff_table = jnp.ones((n_z, n_bands))
+
+    t_infall = t_obs - gyr_since_infall
+    logmp_infall = lgmu_infall + logmhost_infall
+    p_merge_smooth = merging_model.get_p_merge_from_merging_params(
+        merging_params, logmp_infall, logmhost_infall, t_obs, t_infall, upid
+    )
 
     dbk_phot_info, dbk_weights = _dbk_phot_kern(
         phot_randoms,

--- a/diffsky/experimental/kernels/gd_dbk_specphot_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_dbk_specphot_kernels_merging.py
@@ -167,7 +167,7 @@ def _dbk_specphot_kern_merging(
     _res = gd_spkm._get_linelum_kern_merging_quantities(*args)
     linelums_obs, linelum_in_situ_mc, linelum_weighted, linelum_in_situ_weighted = _res
 
-    dbk_specphot_info = gd_spkm._get_linelum_results_with_merging(
+    dbk_specphot_info = gd_spkm._update_linelum_results_with_merging(
         dbk_specphot_info,
         linelums_obs,
         linelum_in_situ_mc,
@@ -175,14 +175,14 @@ def _dbk_specphot_kern_merging(
         linelum_in_situ_weighted,
     )
 
-    dbk_specphot_info, dbk_weights = _get_dbk_specphot_info_with_merging(
+    dbk_specphot_info, dbk_weights = _update_dbk_specphot_info_with_merging(
         dbk_specphot_info, dbk_weights, mstar_in_situ, mstar_obs, flux_in_situ, flux_obs
     )
     return dbk_specphot_info, dbk_weights
 
 
 @jjit
-def _get_dbk_specphot_info_with_merging(
+def _update_dbk_specphot_info_with_merging(
     dbk_specphot_info, dbk_weights, mstar_in_situ, mstar_obs, flux_in_situ, flux_obs
 ):
     n_gals = dbk_specphot_info.logsm_obs.size

--- a/diffsky/experimental/kernels/gd_dbk_specphot_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_dbk_specphot_kernels_merging.py
@@ -1,0 +1,224 @@
+""""""
+
+from collections import namedtuple
+
+from jax import jit as jjit
+from jax import numpy as jnp
+
+from ...merging import merging_model
+from . import gd_dbk_specphot_kernels as gd_dbkspk
+from . import gd_phot_kernels_merging as gd_pkm
+from . import gd_specphot_kernels_merging as gd_spkm
+from . import mc_randoms
+
+
+@jjit
+def _mc_dbk_specphot_kern_merging(
+    ran_key,
+    z_obs,
+    t_obs,
+    mah_params,
+    ssp_data,
+    precomputed_ssp_mag_table,
+    z_phot_table,
+    wave_eff_table,
+    line_wave_table,
+    diffstarpop_params,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    merging_params,
+    cosmo_params,
+    fb,
+    logmp_infall,
+    logmhost_infall,
+    t_infall,
+    is_central,
+    sat_weights,
+    halo_indx,
+    mc_merge,
+):
+    upid = jnp.where(is_central == 1, -1, halo_indx)
+    lgmu_infall = logmp_infall - logmhost_infall
+    gyr_since_infall = t_obs - t_infall
+    _res = mc_randoms.get_dbk_phot_merge_randoms(
+        ran_key,
+        diffstarpop_params,
+        mah_params,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        cosmo_params,
+    )
+    phot_randoms, diffstarpop_results, dbk_randoms, merging_randoms = _res
+
+    dbk_specphot_info, dbk_weights = _dbk_specphot_kern_merging(
+        phot_randoms,
+        diffstarpop_results,
+        dbk_randoms,
+        merging_randoms,
+        z_obs,
+        t_obs,
+        mah_params,
+        ssp_data,
+        precomputed_ssp_mag_table,
+        z_phot_table,
+        wave_eff_table,
+        line_wave_table,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        merging_params,
+        cosmo_params,
+        fb,
+        logmp_infall,
+        logmhost_infall,
+        t_infall,
+        is_central,
+        sat_weights,
+        halo_indx,
+        mc_merge,
+    )
+    return dbk_specphot_info, dbk_weights
+
+
+@jjit
+def _dbk_specphot_kern_merging(
+    phot_randoms,
+    diffstarpop_results,
+    dbk_randoms,
+    merging_randoms,
+    z_obs,
+    t_obs,
+    mah_params,
+    ssp_data,
+    precomputed_ssp_mag_table,
+    z_phot_table,
+    wave_eff_table,
+    line_wave_table,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    merging_params,
+    cosmo_params,
+    fb,
+    logmp_infall,
+    logmhost_infall,
+    t_infall,
+    is_central,
+    sat_weights,
+    halo_indx,
+    mc_merge,
+):
+    upid = jnp.where(is_central == 1, -1, halo_indx)
+    p_merge_smooth = merging_model.get_p_merge_from_merging_params(
+        merging_params, logmp_infall, logmhost_infall, t_obs, t_infall, upid
+    )
+
+    dbk_specphot_info, dbk_weights = gd_dbkspk._dbk_specphot_kern(
+        phot_randoms,
+        diffstarpop_results,
+        dbk_randoms,
+        z_obs,
+        t_obs,
+        mah_params,
+        p_merge_smooth,
+        ssp_data,
+        precomputed_ssp_mag_table,
+        z_phot_table,
+        wave_eff_table,
+        line_wave_table,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        cosmo_params,
+        fb,
+    )
+
+    _res = gd_pkm._get_phot_kern_merging_quantities(
+        dbk_specphot_info,
+        merging_randoms,
+        p_merge_smooth,
+        sat_weights,
+        halo_indx,
+        mc_merge,
+    )
+    mstar_in_situ, mstar_obs, flux_in_situ, flux_obs, flux_obs_weighted, p_merge = _res
+
+    args = (
+        dbk_specphot_info,
+        mstar_in_situ,
+        mstar_obs,
+        flux_in_situ,
+        flux_obs,
+        flux_obs_weighted,
+        p_merge,
+        merging_randoms.uran_pmerge,
+    )
+    func = gd_pkm._update_phot_kern_results_with_merging
+    dbk_specphot_info = func(*args)
+
+    args = dbk_specphot_info, dbk_specphot_info, sat_weights, halo_indx
+    _res = gd_spkm._get_linelum_kern_merging_quantities(*args)
+    linelums_obs, linelum_in_situ_mc, linelum_weighted, linelum_in_situ_weighted = _res
+
+    dbk_specphot_info = gd_spkm._get_linelum_results_with_merging(
+        dbk_specphot_info,
+        linelums_obs,
+        linelum_in_situ_mc,
+        linelum_weighted,
+        linelum_in_situ_weighted,
+    )
+
+    dbk_specphot_info, dbk_weights = _get_dbk_specphot_info_with_merging(
+        dbk_specphot_info, dbk_weights, mstar_in_situ, mstar_obs, flux_in_situ, flux_obs
+    )
+    return dbk_specphot_info, dbk_weights
+
+
+@jjit
+def _get_dbk_specphot_info_with_merging(
+    dbk_specphot_info, dbk_weights, mstar_in_situ, mstar_obs, flux_in_situ, flux_obs
+):
+    n_gals = dbk_specphot_info.logsm_obs.size
+
+    frac_dm = mstar_obs / mstar_in_situ
+    dmag = -2.5 * jnp.log10(flux_obs / flux_in_situ)
+
+    ex_situ_dict = dict()
+    in_situ_dict = dict()
+
+    mstar_colnames = ("mstar_bulge", "mstar_disk", "mstar_knots")
+    for name in mstar_colnames:
+        outname = name.replace("mstar", "logsm")
+        ex_situ_dict[outname] = jnp.log10(getattr(dbk_weights, name) * frac_dm)
+        in_situ_dict[outname + "_in_situ"] = jnp.log10(getattr(dbk_weights, name))
+
+    mag_colnames = ("obs_mags_bulge", "obs_mags_disk", "obs_mags_knots")
+    for name in mag_colnames:
+        ex_situ_dict[name] = getattr(dbk_specphot_info, name) + dmag
+        in_situ_dict[name + "_in_situ"] = getattr(dbk_specphot_info, name)
+
+    line_colnames = ("linelum_bulge", "linelum_disk", "linelum_knots")
+    for name in line_colnames:
+        _f = frac_dm.reshape((n_gals, 1))
+        ex_situ_dict[name] = getattr(dbk_specphot_info, name) * _f
+        in_situ_dict[name + "_in_situ"] = getattr(dbk_specphot_info, name)
+
+    dbk_specphot_info = dbk_specphot_info._replace(**ex_situ_dict)
+    dbk_weights = dbk_weights._replace(
+        mstar_bulge=dbk_weights.mstar_bulge * frac_dm,
+        mstar_disk=dbk_weights.mstar_disk * frac_dm,
+        mstar_knots=dbk_weights.mstar_knots * frac_dm,
+    )
+
+    new_keys = list(in_situ_dict.keys())
+    dbk_specphot_info_keys = list(dbk_specphot_info._fields) + new_keys
+    MCDBKSpecPhotInfo = namedtuple("MCDBKSpecPhotInfo", dbk_specphot_info_keys)
+    dbk_specphot_info = MCDBKSpecPhotInfo(**dbk_specphot_info._asdict(), **in_situ_dict)
+    return dbk_specphot_info, dbk_weights

--- a/diffsky/experimental/kernels/gd_linelum_kernels.py
+++ b/diffsky/experimental/kernels/gd_linelum_kernels.py
@@ -111,7 +111,7 @@ def _specphot_kern(
         fb,
     )
 
-    _dust_res = sspwk.compute_dust_attenuation_lines(
+    _dust_res_mc = sspwk.compute_dust_attenuation_lines(
         phot_randoms.uran_av,
         phot_randoms.uran_delta,
         phot_randoms.uran_funo,
@@ -123,18 +123,96 @@ def _specphot_kern(
         spspop_params.dustpop_params,
         scatter_params,
     )
-    dust_ftrans_lines = _dust_res[0]
+    dust_ftrans_lines_mc = _dust_res_mc[0]
 
     linelum_gal = sspwk._compute_linelum_from_weights(
         phot_kern_results.logsm_obs,
-        dust_ftrans_lines,
+        dust_ftrans_lines_mc,
         ssp_data,
         phot_kern_results.ssp_weights,
     )
 
-    spec_kern_results = SpecKernResults(linelum_gal, dust_ftrans_lines)
+    _dust_res_q = sspwk.compute_dust_attenuation_lines(
+        phot_randoms.uran_av,
+        phot_randoms.uran_delta,
+        phot_randoms.uran_funo,
+        phot_kern_results.diffstar_info_q.logsm_obs,
+        phot_kern_results.diffstar_info_q.logssfr_obs,
+        ssp_data,
+        z_obs,
+        line_wave_table,
+        spspop_params.dustpop_params,
+        scatter_params,
+    )
+    dust_ftrans_lines_q = _dust_res_q[0]
+
+    linelum_q = sspwk._compute_linelum_from_weights(
+        phot_kern_results.diffstar_info_q.logsm_obs,
+        dust_ftrans_lines_q,
+        ssp_data,
+        phot_kern_results.burstiness_info_q.ssp_weights_smooth,
+    )
+
+    _dust_res_ms = sspwk.compute_dust_attenuation_lines(
+        phot_randoms.uran_av,
+        phot_randoms.uran_delta,
+        phot_randoms.uran_funo,
+        phot_kern_results.diffstar_info_ms.logsm_obs,
+        phot_kern_results.diffstar_info_ms.logssfr_obs,
+        ssp_data,
+        z_obs,
+        line_wave_table,
+        spspop_params.dustpop_params,
+        scatter_params,
+    )
+    dust_ftrans_lines_ms = _dust_res_ms[0]
+
+    linelum_ms = sspwk._compute_linelum_from_weights(
+        phot_kern_results.diffstar_info_ms.logsm_obs,
+        dust_ftrans_lines_ms,
+        ssp_data,
+        phot_kern_results.burstiness_info_ms.ssp_weights_smooth,
+    )
+
+    linelum_bursty = sspwk._compute_linelum_from_weights(
+        phot_kern_results.diffstar_info_ms.logsm_obs,
+        dust_ftrans_lines_ms,
+        ssp_data,
+        phot_kern_results.burstiness_info_ms.ssp_weights_bursty,
+    )
+
+    n_gals = linelum_q.shape[0]
+    fq = diffstarpop_results.frac_q
+    weights_q = fq
+    weights_ms = (1 - fq) * (1 - phot_kern_results.burstiness_info_ms.p_burst)
+    weights_bursty = (1 - fq) * phot_kern_results.burstiness_info_ms.p_burst
+
+    linelum_weighted = (
+        (weights_q.reshape((n_gals, 1)) * linelum_q)
+        + (weights_ms.reshape((n_gals, 1)) * linelum_ms)
+        + (weights_bursty.reshape((n_gals, 1)) * linelum_bursty)
+    )
+
+    spec_kern_results = SpecKernResults(
+        linelum_gal,
+        linelum_weighted,
+        dust_ftrans_lines_mc,
+        linelum_ms,
+        linelum_q,
+        linelum_bursty,
+    )
 
     return phot_kern_results, spec_kern_results
 
 
-SpecKernResults = namedtuple("SpecKernResults", ("linelum_gal", "dust_ftrans_lines"))
+SpecKernResults = namedtuple(
+    "SpecKernResults",
+    (
+        "linelum_gal",
+        "linelum_weighted",
+        "dust_ftrans_lines",
+        "linelum_ms",
+        "linelum_q",
+        "linelum_bursty",
+    ),
+)

--- a/diffsky/experimental/kernels/gd_linelum_kernels.py
+++ b/diffsky/experimental/kernels/gd_linelum_kernels.py
@@ -1,0 +1,140 @@
+""""""
+
+from collections import namedtuple
+
+from jax import jit as jjit
+
+from ...merging import merging_model
+from . import gd_phot_kernels, mc_randoms
+from . import ssp_weight_kernels as sspwk
+
+
+@jjit
+def _mc_specphot_kern(
+    ran_key,
+    z_obs,
+    t_obs,
+    mah_params,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
+    ssp_data,
+    precomputed_ssp_mag_table,
+    z_phot_table,
+    wave_eff_table,
+    line_wave_table,
+    diffstarpop_params,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    merging_params,
+    cosmo_params,
+    fb,
+):
+    phot_randoms, diffstarpop_results = mc_randoms.get_phot_randoms(
+        ran_key,
+        diffstarpop_params,
+        mah_params,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        cosmo_params,
+    )
+    t_infall = t_obs - gyr_since_infall
+    logmp_infall = lgmu_infall + logmhost_infall
+    p_merge_smooth = merging_model.get_p_merge_from_merging_params(
+        merging_params, logmp_infall, logmhost_infall, t_obs, t_infall, upid
+    )
+
+    phot_kern_results, spec_kern_results = _specphot_kern(
+        phot_randoms,
+        diffstarpop_results,
+        z_obs,
+        t_obs,
+        mah_params,
+        p_merge_smooth,
+        ssp_data,
+        precomputed_ssp_mag_table,
+        z_phot_table,
+        wave_eff_table,
+        line_wave_table,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        cosmo_params,
+        fb,
+    )
+
+    return phot_kern_results, phot_randoms, spec_kern_results
+
+
+@jjit
+def _specphot_kern(
+    phot_randoms,
+    diffstarpop_results,
+    z_obs,
+    t_obs,
+    mah_params,
+    p_merge_smooth,
+    ssp_data,
+    precomputed_ssp_mag_table,
+    z_phot_table,
+    wave_eff_table,
+    line_wave_table,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    cosmo_params,
+    fb,
+):
+    phot_kern_results = gd_phot_kernels._phot_kern(
+        phot_randoms,
+        diffstarpop_results,
+        z_obs,
+        t_obs,
+        mah_params,
+        p_merge_smooth,
+        ssp_data,
+        precomputed_ssp_mag_table,
+        z_phot_table,
+        wave_eff_table,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        cosmo_params,
+        fb,
+    )
+
+    _dust_res = sspwk.compute_dust_attenuation_lines(
+        phot_randoms.uran_av,
+        phot_randoms.uran_delta,
+        phot_randoms.uran_funo,
+        phot_kern_results.logsm_obs,
+        phot_kern_results.logssfr_obs,
+        ssp_data,
+        z_obs,
+        line_wave_table,
+        spspop_params.dustpop_params,
+        scatter_params,
+    )
+    dust_ftrans_lines = _dust_res[0]
+
+    linelum_gal = sspwk._compute_linelum_from_weights(
+        phot_kern_results.logsm_obs,
+        dust_ftrans_lines,
+        ssp_data,
+        phot_kern_results.ssp_weights,
+    )
+
+    spec_kern_results = SpecKernResults(linelum_gal, dust_ftrans_lines)
+
+    return phot_kern_results, spec_kern_results
+
+
+SpecKernResults = namedtuple("SpecKernResults", ("linelum_gal", "dust_ftrans_lines"))

--- a/diffsky/experimental/kernels/gd_mc_phot_kernels.py
+++ b/diffsky/experimental/kernels/gd_mc_phot_kernels.py
@@ -1,0 +1,50 @@
+""""""
+
+from . import (
+    constants,
+    dbk_kernels,
+    dbk_specphot_kernels,
+    gd_linelum_kernels,
+    gd_phot_kernels,
+    gd_phot_kernels_merging,
+    gd_specphot_kernels_merging,
+    mc_randoms,
+    sed_kernels,
+)
+
+# constants
+LGMET_SCATTER = constants.LGMET_SCATTER
+
+
+# kernels
+_mc_phot_kern = gd_phot_kernels._mc_phot_kern
+_phot_kern = gd_phot_kernels._phot_kern
+_mc_dbk_kern = dbk_kernels._mc_dbk_kern
+_dbk_kern = dbk_kernels._dbk_kern  # noqa
+_mc_specphot_kern = gd_linelum_kernels._mc_specphot_kern
+_specphot_kern = gd_linelum_kernels._specphot_kern
+_get_dbk_phot_from_dbk_weights = dbk_kernels._get_dbk_phot_from_dbk_weights
+_sed_kern = sed_kernels._sed_kern
+_get_dbk_linelum_decomposition = dbk_kernels._get_dbk_linelum_decomposition
+_mc_phot_kern_merging = gd_phot_kernels_merging._mc_phot_kern_merging
+_phot_kern_merging = gd_phot_kernels_merging._phot_kern_merging
+_mc_specphot_kern_merging = gd_specphot_kernels_merging._mc_specphot_kern_merging
+_specphot_kern_merging = gd_specphot_kernels_merging._specphot_kern_merging
+
+_mc_dbk_phot_kern = dbk_specphot_kernels._mc_dbk_phot_kern
+_mc_dbk_specphot_kern = dbk_specphot_kernels._mc_dbk_specphot_kern
+interp_vmap2 = gd_phot_kernels.interp_vmap2
+
+
+# randoms
+get_mc_phot_randoms = mc_randoms.get_mc_phot_randoms
+get_mc_dbk_randoms = mc_randoms.get_mc_dbk_randoms
+
+# namedtuple containers
+PhotRandoms = mc_randoms.PhotRandoms
+SpecKernResults = gd_linelum_kernels.SpecKernResults
+PhotKernResults = gd_phot_kernels.PhotKernResults
+DBKRandoms = mc_randoms.DBKRandoms
+SEDKernResults = sed_kernels.SEDKernResults
+SEDKernResults = sed_kernels.SEDKernResults
+MCDBKPhotInfo = dbk_specphot_kernels.MCDBKPhotInfo

--- a/diffsky/experimental/kernels/gd_phot_kernels.py
+++ b/diffsky/experimental/kernels/gd_phot_kernels.py
@@ -135,7 +135,7 @@ def _phot_kern(
         n_t_table,
     )
 
-    smooth_ssp_weights_mc = sspwk.get_smooth_ssp_weights(
+    smooth_ssp_weights_mc = rq.get_smooth_ssp_weights_rq(
         diffstar_info_mc.t_table,
         diffstar_info_mc.sfh_table,
         diffstar_info_mc.logsm_obs,
@@ -143,9 +143,10 @@ def _phot_kern(
         t_obs,
         mzr_params,
         LGMET_SCATTER,
+        p_merge_smooth,
     )
 
-    smooth_ssp_weights_q = sspwk.get_smooth_ssp_weights(
+    smooth_ssp_weights_q = rq.get_smooth_ssp_weights_rq(
         diffstar_info_q.t_table,
         diffstar_info_q.sfh_table,
         diffstar_info_q.logsm_obs,
@@ -153,8 +154,9 @@ def _phot_kern(
         t_obs,
         mzr_params,
         LGMET_SCATTER,
+        p_merge_smooth,
     )
-    smooth_ssp_weights_ms = sspwk.get_smooth_ssp_weights(
+    smooth_ssp_weights_ms = rq.get_smooth_ssp_weights_rq(
         diffstar_info_ms.t_table,
         diffstar_info_ms.sfh_table,
         diffstar_info_ms.logsm_obs,
@@ -162,16 +164,7 @@ def _phot_kern(
         t_obs,
         mzr_params,
         LGMET_SCATTER,
-    )
-
-    smooth_ssp_weights_mc = rq.modify_smooth_ssp_weights_with_rapid_quenching(
-        smooth_ssp_weights_mc, p_merge_smooth, ssp_data
-    )
-    smooth_ssp_weights_ms = rq.modify_smooth_ssp_weights_with_rapid_quenching(
-        smooth_ssp_weights_ms, p_merge_smooth, ssp_data
-    )
-    smooth_ssp_weights_q = rq.modify_smooth_ssp_weights_with_rapid_quenching(
-        smooth_ssp_weights_q, p_merge_smooth, ssp_data
+        p_merge_smooth,
     )
 
     burstiness_info_mc = rq.get_burstiness_rq(

--- a/diffsky/experimental/kernels/gd_phot_kernels.py
+++ b/diffsky/experimental/kernels/gd_phot_kernels.py
@@ -164,7 +164,17 @@ def _phot_kern(
         LGMET_SCATTER,
     )
 
-    burstiness_info_mc = sspwk.get_burstiness(
+    smooth_ssp_weights_mc = rq.modify_smooth_ssp_weights_with_rapid_quenching(
+        smooth_ssp_weights_mc, p_merge_smooth, ssp_data
+    )
+    smooth_ssp_weights_ms = rq.modify_smooth_ssp_weights_with_rapid_quenching(
+        smooth_ssp_weights_ms, p_merge_smooth, ssp_data
+    )
+    smooth_ssp_weights_q = rq.modify_smooth_ssp_weights_with_rapid_quenching(
+        smooth_ssp_weights_q, p_merge_smooth, ssp_data
+    )
+
+    burstiness_info_mc = rq.get_burstiness_rq(
         phot_randoms.uran_pburst,
         phot_randoms.mc_is_q,
         diffstar_info_mc.logsm_obs,
@@ -173,16 +183,10 @@ def _phot_kern(
         smooth_ssp_weights_mc.lgmet_weights,
         ssp_data,
         spspop_params.burstpop_params,
-    )
-
-    burstiness_info_mc = rq.modify_burstiness_info_with_rapid_quenching(
-        burstiness_info_mc,
         p_merge_smooth,
-        ssp_data,
-        smooth_ssp_weights_mc.lgmet_weights,
     )
 
-    burstiness_info_ms = sspwk.get_burstiness(
+    burstiness_info_ms = rq.get_burstiness_rq(
         phot_randoms.uran_pburst,
         phot_randoms.mc_is_q,
         diffstar_info_ms.logsm_obs,
@@ -191,15 +195,10 @@ def _phot_kern(
         smooth_ssp_weights_ms.lgmet_weights,
         ssp_data,
         spspop_params.burstpop_params,
-    )
-    burstiness_info_ms = rq.modify_burstiness_info_with_rapid_quenching(
-        burstiness_info_ms,
         p_merge_smooth,
-        ssp_data,
-        smooth_ssp_weights_ms.lgmet_weights,
     )
 
-    burstiness_info_q = sspwk.get_burstiness(
+    burstiness_info_q = rq.get_burstiness_rq(
         phot_randoms.uran_pburst,
         phot_randoms.mc_is_q,
         diffstar_info_q.logsm_obs,
@@ -208,12 +207,7 @@ def _phot_kern(
         smooth_ssp_weights_q.lgmet_weights,
         ssp_data,
         spspop_params.burstpop_params,
-    )
-    burstiness_info_q = rq.modify_burstiness_info_with_rapid_quenching(
-        burstiness_info_q,
         p_merge_smooth,
-        ssp_data,
-        smooth_ssp_weights_q.lgmet_weights,
     )
 
     dust_frac_trans_mc, dust_params_mc = sspwk.compute_dust_attenuation(

--- a/diffsky/experimental/kernels/gd_phot_kernels.py
+++ b/diffsky/experimental/kernels/gd_phot_kernels.py
@@ -351,6 +351,8 @@ def _phot_kern(
         obs_mags_weighted,
         diffstar_info_ms,
         diffstar_info_q,
+        burstiness_info_ms,
+        burstiness_info_q,
     )
     return phot_kern_results
 
@@ -378,5 +380,7 @@ PHOT_KERN_KEYS = (
     "obs_mags_weighted",
     "diffstar_info_ms",
     "diffstar_info_q",
+    "burstiness_info_ms",
+    "burstiness_info_q",
 )
 PhotKernResults = namedtuple("PhotKernResults", PHOT_KERN_KEYS)

--- a/diffsky/experimental/kernels/gd_phot_kernels.py
+++ b/diffsky/experimental/kernels/gd_phot_kernels.py
@@ -10,13 +10,13 @@ from jax import numpy as jnp
 from jax import vmap
 
 from ...dustpop.tw_dust import DEFAULT_DUST_PARAMS
+from ...merging import merging_model
 from ...ssp_err_model import ssp_err_model
 from .. import mc_diffstarpop_wrappers as mcdw
 from .. import photometry_interpolation as photerp
 from . import constants, mc_randoms
-from . import ssp_weight_kernels as sspwk
 from . import rapid_quenching as rq
-from ...merging import merging_model
+from . import ssp_weight_kernels as sspwk
 
 LGMET_SCATTER = constants.LGMET_SCATTER
 
@@ -349,6 +349,8 @@ def _phot_kern(
         obs_mags_bursty,
         diffstarpop_results.frac_q,
         obs_mags_weighted,
+        diffstar_info_ms,
+        diffstar_info_q,
     )
     return phot_kern_results
 
@@ -374,5 +376,7 @@ PHOT_KERN_KEYS = (
     "obs_mags_bursty",
     "frac_q",
     "obs_mags_weighted",
+    "diffstar_info_ms",
+    "diffstar_info_q",
 )
 PhotKernResults = namedtuple("PhotKernResults", PHOT_KERN_KEYS)

--- a/diffsky/experimental/kernels/gd_specphot_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_specphot_kernels_merging.py
@@ -164,7 +164,7 @@ def _specphot_kern_merging(
     _res = _get_linelum_kern_merging_quantities(*args)
     linelums_obs, linelum_in_situ_mc, linelum_weighted, linelum_in_situ_weighted = _res
 
-    spec_kern_results = _get_linelum_results_with_merging(
+    spec_kern_results = _update_linelum_results_with_merging(
         spec_kern_results,
         linelums_obs,
         linelum_in_situ_mc,
@@ -199,7 +199,7 @@ def _get_linelum_kern_merging_quantities(
 
 
 @jjit
-def _get_linelum_results_with_merging(
+def _update_linelum_results_with_merging(
     spec_kern_results,
     linelums_obs,
     linelum_in_situ,

--- a/diffsky/experimental/kernels/gd_specphot_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_specphot_kernels_merging.py
@@ -1,0 +1,183 @@
+""""""
+
+from collections import namedtuple
+
+from jax import jit as jjit
+from jax import numpy as jnp
+
+from ...merging import compute_x_tot_from_x_in_situ
+from . import linelum_kernels, mc_randoms, phot_kernels_merging
+
+
+@jjit
+def _mc_specphot_kern_merging(
+    ran_key,
+    z_obs,
+    t_obs,
+    mah_params,
+    ssp_data,
+    precomputed_ssp_mag_table,
+    z_phot_table,
+    wave_eff_table,
+    line_wave_table,
+    diffstarpop_params,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    merging_params,
+    cosmo_params,
+    fb,
+    logmp_infall,
+    logmhost_infall,
+    t_infall,
+    is_central,
+    sat_weights,
+    halo_indx,
+    mc_merge,
+):
+    phot_randoms, sfh_params, merging_randoms = mc_randoms.get_mc_phot_merge_randoms(
+        ran_key, diffstarpop_params, mah_params, cosmo_params
+    )
+
+    phot_kern_results, spec_kern_results = _specphot_kern_merging(
+        phot_randoms,
+        merging_randoms,
+        sfh_params,
+        z_obs,
+        t_obs,
+        mah_params,
+        ssp_data,
+        precomputed_ssp_mag_table,
+        z_phot_table,
+        wave_eff_table,
+        line_wave_table,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        merging_params,
+        cosmo_params,
+        fb,
+        logmp_infall,
+        logmhost_infall,
+        t_infall,
+        is_central,
+        sat_weights,
+        halo_indx,
+        mc_merge,
+    )
+
+    return phot_kern_results, phot_randoms, spec_kern_results
+
+
+@jjit
+def _specphot_kern_merging(
+    phot_randoms,
+    merging_randoms,
+    sfh_params,
+    z_obs,
+    t_obs,
+    mah_params,
+    ssp_data,
+    precomputed_ssp_mag_table,
+    z_phot_table,
+    wave_eff_table,
+    line_wave_table,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    merging_params,
+    cosmo_params,
+    fb,
+    logmp_infall,
+    logmhost_infall,
+    t_infall,
+    is_central,
+    sat_weights,
+    halo_indx,
+    mc_merge,
+):
+    _res = linelum_kernels._specphot_kern(
+        phot_randoms,
+        sfh_params,
+        z_obs,
+        t_obs,
+        mah_params,
+        ssp_data,
+        precomputed_ssp_mag_table,
+        z_phot_table,
+        wave_eff_table,
+        line_wave_table,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        cosmo_params,
+        fb,
+    )
+    phot_kern_results, spec_kern_results = _res
+
+    _res = phot_kernels_merging._get_phot_kern_merging_quantities(
+        phot_kern_results,
+        merging_randoms,
+        t_obs,
+        merging_params,
+        logmp_infall,
+        logmhost_infall,
+        t_infall,
+        is_central,
+        sat_weights,
+        halo_indx,
+        mc_merge,
+    )
+    mstar_in_situ, mstar_obs, flux_in_situ, flux_obs, p_merge = _res
+
+    args = (
+        phot_kern_results,
+        mstar_in_situ,
+        mstar_obs,
+        flux_in_situ,
+        flux_obs,
+        p_merge,
+        merging_randoms.uran_pmerge,
+    )
+    phot_kern_results = phot_kernels_merging._update_phot_kern_results_with_merging(
+        *args
+    )
+
+    args = phot_kern_results, spec_kern_results, sat_weights, halo_indx
+    linelums_obs, linelum_in_situ = _get_linelum_kern_merging_quantities(*args)
+    spec_kern_results = _get_linelum_results_with_merging(
+        spec_kern_results, linelums_obs, linelum_in_situ
+    )
+
+    return phot_kern_results, spec_kern_results
+
+
+@jjit
+def _get_linelum_kern_merging_quantities(
+    phot_kern_results, spec_kern_results, sat_weights, halo_indx
+):
+    linelum_in_situ = spec_kern_results.linelum_gal
+    linelums_obs = compute_x_tot_from_x_in_situ(
+        linelum_in_situ,
+        phot_kern_results.p_merge[:, jnp.newaxis],
+        sat_weights[:, jnp.newaxis],
+        halo_indx,
+    )
+    return linelums_obs, linelum_in_situ
+
+
+@jjit
+def _get_linelum_results_with_merging(spec_kern_results, linelums_obs, linelum_in_situ):
+    spec_kern_results = spec_kern_results._replace(linelum_gal=linelums_obs)
+
+    new_keys = ["linelum_gal_in_situ"]
+    fields = list(spec_kern_results._fields) + new_keys
+    SpecKernResults = namedtuple("SpecKernResults", fields)
+    spec_kern_results = SpecKernResults(
+        **spec_kern_results._asdict(), linelum_gal_in_situ=linelum_in_situ
+    )
+    return spec_kern_results

--- a/diffsky/experimental/kernels/gd_specphot_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_specphot_kernels_merging.py
@@ -5,8 +5,8 @@ from collections import namedtuple
 from jax import jit as jjit
 from jax import numpy as jnp
 
-from ...merging import compute_x_tot_from_x_in_situ
-from . import linelum_kernels, mc_randoms, phot_kernels_merging
+from ...merging import compute_x_tot_from_x_in_situ, merging_model
+from . import gd_linelum_kernels, gd_phot_kernels_merging, mc_randoms
 
 
 @jjit
@@ -36,14 +36,26 @@ def _mc_specphot_kern_merging(
     halo_indx,
     mc_merge,
 ):
-    phot_randoms, sfh_params, merging_randoms = mc_randoms.get_mc_phot_merge_randoms(
-        ran_key, diffstarpop_params, mah_params, cosmo_params
+    upid = jnp.where(is_central == 1, -1, halo_indx)
+    lgmu_infall = logmp_infall - logmhost_infall
+    gyr_since_infall = t_obs - t_infall
+    phot_randoms, diffstarpop_results, merging_randoms = (
+        mc_randoms.get_phot_merge_randoms(
+            ran_key,
+            diffstarpop_params,
+            mah_params,
+            upid,
+            lgmu_infall,
+            logmhost_infall,
+            gyr_since_infall,
+            cosmo_params,
+        )
     )
 
     phot_kern_results, spec_kern_results = _specphot_kern_merging(
         phot_randoms,
         merging_randoms,
-        sfh_params,
+        diffstarpop_results,
         z_obs,
         t_obs,
         mah_params,
@@ -75,7 +87,7 @@ def _mc_specphot_kern_merging(
 def _specphot_kern_merging(
     phot_randoms,
     merging_randoms,
-    sfh_params,
+    diffstarpop_results,
     z_obs,
     t_obs,
     mah_params,
@@ -99,12 +111,18 @@ def _specphot_kern_merging(
     halo_indx,
     mc_merge,
 ):
-    _res = linelum_kernels._specphot_kern(
+    upids = jnp.where(is_central == 1, -1.0, 0.0)
+    p_merge_smooth = merging_model.get_p_merge_from_merging_params(
+        merging_params, logmp_infall, logmhost_infall, t_obs, t_infall, upids
+    )
+
+    _res = gd_linelum_kernels._specphot_kern(
         phot_randoms,
-        sfh_params,
+        diffstarpop_results,
         z_obs,
         t_obs,
         mah_params,
+        p_merge_smooth,
         ssp_data,
         precomputed_ssp_mag_table,
         z_phot_table,
@@ -119,20 +137,15 @@ def _specphot_kern_merging(
     )
     phot_kern_results, spec_kern_results = _res
 
-    _res = phot_kernels_merging._get_phot_kern_merging_quantities(
+    _res = gd_phot_kernels_merging._get_phot_kern_merging_quantities(
         phot_kern_results,
         merging_randoms,
-        t_obs,
-        merging_params,
-        logmp_infall,
-        logmhost_infall,
-        t_infall,
-        is_central,
+        p_merge_smooth,
         sat_weights,
         halo_indx,
         mc_merge,
     )
-    mstar_in_situ, mstar_obs, flux_in_situ, flux_obs, p_merge = _res
+    mstar_in_situ, mstar_obs, flux_in_situ, flux_obs, flux_obs_weighted, p_merge = _res
 
     args = (
         phot_kern_results,
@@ -140,12 +153,12 @@ def _specphot_kern_merging(
         mstar_obs,
         flux_in_situ,
         flux_obs,
+        flux_obs_weighted,
         p_merge,
         merging_randoms.uran_pmerge,
     )
-    phot_kern_results = phot_kernels_merging._update_phot_kern_results_with_merging(
-        *args
-    )
+    func = gd_phot_kernels_merging._update_phot_kern_results_with_merging
+    phot_kern_results = func(*args)
 
     args = phot_kern_results, spec_kern_results, sat_weights, halo_indx
     linelums_obs, linelum_in_situ = _get_linelum_kern_merging_quantities(*args)

--- a/diffsky/experimental/kernels/gd_specphot_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_specphot_kernels_merging.py
@@ -161,9 +161,15 @@ def _specphot_kern_merging(
     phot_kern_results = func(*args)
 
     args = phot_kern_results, spec_kern_results, sat_weights, halo_indx
-    linelums_obs, linelum_in_situ = _get_linelum_kern_merging_quantities(*args)
+    _res = _get_linelum_kern_merging_quantities(*args)
+    linelums_obs, linelum_in_situ_mc, linelum_weighted, linelum_in_situ_weighted = _res
+
     spec_kern_results = _get_linelum_results_with_merging(
-        spec_kern_results, linelums_obs, linelum_in_situ
+        spec_kern_results,
+        linelums_obs,
+        linelum_in_situ_mc,
+        linelum_weighted,
+        linelum_in_situ_weighted,
     )
 
     return phot_kern_results, spec_kern_results
@@ -173,24 +179,44 @@ def _specphot_kern_merging(
 def _get_linelum_kern_merging_quantities(
     phot_kern_results, spec_kern_results, sat_weights, halo_indx
 ):
-    linelum_in_situ = spec_kern_results.linelum_gal
+    linelum_in_situ_mc = spec_kern_results.linelum_gal
     linelums_obs = compute_x_tot_from_x_in_situ(
-        linelum_in_situ,
+        linelum_in_situ_mc,
         phot_kern_results.p_merge[:, jnp.newaxis],
         sat_weights[:, jnp.newaxis],
         halo_indx,
     )
-    return linelums_obs, linelum_in_situ
+
+    linelum_in_situ_weighted = spec_kern_results.linelum_weighted
+    linelum_weighted = compute_x_tot_from_x_in_situ(
+        linelum_in_situ_weighted,
+        phot_kern_results.p_merge[:, jnp.newaxis],
+        sat_weights[:, jnp.newaxis],
+        halo_indx,
+    )
+
+    return linelums_obs, linelum_in_situ_mc, linelum_weighted, linelum_in_situ_weighted
 
 
 @jjit
-def _get_linelum_results_with_merging(spec_kern_results, linelums_obs, linelum_in_situ):
-    spec_kern_results = spec_kern_results._replace(linelum_gal=linelums_obs)
+def _get_linelum_results_with_merging(
+    spec_kern_results,
+    linelums_obs,
+    linelum_in_situ,
+    linelum_weighted,
+    linelum_in_situ_weighted,
+):
+    spec_kern_results = spec_kern_results._replace(
+        linelum_gal=linelums_obs, linelum_weighted=linelum_weighted
+    )
 
-    new_keys = ["linelum_gal_in_situ"]
+    new_keys = ["linelum_gal_in_situ", "linelum_in_situ_weighted"]
     fields = list(spec_kern_results._fields) + new_keys
     SpecKernResults = namedtuple("SpecKernResults", fields)
+
     spec_kern_results = SpecKernResults(
-        **spec_kern_results._asdict(), linelum_gal_in_situ=linelum_in_situ
+        **spec_kern_results._asdict(),
+        linelum_gal_in_situ=linelum_in_situ,
+        linelum_in_situ_weighted=linelum_in_situ_weighted,
     )
     return spec_kern_results

--- a/diffsky/experimental/kernels/mc_randoms.py
+++ b/diffsky/experimental/kernels/mc_randoms.py
@@ -212,3 +212,32 @@ def get_mc_dbk_phot_merge_randoms(
     merging_randoms = get_merging_randoms(merge_key, n_gals)
 
     return phot_randoms, sfh_params, dbk_randoms, merging_randoms
+
+
+@jjit
+def get_dbk_phot_merge_randoms(
+    ran_key,
+    diffstarpop_params,
+    mah_params,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
+    cosmo_params,
+):
+    phot_key, dbk_key, merge_key = jran.split(ran_key, 3)
+    phot_randoms, diffstarpop_results = get_phot_randoms(
+        phot_key,
+        diffstarpop_params,
+        mah_params,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        cosmo_params,
+    )
+    n_gals = diffstarpop_results.sfh_params[0].shape[0]
+    dbk_randoms = get_mc_dbk_randoms(dbk_key, n_gals)
+    merging_randoms = get_merging_randoms(merge_key, n_gals)
+
+    return phot_randoms, diffstarpop_results, dbk_randoms, merging_randoms

--- a/diffsky/experimental/kernels/mc_randoms.py
+++ b/diffsky/experimental/kernels/mc_randoms.py
@@ -134,6 +134,33 @@ def get_mc_dbk_phot_randoms(ran_key, diffstarpop_params, mah_params, cosmo_param
 
 
 @jjit
+def get_dbk_phot_randoms(
+    ran_key,
+    diffstarpop_params,
+    mah_params,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
+    cosmo_params,
+):
+    phot_key, dbk_key = jran.split(ran_key, 2)
+    phot_randoms, diffstarpop_results = get_phot_randoms(
+        phot_key,
+        diffstarpop_params,
+        mah_params,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        cosmo_params,
+    )
+    n_gals = diffstarpop_results.sfh_params[0].shape[0]
+    dbk_randoms = get_mc_dbk_randoms(dbk_key, n_gals)
+    return phot_randoms, diffstarpop_results, dbk_randoms
+
+
+@jjit
 def get_mc_phot_merge_randoms(ran_key, diffstarpop_params, mah_params, cosmo_params):
     phot_key, merge_key = jran.split(ran_key, 2)
     phot_randoms, sfh_params = get_mc_phot_randoms(

--- a/diffsky/experimental/kernels/rapid_quenching.py
+++ b/diffsky/experimental/kernels/rapid_quenching.py
@@ -25,6 +25,26 @@ calc_bursty_age_weights_vmap = jjit(vmap(calc_bursty_age_weights, in_axes=(0, 0,
 
 
 @jjit
+def get_smooth_ssp_weights_rq(
+    t_table,
+    sfh_table,
+    logsm_obs,
+    ssp_data,
+    t_obs,
+    mzr_params,
+    lgmet_scatter,
+    p_merge_smooth,
+):
+    smooth_ssp_weights = sspwk.get_smooth_ssp_weights(
+        t_table, sfh_table, logsm_obs, ssp_data, t_obs, mzr_params, lgmet_scatter
+    )
+    smooth_ssp_weights_rq = modify_smooth_ssp_weights_with_rapid_quenching(
+        smooth_ssp_weights, p_merge_smooth, ssp_data
+    )
+    return smooth_ssp_weights_rq
+
+
+@jjit
 def get_burstiness_rq(
     uran_pburst,
     mc_is_q,

--- a/diffsky/experimental/kernels/rapid_quenching.py
+++ b/diffsky/experimental/kernels/rapid_quenching.py
@@ -135,7 +135,7 @@ def modify_lgfburst_with_rapid_quenching(p_merge, lgfb_orig):
         DEFAULT_RQ_PARAMS.rq_p_merge_x0,
         K_P_MERGE,
         lgfb_orig,
-        diffburst.LGFBURST_MIN + 0.1,
+        diffburst.LGFBURST_MIN + 0.01,
     )
     return lgfb_rq
 

--- a/diffsky/experimental/kernels/rapid_quenching.py
+++ b/diffsky/experimental/kernels/rapid_quenching.py
@@ -1,10 +1,12 @@
 """"""
 
 from collections import namedtuple
+
 from dsps.utils import _sigmoid
-from jax import numpy as jnp
 from jax import jit as jjit
+from jax import numpy as jnp
 from jax import vmap
+
 from . import ssp_weight_kernels as sspwk
 
 RapidQParams = namedtuple("RapidQParams", ("rq_p_merge_x0", "rq_lg_age_gyr_max"))
@@ -12,6 +14,20 @@ DEFAULT_RQ_PARAMS = RapidQParams(rq_p_merge_x0=0.2, rq_lg_age_gyr_max=-1.0)
 DEFAULT_RQ_BOUNDS = RapidQParams(
     rq_p_merge_x0=(0.01, 1.0), rq_lg_age_gyr_max=(-5.0, 0.0)
 )
+
+
+@jjit
+def modify_smooth_ssp_weights_with_rapid_quenching(
+    ssp_weights_smooth, p_merge, ssp_data
+):
+    age_weights_rq, __ = get_age_weights_rq_vmap(
+        ssp_weights_smooth.age_weights,
+        p_merge,
+        ssp_data.ssp_lg_age_gyr,
+        DEFAULT_RQ_PARAMS,
+    )
+    ssp_weights_rq = ssp_weights_smooth._replace(age_weights=age_weights_rq)
+    return ssp_weights_rq
 
 
 @jjit

--- a/diffsky/experimental/kernels/rapid_quenching.py
+++ b/diffsky/experimental/kernels/rapid_quenching.py
@@ -2,11 +2,14 @@
 
 from collections import namedtuple
 
+from dsps.sfh import diffburst
+from dsps.sfh.diffburst import calc_bursty_age_weights
 from dsps.utils import _sigmoid
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import vmap
 
+from ...burstpop import freqburst_mono
 from . import ssp_weight_kernels as sspwk
 
 RapidQParams = namedtuple("RapidQParams", ("rq_p_merge_x0", "rq_lg_age_gyr_max"))
@@ -14,6 +17,81 @@ DEFAULT_RQ_PARAMS = RapidQParams(rq_p_merge_x0=0.2, rq_lg_age_gyr_max=-1.0)
 DEFAULT_RQ_BOUNDS = RapidQParams(
     rq_p_merge_x0=(0.01, 1.0), rq_lg_age_gyr_max=(-5.0, 0.0)
 )
+K_P_MERGE = 100
+K_LG_AGE = 100
+
+
+calc_bursty_age_weights_vmap = jjit(vmap(calc_bursty_age_weights, in_axes=(0, 0, None)))
+
+
+@jjit
+def get_burstiness_rq(
+    uran_pburst,
+    mc_is_q,
+    logsm_obs,
+    logssfr_obs,
+    age_weights_smooth,
+    lgmet_weights,
+    ssp_data,
+    burstpop_params,
+    p_merge_smooth,
+):
+    n_gals = mc_is_q.shape[0]
+
+    _args = (
+        burstpop_params,
+        logsm_obs,
+        logssfr_obs,
+        ssp_data.ssp_lg_age_gyr,
+        age_weights_smooth,
+    )
+    _res = sspwk._calc_bursty_age_weights_vmap(*_args)
+    age_weights_bursty, burst_params_bursty = _res
+
+    lgfb_rq = modify_lgfburst_with_rapid_quenching(
+        p_merge_smooth, burst_params_bursty.lgfburst
+    )
+    burst_params_bursty = burst_params_bursty._replace(lgfburst=lgfb_rq)
+    age_weights_bursty = calc_bursty_age_weights_vmap(
+        burst_params_bursty, age_weights_smooth, ssp_data.ssp_lg_age_gyr
+    )
+
+    # Calculate the frequency of SFH bursts
+    p_burst = freqburst_mono.get_freqburst_from_freqburst_params(
+        burstpop_params.freqburst_params, logsm_obs, logssfr_obs
+    )
+
+    mc_sfh_type = jnp.where(mc_is_q, 0, 1).astype(int)
+    msk_bursty = (uran_pburst < p_burst) & (mc_sfh_type == 1)
+    mc_sfh_type = jnp.where(msk_bursty, 2, mc_sfh_type).astype(int)
+
+    lgfburst_mc = jnp.where(
+        mc_sfh_type < 2, diffburst.LGFBURST_MIN + 0.01, burst_params_bursty.lgfburst
+    )
+    burst_params_mc = burst_params_bursty._replace(lgfburst=lgfburst_mc)
+
+    age_weights_mc = jnp.where(
+        mc_sfh_type.reshape((n_gals, 1)) == 2, age_weights_bursty, age_weights_smooth
+    )
+
+    ssp_weights_smooth = sspwk.combine_age_met_weights(
+        age_weights_smooth, lgmet_weights
+    )
+    ssp_weights_bursty = sspwk.combine_age_met_weights(
+        age_weights_bursty, lgmet_weights
+    )
+    ssp_weights_mc = sspwk.combine_age_met_weights(age_weights_mc, lgmet_weights)
+
+    burstiness_info = sspwk.BurstinessInfo(
+        ssp_weights_mc,
+        ssp_weights_smooth,
+        ssp_weights_bursty,
+        burst_params_mc,
+        burst_params_bursty,
+        mc_sfh_type,
+        p_burst,
+    )
+    return burstiness_info
 
 
 @jjit
@@ -31,48 +109,24 @@ def modify_smooth_ssp_weights_with_rapid_quenching(
 
 
 @jjit
-def modify_burstiness_info_with_rapid_quenching(
-    burstiness_info, p_merge, ssp_data, lgmet_weights
-):
-    age_weights_mc = jnp.sum(burstiness_info.ssp_weights_mc, axis=1)
-    age_weights_mc_rq, __ = get_age_weights_rq_vmap(
-        age_weights_mc, p_merge, ssp_data.ssp_lg_age_gyr, DEFAULT_RQ_PARAMS
+def modify_lgfburst_with_rapid_quenching(p_merge, lgfb_orig):
+    lgfb_rq = _sigmoid(
+        p_merge,
+        DEFAULT_RQ_PARAMS.rq_p_merge_x0,
+        K_P_MERGE,
+        lgfb_orig,
+        diffburst.LGFBURST_MIN + 0.1,
     )
-    ssp_weights_mc_rq = sspwk.combine_age_met_weights(age_weights_mc_rq, lgmet_weights)
-
-    age_weights_smooth = jnp.sum(burstiness_info.ssp_weights_smooth, axis=1)
-    age_weights_smooth_rq, __ = get_age_weights_rq_vmap(
-        age_weights_smooth, p_merge, ssp_data.ssp_lg_age_gyr, DEFAULT_RQ_PARAMS
-    )
-    ssp_weights_smooth_rq = sspwk.combine_age_met_weights(
-        age_weights_smooth_rq, lgmet_weights
-    )
-
-    age_weights_bursty = jnp.sum(burstiness_info.ssp_weights_bursty, axis=1)
-    age_weights_bursty_rq, __ = get_age_weights_rq_vmap(
-        age_weights_bursty, p_merge, ssp_data.ssp_lg_age_gyr, DEFAULT_RQ_PARAMS
-    )
-    ssp_weights_bursty_rq = sspwk.combine_age_met_weights(
-        age_weights_bursty_rq, lgmet_weights
-    )
-
-    burstiness_info_rq = burstiness_info._replace(
-        ssp_weights_mc=ssp_weights_mc_rq,
-        ssp_weights_smooth=ssp_weights_smooth_rq,
-        ssp_weights_bursty=ssp_weights_bursty_rq,
-    )
-
-    return burstiness_info_rq
+    return lgfb_rq
 
 
 @jjit
 def _rapid_qkern(age_weights, ssp_lg_age_gyr, cutoff_lg_age_gyr):
     """Calculate how rapid quenching changes the stellar age PDF.
     Stars younger than cutoff_lg_age_gyr are removed from the population."""
-    k = 100.0
     ylo = age_weights / 10_000
     yhi = age_weights
-    age_weights_rq = _sigmoid(ssp_lg_age_gyr, cutoff_lg_age_gyr, k, ylo, yhi)
+    age_weights_rq = _sigmoid(ssp_lg_age_gyr, cutoff_lg_age_gyr, K_LG_AGE, ylo, yhi)
     age_weights_rq = age_weights_rq / age_weights_rq.sum()
     return age_weights_rq
 
@@ -81,8 +135,9 @@ def _rapid_qkern(age_weights, ssp_lg_age_gyr, cutoff_lg_age_gyr):
 def _get_cutoff_lg_age_gyr(p_merge, p_merge_x0, lg_age_gyr_min, lg_age_gyr_max):
     """Calculate the cutoff age in rapid quenching.
     Stars younger than the cutoff age are removed from the population."""
-    k = 100.0
-    cutoff_lg_age_gyr = _sigmoid(p_merge, p_merge_x0, k, lg_age_gyr_min, lg_age_gyr_max)
+    cutoff_lg_age_gyr = _sigmoid(
+        p_merge, p_merge_x0, K_P_MERGE, lg_age_gyr_min, lg_age_gyr_max
+    )
     return cutoff_lg_age_gyr
 
 

--- a/diffsky/experimental/kernels/specphot_kernels_merging.py
+++ b/diffsky/experimental/kernels/specphot_kernels_merging.py
@@ -149,7 +149,7 @@ def _specphot_kern_merging(
 
     args = phot_kern_results, spec_kern_results, sat_weights, halo_indx
     linelums_obs, linelum_in_situ = _get_linelum_kern_merging_quantities(*args)
-    spec_kern_results = _get_linelum_results_with_merging(
+    spec_kern_results = _update_linelum_results_with_merging(
         spec_kern_results, linelums_obs, linelum_in_situ
     )
 
@@ -171,7 +171,9 @@ def _get_linelum_kern_merging_quantities(
 
 
 @jjit
-def _get_linelum_results_with_merging(spec_kern_results, linelums_obs, linelum_in_situ):
+def _update_linelum_results_with_merging(
+    spec_kern_results, linelums_obs, linelum_in_situ
+):
     spec_kern_results = spec_kern_results._replace(linelum_gal=linelums_obs)
 
     new_keys = ["linelum_gal_in_situ"]

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_specphot_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_specphot_kernels.py
@@ -1,0 +1,154 @@
+""""""
+
+import numpy as np
+from diffstar import DEFAULT_DIFFSTAR_PARAMS
+from dsps.cosmology import DEFAULT_COSMOLOGY
+from jax import random as jran
+
+from ....param_utils import diffsky_param_wrapper as dpw
+from ... import dbk_phot_from_mock
+from ...tests import test_lightcone_generators as tlcg
+from .. import gd_dbk_specphot_kernels as gd_dbkspk
+
+
+def test_mc_dbk_phot_kern(num_halos=19):
+    ran_key = jran.key(0)
+    lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
+        num_halos=num_halos
+    )
+    fb = 0.196
+
+    args = (
+        ran_key,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        lc_data.ssp_data,
+        lc_data.precomputed_ssp_mag_table,
+        lc_data.z_phot_table,
+        lc_data.wave_eff_table,
+        *dpw.DEFAULT_PARAM_COLLECTION,
+        DEFAULT_COSMOLOGY,
+        fb,
+    )
+    dbk_phot_info, dbk_weights = gd_dbkspk._mc_dbk_phot_kern(*args)
+
+
+def test_mc_dbk_specphot_kern(num_halos=13):
+    """Enforce that the sum of the component lines equals the composite line"""
+    ran_key = jran.key(0)
+    lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
+        num_halos=num_halos
+    )
+    fb = 0.196
+
+    args = (
+        ran_key,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        lc_data.ssp_data,
+        lc_data.precomputed_ssp_mag_table,
+        lc_data.z_phot_table,
+        lc_data.wave_eff_table,
+        lc_data.line_wave_table,
+        *dpw.DEFAULT_PARAM_COLLECTION,
+        DEFAULT_COSMOLOGY,
+        fb,
+    )
+    dbk_specphot_info, dbk_weights = gd_dbkspk._mc_dbk_specphot_kern(*args)
+
+    for key in ("linelum_gal", "linelum_bulge", "linelum_disk", "linelum_knots"):
+        assert np.all(np.isfinite(getattr(dbk_specphot_info, key)))
+
+    component_lines_sum = (
+        dbk_specphot_info.linelum_bulge
+        + dbk_specphot_info.linelum_disk
+        + dbk_specphot_info.linelum_knots
+    )
+    logdiff = np.log10(component_lines_sum) - np.log10(dbk_specphot_info.linelum_gal)
+    assert np.allclose(logdiff, 0.0, atol=0.01)
+
+
+def test_dbk_sed_kern(num_halos=17):
+    """Enforce that the sum of the component SEDs equals the composite SED"""
+    ran_key = jran.key(0)
+    lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
+        num_halos=num_halos
+    )
+    fb = 0.116
+
+    args = (
+        ran_key,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        lc_data.ssp_data,
+        lc_data.precomputed_ssp_mag_table,
+        lc_data.z_phot_table,
+        lc_data.wave_eff_table,
+        lc_data.line_wave_table,
+        *dpw.DEFAULT_PARAM_COLLECTION,
+        DEFAULT_COSMOLOGY,
+        fb,
+    )
+    dbk_specphot_info, dbk_weights = gd_dbkspk._mc_dbk_specphot_kern(*args)
+
+    sfh_params = DEFAULT_DIFFSTAR_PARAMS._make(
+        [getattr(dbk_specphot_info, pname) for pname in DEFAULT_DIFFSTAR_PARAMS._fields]
+    )
+
+    dbk_sed_info, __ = gd_dbkspk._dbk_sed_kern(
+        dbk_specphot_info.mc_is_q,
+        dbk_specphot_info.uran_av,
+        dbk_specphot_info.uran_delta,
+        dbk_specphot_info.uran_funo,
+        dbk_specphot_info.uran_pburst,
+        dbk_specphot_info.delta_mag_ssp_scatter,
+        dbk_specphot_info.uran_fbulge,
+        dbk_specphot_info.fknot,
+        sfh_params,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        lc_data.ssp_data,
+        dpw.DEFAULT_PARAM_COLLECTION.mzr_params,
+        dpw.DEFAULT_PARAM_COLLECTION.spspop_params,
+        dpw.DEFAULT_PARAM_COLLECTION.scatter_params,
+        dpw.DEFAULT_PARAM_COLLECTION.ssperr_params,
+        DEFAULT_COSMOLOGY,
+        fb,
+    )
+    sed_sum = (
+        dbk_sed_info.rest_sed_bulge
+        + dbk_sed_info.rest_sed_disk
+        + dbk_sed_info.rest_sed_knots
+    )
+
+    temp_args = (
+        dbk_specphot_info.mc_is_q,
+        dbk_specphot_info.uran_av,
+        dbk_specphot_info.uran_delta,
+        dbk_specphot_info.uran_funo,
+        dbk_specphot_info.uran_pburst,
+        dbk_specphot_info.delta_mag_ssp_scatter,
+        sfh_params,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        lc_data.ssp_data,
+        lc_data.precomputed_ssp_mag_table,
+        lc_data.z_phot_table,
+        lc_data.wave_eff_table,
+        dpw.DEFAULT_PARAM_COLLECTION.mzr_params,
+        dpw.DEFAULT_PARAM_COLLECTION.spspop_params,
+        dpw.DEFAULT_PARAM_COLLECTION.scatter_params,
+        dpw.DEFAULT_PARAM_COLLECTION.ssperr_params,
+        DEFAULT_COSMOLOGY,
+        fb,
+    )
+    _res = dbk_phot_from_mock._reproduce_mock_sed_kern(*temp_args)
+    phot_kern_results, phot_randoms, sed_kern_results = _res
+
+    logdiff = np.log10(sed_sum) - np.log10(sed_kern_results.rest_sed)
+    assert np.allclose(logdiff, 0.0, atol=0.01)

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_specphot_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_specphot_kernels.py
@@ -5,7 +5,7 @@ from diffstar import DEFAULT_DIFFSTAR_PARAMS
 from dsps.cosmology import DEFAULT_COSMOLOGY
 from jax import random as jran
 
-from ....param_utils import diffsky_param_wrapper as dpw
+from ....param_utils import diffsky_param_wrapper_merging as dpwm
 from ... import dbk_phot_from_mock
 from ...tests import test_lightcone_generators as tlcg
 from .. import gd_dbk_specphot_kernels as gd_dbkspk
@@ -17,17 +17,29 @@ def test_mc_dbk_phot_kern(num_halos=19):
         num_halos=num_halos
     )
     fb = 0.196
+    upid = np.where(lc_data.is_central == 1, -1, lc_data.halo_indx)
+    lgmu_infall = lc_data.logmp_infall - lc_data.logmhost_infall
+    gyr_since_infall = lc_data.t_infall - lc_data.t_obs
 
     args = (
         ran_key,
         lc_data.z_obs,
         lc_data.t_obs,
         lc_data.mah_params,
+        upid,
+        lgmu_infall,
+        lc_data.logmhost_infall,
+        gyr_since_infall,
         lc_data.ssp_data,
         lc_data.precomputed_ssp_mag_table,
         lc_data.z_phot_table,
         lc_data.wave_eff_table,
-        *dpw.DEFAULT_PARAM_COLLECTION,
+        dpwm.DEFAULT_PARAM_COLLECTION.diffstarpop_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.mzr_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.spspop_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.scatter_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.ssperr_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.merging_params,
         DEFAULT_COSMOLOGY,
         fb,
     )
@@ -42,17 +54,30 @@ def test_mc_dbk_specphot_kern(num_halos=13):
     )
     fb = 0.196
 
+    upid = np.where(lc_data.is_central == 1, -1, lc_data.halo_indx)
+    lgmu_infall = lc_data.logmp_infall - lc_data.logmhost_infall
+    gyr_since_infall = lc_data.t_infall - lc_data.t_obs
+
     args = (
         ran_key,
         lc_data.z_obs,
         lc_data.t_obs,
         lc_data.mah_params,
+        upid,
+        lgmu_infall,
+        lc_data.logmhost_infall,
+        gyr_since_infall,
         lc_data.ssp_data,
         lc_data.precomputed_ssp_mag_table,
         lc_data.z_phot_table,
         lc_data.wave_eff_table,
         lc_data.line_wave_table,
-        *dpw.DEFAULT_PARAM_COLLECTION,
+        dpwm.DEFAULT_PARAM_COLLECTION.diffstarpop_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.mzr_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.spspop_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.scatter_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.ssperr_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.merging_params,
         DEFAULT_COSMOLOGY,
         fb,
     )

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_specphot_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_specphot_kernels.py
@@ -7,6 +7,7 @@ from jax import random as jran
 
 from ....param_utils import diffsky_param_wrapper_merging as dpwm
 from ... import dbk_phot_from_mock
+from ... import mc_diffstarpop_wrappers as mcdpw
 from ...tests import test_lightcone_generators as tlcg
 from .. import gd_dbk_specphot_kernels as gd_dbkspk
 
@@ -102,28 +103,44 @@ def test_dbk_sed_kern(num_halos=17):
         num_halos=num_halos
     )
     fb = 0.116
+    upid = np.where(lc_data.is_central == 1, -1, lc_data.halo_indx)
+    lgmu_infall = lc_data.logmp_infall - lc_data.logmhost_infall
+    gyr_since_infall = lc_data.t_infall - lc_data.t_obs
 
     args = (
         ran_key,
         lc_data.z_obs,
         lc_data.t_obs,
         lc_data.mah_params,
+        upid,
+        lgmu_infall,
+        lc_data.logmhost_infall,
+        gyr_since_infall,
         lc_data.ssp_data,
         lc_data.precomputed_ssp_mag_table,
         lc_data.z_phot_table,
         lc_data.wave_eff_table,
         lc_data.line_wave_table,
-        *dpw.DEFAULT_PARAM_COLLECTION,
+        *dpwm.DEFAULT_PARAM_COLLECTION,
         DEFAULT_COSMOLOGY,
         fb,
     )
+
     dbk_specphot_info, dbk_weights = gd_dbkspk._mc_dbk_specphot_kern(*args)
+    assert "diffstar_info_ms" in dbk_specphot_info._fields
 
     sfh_params = DEFAULT_DIFFSTAR_PARAMS._make(
-        [getattr(dbk_specphot_info, pname) for pname in DEFAULT_DIFFSTAR_PARAMS._fields]
+        [getattr(dbk_specphot_info, k) for k in DEFAULT_DIFFSTAR_PARAMS._fields]
+    )
+    diffstarpop_results = mcdpw.DiffstarPopResults(
+        sfh_params=sfh_params,
+        sfh_params_ms=dbk_specphot_info.diffstar_info_ms.sfh_params,
+        sfh_params_q=dbk_specphot_info.diffstar_info_q.sfh_params,
+        mc_is_q=dbk_specphot_info.mc_is_q,
+        frac_q=dbk_specphot_info.frac_q,
     )
 
-    dbk_sed_info, __ = gd_dbkspk._dbk_sed_kern(
+    dbk_sed_kern_args = (
         dbk_specphot_info.mc_is_q,
         dbk_specphot_info.uran_av,
         dbk_specphot_info.uran_delta,
@@ -132,18 +149,25 @@ def test_dbk_sed_kern(num_halos=17):
         dbk_specphot_info.delta_mag_ssp_scatter,
         dbk_specphot_info.uran_fbulge,
         dbk_specphot_info.fknot,
-        sfh_params,
+        diffstarpop_results,
         lc_data.z_obs,
         lc_data.t_obs,
         lc_data.mah_params,
+        upid,
+        lgmu_infall,
+        lc_data.logmhost_infall,
+        gyr_since_infall,
         lc_data.ssp_data,
-        dpw.DEFAULT_PARAM_COLLECTION.mzr_params,
-        dpw.DEFAULT_PARAM_COLLECTION.spspop_params,
-        dpw.DEFAULT_PARAM_COLLECTION.scatter_params,
-        dpw.DEFAULT_PARAM_COLLECTION.ssperr_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.mzr_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.spspop_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.scatter_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.ssperr_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.merging_params,
         DEFAULT_COSMOLOGY,
         fb,
     )
+    dbk_sed_info, __ = gd_dbkspk._dbk_sed_kern(*dbk_sed_kern_args)
+
     sed_sum = (
         dbk_sed_info.rest_sed_bulge
         + dbk_sed_info.rest_sed_disk
@@ -165,10 +189,10 @@ def test_dbk_sed_kern(num_halos=17):
         lc_data.precomputed_ssp_mag_table,
         lc_data.z_phot_table,
         lc_data.wave_eff_table,
-        dpw.DEFAULT_PARAM_COLLECTION.mzr_params,
-        dpw.DEFAULT_PARAM_COLLECTION.spspop_params,
-        dpw.DEFAULT_PARAM_COLLECTION.scatter_params,
-        dpw.DEFAULT_PARAM_COLLECTION.ssperr_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.mzr_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.spspop_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.scatter_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.ssperr_params,
         DEFAULT_COSMOLOGY,
         fb,
     )

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_specphot_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_specphot_kernels_merging.py
@@ -1,0 +1,155 @@
+""""""
+
+import numpy as np
+import pytest
+from dsps.cosmology import DEFAULT_COSMOLOGY
+from jax import random as jran
+
+from ....param_utils import diffsky_param_wrapper_merging as dpwm
+from ...tests import test_lightcone_generators as tlcg
+from .. import gd_dbk_specphot_kernels_merging as gd_dbkspkm
+from .test_gd_specphot_kernels_merging import check_spec_kern_merging_results
+from .test_phot_kernels_merging import check_phot_kern_merging_results
+
+TOL = 1e-8
+
+
+def check_dbk_specphot_kern_merging_results(dbk_specphot_info, dbk_weights, lc_data):
+
+    skip_fields = (
+        "diffstar_info_ms",
+        "diffstar_info_q",
+        "burstiness_info_ms",
+        "burstiness_info_q",
+    )
+    for key in dbk_specphot_info._fields:
+        if key not in skip_fields:
+            arr = getattr(dbk_specphot_info, key)
+            try:
+                assert np.all(np.isfinite(arr))
+            except ValueError:
+                raise ValueError(f"{key} is not a flat array")
+
+    component_names = ("_bulge", "_disk", "_knots")
+
+    # Enforce consistent array shapes
+    correct_shape = getattr(dbk_specphot_info, "logsm_obs").shape
+    for k in component_names:
+        kname = "logsm" + k
+        component_shape = getattr(dbk_specphot_info, kname).shape
+        assert correct_shape == component_shape, kname
+
+    correct_shape = getattr(dbk_specphot_info, "obs_mags").shape
+    for k in component_names:
+        kname = "obs_mags" + k
+        component_shape = getattr(dbk_specphot_info, kname).shape
+        assert correct_shape == component_shape, kname
+
+    correct_shape = getattr(dbk_specphot_info, "linelum_gal").shape
+    for k in component_names:
+        kname = "linelum" + k
+        component_shape = getattr(dbk_specphot_info, kname).shape
+        assert correct_shape == component_shape, kname
+
+    # Enforce consistency with dbk_weights
+    specphot_key, dbk_key = "logsm", "mstar"
+    for k in component_names:
+        x = getattr(dbk_specphot_info, specphot_key + k)
+        y = np.log10(getattr(dbk_weights, dbk_key + k))
+        assert np.allclose(x, y, atol=0.01)
+
+    msk_cen = lc_data.is_central == 1
+    msk_sat = ~msk_cen
+
+    # Enforce centrals can only get more massive and satellites less massive
+    name = "logsm_obs"
+    x = getattr(dbk_specphot_info, name)
+    y = getattr(dbk_specphot_info, name + "_in_situ")
+    assert np.all(x[msk_cen] >= y[msk_cen] - TOL)
+    assert np.all(x[msk_sat] <= y[msk_sat] + TOL)
+    # Separately enforce for DBK decomposition
+    for k in component_names:
+        kname = name.replace("_obs", k)
+        x = getattr(dbk_specphot_info, kname)
+        y = getattr(dbk_specphot_info, kname + "_in_situ")
+        assert np.all(x[msk_cen] >= y[msk_cen] - TOL)
+        assert np.all(x[msk_sat] <= y[msk_sat] + TOL)
+        # Enforce merging is nontrivial
+        assert np.any(x[msk_cen] > y[msk_cen])
+        assert np.any(x[msk_sat] < y[msk_sat])
+
+    # Enforce centrals can only get brighter and satellites can only get dimmer
+    name = "obs_mags"
+    x = getattr(dbk_specphot_info, name)
+    y = getattr(dbk_specphot_info, name + "_in_situ")
+    assert np.all(x[msk_cen] <= y[msk_cen] + TOL)
+    assert np.all(x[msk_sat] >= y[msk_sat] - TOL)
+    # Enforce merging is nontrivial
+    assert np.any(x[msk_cen] < y[msk_cen])
+    assert np.any(x[msk_sat] > y[msk_sat])
+    # Separately enforce for DBK decomposition
+    for k in component_names:
+        x = getattr(dbk_specphot_info, name + k)
+        y = getattr(dbk_specphot_info, name + k + "_in_situ")
+        assert np.all(x[msk_cen] <= y[msk_cen] + TOL)
+        assert np.all(x[msk_sat] >= y[msk_sat] - TOL)
+        # Enforce merging is nontrivial
+        assert np.any(x[msk_cen] < y[msk_cen])
+        assert np.any(x[msk_sat] > y[msk_sat])
+
+    # Enforce centrals can only get brighter lines and satellites less bright
+    name = "linelum_gal"
+    x = getattr(dbk_specphot_info, name)
+    y = getattr(dbk_specphot_info, name + "_in_situ")
+    assert np.all(x[msk_cen] >= y[msk_cen] - TOL)
+    assert np.all(x[msk_sat] <= y[msk_sat] + TOL)
+    # Separately enforce for DBK decomposition
+    for k in component_names:
+        kname = name.replace("_gal", k)
+        x = np.log10(getattr(dbk_specphot_info, kname))
+        y = np.log10(getattr(dbk_specphot_info, kname + "_in_situ"))
+        assert np.all(np.isfinite(x))
+        assert np.all(np.isfinite(y))
+        assert np.all(x[msk_cen] >= y[msk_cen] - TOL), k
+        assert np.all(x[msk_sat] <= y[msk_sat] + TOL)
+        # Enforce merging is nontrivial
+        assert np.any(x[msk_cen] > y[msk_cen])
+        assert np.any(x[msk_sat] < y[msk_sat])
+
+
+@pytest.mark.parametrize("mc_merge", [0, 1])
+def test_mc_dbk_specphot_kern_merging(mc_merge, num_halos=150):
+    """Enforce that the sum of the component lines equals the composite line"""
+    ran_key = jran.key(0)
+    lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
+        num_halos=num_halos
+    )
+    fb = 0.13
+
+    args = (
+        ran_key,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        lc_data.ssp_data,
+        lc_data.precomputed_ssp_mag_table,
+        lc_data.z_phot_table,
+        lc_data.wave_eff_table,
+        lc_data.line_wave_table,
+        *dpwm.DEFAULT_PARAM_COLLECTION,
+        DEFAULT_COSMOLOGY,
+        fb,
+        lc_data.logmp_infall,
+        lc_data.logmhost_infall,
+        lc_data.t_infall,
+        lc_data.is_central,
+        lc_data.sat_weight,
+        lc_data.halo_indx,
+        mc_merge,
+    )
+    _res = gd_dbkspkm._mc_dbk_specphot_kern_merging(*args)
+    dbk_specphot_info, dbk_weights = _res
+
+    check_phot_kern_merging_results(dbk_specphot_info, lc_data)
+    check_spec_kern_merging_results(dbk_specphot_info, lc_data)
+    check_dbk_specphot_kern_merging_results(dbk_specphot_info, dbk_weights, lc_data)

--- a/diffsky/experimental/kernels/tests/test_gd_linelum_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_linelum_kernels.py
@@ -1,0 +1,95 @@
+""""""
+
+import numpy as np
+from dsps.cosmology import DEFAULT_COSMOLOGY
+from dsps.data_loaders import load_emline_info as lemi
+from jax import random as jran
+
+from ....param_utils import diffsky_param_wrapper_merging as dpwm
+from ...tests import test_lightcone_generators as tlcg
+from .. import gd_linelum_kernels, gd_phot_kernels
+
+
+def test_mc_specphot_kern(num_halos=150):
+    ran_key = jran.key(0)
+    lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
+        num_halos=num_halos
+    )
+    fb = 0.176
+    ran_key, phot_key = jran.split(ran_key, 2)
+
+    upid = np.where(lc_data.is_central == 1, -1, lc_data.halo_indx)
+    lgmu_infall = lc_data.logmp_infall - lc_data.logmhost_infall
+    gyr_since_infall = lc_data.t_infall - lc_data.t_obs
+    _res = gd_phot_kernels._mc_phot_kern(
+        phot_key,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        upid,
+        lgmu_infall,
+        lc_data.logmhost_infall,
+        gyr_since_infall,
+        lc_data.ssp_data,
+        lc_data.precomputed_ssp_mag_table,
+        lc_data.z_phot_table,
+        lc_data.wave_eff_table,
+        *dpwm.DEFAULT_PARAM_COLLECTION,
+        DEFAULT_COSMOLOGY,
+        fb,
+    )
+    phot_kern_results, phot_randoms, diffstarpop_results = _res
+
+    n_lines = 3
+    line_wave_table = np.linspace(1_000, 10_000, n_lines)
+    emline_names = lc_data.ssp_data.ssp_emline_wave._fields[0:n_lines]
+    ssp_data = lemi.get_subset_emline_data(lc_data.ssp_data, emline_names)
+    lc_data = lc_data._replace(ssp_data=ssp_data)
+
+    args = (
+        phot_key,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        upid,
+        lgmu_infall,
+        lc_data.logmhost_infall,
+        gyr_since_infall,
+        lc_data.ssp_data,
+        lc_data.precomputed_ssp_mag_table,
+        lc_data.z_phot_table,
+        lc_data.wave_eff_table,
+        line_wave_table,
+        dpwm.DEFAULT_PARAM_COLLECTION.diffstarpop_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.mzr_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.spspop_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.scatter_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.ssperr_params,
+        dpwm.DEFAULT_PARAM_COLLECTION.merging_params,
+        DEFAULT_COSMOLOGY,
+        fb,
+    )
+    _specphot_res = gd_linelum_kernels._mc_specphot_kern(*args)
+    # _specphot_res = gd_linelum_kernels._mc_specphot_kern(
+    #     phot_key,
+    #     lc_data.z_obs,
+    #     lc_data.t_obs,
+    #     lc_data.mah_params,
+    #     lc_data.ssp_data,
+    #     lc_data.precomputed_ssp_mag_table,
+    #     lc_data.z_phot_table,
+    #     lc_data.wave_eff_table,
+    #     line_wave_table,
+    #     dpwm.DEFAULT_PARAM_COLLECTION.diffstarpop_params,
+    #     dpwm.DEFAULT_PARAM_COLLECTION.mzr_params,
+    #     dpwm.DEFAULT_PARAM_COLLECTION.spspop_params,
+    #     dpwm.DEFAULT_PARAM_COLLECTION.scatter_params,
+    #     dpwm.DEFAULT_PARAM_COLLECTION.ssperr_params,
+    #     DEFAULT_COSMOLOGY,
+    #     fb,
+    # )
+
+    phot_kern_results2, phot_randoms2, spec_kern_results = _specphot_res
+    assert np.allclose(
+        phot_kern_results.obs_mags, phot_kern_results2.obs_mags, rtol=1e-4
+    )

--- a/diffsky/experimental/kernels/tests/test_gd_phot_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_phot_kernels.py
@@ -103,8 +103,14 @@ def test_mc_phot_kern(num_halos=75):
         fb,
     )
 
+    skip_keys = (
+        "burstiness_info_q",
+        "burstiness_info_ms",
+        "diffstar_info_ms",
+        "diffstar_info_q",
+    )
     for key in mc_gd_phot_kern_results._fields:
-        if key not in ("diffstar_info_ms", "diffstar_info_q"):
+        if key not in skip_keys:
             x = getattr(mc_gd_phot_kern_results, key)
             x2 = getattr(gd_phot_kern_results, key)
             assert np.allclose(x, x2)

--- a/diffsky/experimental/kernels/tests/test_gd_phot_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_phot_kernels.py
@@ -5,12 +5,12 @@ from diffstar import DEFAULT_DIFFSTAR_PARAMS
 from dsps.cosmology import DEFAULT_COSMOLOGY
 from jax import random as jran
 
+from ....merging import merging_model
 from ....param_utils import diffsky_param_wrapper as dpw
 from ....param_utils import diffsky_param_wrapper_merging as dpwm
+from ...tests import test_lightcone_generators as tlcg
 from ...tests import test_mc_phot
 from .. import gd_phot_kernels, phot_kernels
-from ...tests import test_lightcone_generators as tlcg
-from ....merging import merging_model
 
 
 def test_mc_phot_kern(num_halos=75):
@@ -103,8 +103,11 @@ def test_mc_phot_kern(num_halos=75):
         fb,
     )
 
-    for x, x2 in zip(mc_gd_phot_kern_results, gd_phot_kern_results):
-        assert np.allclose(x, x2)
+    for key in mc_gd_phot_kern_results._fields:
+        if key not in ("diffstar_info_ms", "diffstar_info_q"):
+            x = getattr(mc_gd_phot_kern_results, key)
+            x2 = getattr(gd_phot_kern_results, key)
+            assert np.allclose(x, x2)
 
     mc_phot_kern_results, mc_phot_kern_randoms = phot_kernels._mc_phot_kern(
         phot_key,

--- a/diffsky/experimental/kernels/tests/test_gd_phot_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_phot_kernels_merging.py
@@ -17,8 +17,21 @@ def check_phot_kern_merging_results(phot_kern_results, lc_data):
     n_gals = lc_data.z_obs.size
     n_z_table, n_bands, n_met, n_age = lc_data.precomputed_ssp_mag_table.shape
 
-    for arr in phot_kern_results:
-        assert np.all(np.isfinite(arr))
+    skip_keys = (
+        "burstiness_info_q",
+        "burstiness_info_ms",
+        "diffstar_info_ms",
+        "diffstar_info_q",
+    )
+    for key in phot_kern_results._fields:
+        if key not in skip_keys:
+            x = getattr(phot_kern_results, key)
+            assert np.all(np.isfinite(x))
+
+    for key in skip_keys:
+        data = getattr(phot_kern_results, key)
+        for x in data:
+            assert np.all(np.isfinite(x))
 
     assert np.all(phot_kern_results.p_merge >= 0)
     assert np.all(phot_kern_results.p_merge <= 1)

--- a/diffsky/experimental/kernels/tests/test_gd_specphot_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_specphot_kernels_merging.py
@@ -22,8 +22,19 @@ def check_spec_kern_merging_results(spec_kern_results, lc_data):
     assert spec_kern_results.linelum_gal.shape == (n_gals, n_lines)
     assert spec_kern_results.linelum_gal_in_situ.shape == (n_gals, n_lines)
 
-    for arr in spec_kern_results:
-        assert np.all(np.isfinite(arr))
+    skip_fields = (
+        "diffstar_info_ms",
+        "diffstar_info_q",
+        "burstiness_info_ms",
+        "burstiness_info_q",
+    )
+    for key in spec_kern_results._fields:
+        if key not in skip_fields:
+            arr = getattr(spec_kern_results, key)
+            try:
+                assert np.all(np.isfinite(arr))
+            except ValueError:
+                raise ValueError(f"{key} is not a flat array")
 
     msk_cen = lc_data.is_central == 1
     msk_sat = ~msk_cen

--- a/diffsky/experimental/kernels/tests/test_gd_specphot_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_specphot_kernels_merging.py
@@ -1,0 +1,82 @@
+""" """
+
+import numpy as np
+import pytest
+from dsps.cosmology import DEFAULT_COSMOLOGY
+from dsps.data_loaders import load_emline_info as lemi
+from jax import random as jran
+
+from ....merging import merging_model
+from ....param_utils import diffsky_param_wrapper as dpw
+from ...tests import test_lightcone_generators as tlcg
+from .. import gd_specphot_kernels_merging as sppkm
+from .test_phot_kernels_merging import check_phot_kern_merging_results
+
+TOL = 1e-8
+
+
+def check_spec_kern_merging_results(spec_kern_results, lc_data):
+    n_gals = lc_data.z_obs.size
+    n_lines = len(lc_data.ssp_data.ssp_emline_wave)
+
+    assert spec_kern_results.linelum_gal.shape == (n_gals, n_lines)
+    assert spec_kern_results.linelum_gal_in_situ.shape == (n_gals, n_lines)
+
+    for arr in spec_kern_results:
+        assert np.all(np.isfinite(arr))
+
+    msk_cen = lc_data.is_central == 1
+    msk_sat = ~msk_cen
+
+    # Enforce centrals can only get more massive and satellites less massive
+    name = "linelum_gal"
+    x = np.log10(getattr(spec_kern_results, name))
+    y = np.log10(getattr(spec_kern_results, name + "_in_situ"))
+    assert np.all(x[msk_cen] >= y[msk_cen] - TOL)
+    assert np.all(x[msk_sat] <= y[msk_sat] + TOL)
+    # Enforce merging is nontrivial
+    assert np.any(x[msk_cen] > y[msk_cen])
+    assert np.any(x[msk_sat] < y[msk_sat])
+
+
+@pytest.mark.parametrize("mc_merge", [0, 1])
+def test_mc_specphot_kern_merging(mc_merge, num_halos=141):
+    ran_key = jran.key(0)
+    lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
+        num_halos=num_halos
+    )
+    fb = 0.151
+
+    n_lines = 3
+    line_wave_table = np.linspace(1_000, 10_000, n_lines)
+    emline_names = lc_data.ssp_data.ssp_emline_wave._fields[0:n_lines]
+    ssp_data = lemi.get_subset_emline_data(lc_data.ssp_data, emline_names)
+    lc_data = lc_data._replace(ssp_data=ssp_data)
+
+    phot_kern_results, phot_randoms, spec_kern_results = (
+        sppkm._mc_specphot_kern_merging(
+            ran_key,
+            lc_data.z_obs,
+            lc_data.t_obs,
+            lc_data.mah_params,
+            lc_data.ssp_data,
+            lc_data.precomputed_ssp_mag_table,
+            lc_data.z_phot_table,
+            lc_data.wave_eff_table,
+            line_wave_table,
+            *dpw.DEFAULT_PARAM_COLLECTION,
+            merging_model.DEFAULT_MERGE_PARAMS,
+            DEFAULT_COSMOLOGY,
+            fb,
+            lc_data.logmp_infall,
+            lc_data.logmhost_infall,
+            lc_data.t_infall,
+            lc_data.is_central,
+            lc_data.sat_weight,
+            lc_data.halo_indx,
+            mc_merge,
+        )
+    )
+
+    check_phot_kern_merging_results(phot_kern_results, lc_data)
+    check_spec_kern_merging_results(spec_kern_results, lc_data)

--- a/diffsky/experimental/kernels/tests/test_phot_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_phot_kernels_merging.py
@@ -16,8 +16,19 @@ def check_phot_kern_merging_results(phot_kern_results, lc_data):
     n_gals = lc_data.z_obs.size
     n_z_table, n_bands, n_met, n_age = lc_data.precomputed_ssp_mag_table.shape
 
-    for arr in phot_kern_results:
-        assert np.all(np.isfinite(arr))
+    skip_fields = (
+        "diffstar_info_ms",
+        "diffstar_info_q",
+        "burstiness_info_ms",
+        "burstiness_info_q",
+    )
+    for key in phot_kern_results._fields:
+        if key not in skip_fields:
+            arr = getattr(phot_kern_results, key)
+            try:
+                assert np.all(np.isfinite(arr))
+            except ValueError:
+                raise ValueError(f"{key} is not a flat array")
 
     assert np.all(phot_kern_results.p_merge >= 0)
     assert np.all(phot_kern_results.p_merge <= 1)

--- a/diffsky/experimental/mc_diffstarpop_wrappers.py
+++ b/diffsky/experimental/mc_diffstarpop_wrappers.py
@@ -21,6 +21,10 @@ MCDiffstar = namedtuple(
     "MCDiffstar",
     ("diffstar_params_ms", "diffstar_params_q", "sfh_ms", "sfh_q", "frac_q", "mc_is_q"),
 )
+DiffstarPopResults = namedtuple(
+    "DiffstarPopResults",
+    ["sfh_params", "sfh_params_ms", "sfh_params_q", "mc_is_q", "frac_q"],
+)
 
 interp_vmap = jjit(vmap(jnp.interp, in_axes=(0, None, 0)))
 
@@ -144,10 +148,6 @@ def mc_diffstarpop_wrapper(
     sfh_params_ms, sfh_params_q, frac_q, mc_is_q = _res
     sfh_params = mc_select_diffstar_params(sfh_params_q, sfh_params_ms, mc_is_q)
 
-    DiffstarPopResults = namedtuple(
-        "DiffstarPopResults",
-        ["sfh_params", "sfh_params_ms", "sfh_params_q", "mc_is_q", "frac_q"],
-    )
     diffstarpop_results = DiffstarPopResults(
         sfh_params, sfh_params_ms, sfh_params_q, mc_is_q, frac_q
     )


### PR DESCRIPTION
This PR brings in `gd_`-versions of all the photometry kernels, e.g., `gd_dbk_kernels.py`, `gd_dbk_specphot_kernels_merging.py`, etc. This is partial progress towards the effort began in #421 and #425 to incorporate differentiable satellite quenching into the kernels.

Note that the way that the `rapid_quenching` module is used in this code is slightly different from what was implemented in #421 and #425. Here, we implement rapid quenching _before_ burstiness is added, whereas before we implemented it after. This new way of doing it made it much more straightforward to incorporate rapid quenching into the disk/bulge/knot decomposition. With this new way of doing things, some additional work is needed to ensure that burstiness does not undo the effect of rapid quenching: now we additionally map `lgfburst-->1e-7` as `p_merge-->1`, whereas before this additional step was not needed. The upshot is that previously-run gradient descents were run on slightly different versions of the rapid quenching effect. I don't _think_ this change should have any material consequences, but I thought worth flagging just in case.

The new `gd_` modules still exist on an island of code unto themselves, and have not yet been incorporated into the mock production. Before that, we will need `gd_` versions of the sed kernels, such as `kernels/sed_kernels_merging.py` and `kernels/dbk_sed_kernels_merging.py`.