### PR TITLE
Incorporate differentiable satellite quenching into all SED kernels

### DIFF
--- a/diffsky/experimental/kernels/gd_dbk_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_kernels.py
@@ -2,16 +2,20 @@
 
 from collections import namedtuple
 
+from dsps.sfh import diffburst
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import vmap
 
 from ..disk_bulge_modeling import dbpop
-from . import dbk_kernels
 from . import rapid_quenching as rq
 from . import ssp_weight_kernels as sspwk
 
 interp_vmap = jjit(vmap(jnp.interp, in_axes=(0, None, 0)))
+_BPOP = (None, 0, 0)
+get_pureburst_age_weights = jjit(
+    vmap(diffburst._pureburst_age_weights_from_params, in_axes=_BPOP)
+)
 
 
 @jjit
@@ -80,7 +84,7 @@ def get_dbk_weights_rq(
     age_weights_ddk = (_A - _B) / mstar_ddk.reshape((n_gals, 1))
 
     ssp_lg_age_yr = ssp_data.ssp_lg_age_gyr + 9.0
-    age_weights_pureburst = dbk_kernels.get_pureburst_age_weights(
+    age_weights_pureburst = get_pureburst_age_weights(
         ssp_lg_age_yr, burst_params.lgyr_peak, burst_params.lgyr_max
     )
 
@@ -108,7 +112,7 @@ def get_dbk_weights_rq(
     ssp_weights_disk = sspwk.combine_age_met_weights(age_weights_dd, lgmet_weights)
     ssp_weights_knots = sspwk.combine_age_met_weights(age_weights_knots, lgmet_weights)
 
-    dbk_weights_rq = dbk_kernels.DBKWeights(
+    dbk_weights_rq = DBKWeights(
         ssp_weights_bulge=ssp_weights_bulge,
         ssp_weights_disk=ssp_weights_disk,
         ssp_weights_knots=ssp_weights_knots,
@@ -202,4 +206,15 @@ DBKPhotInfo = namedtuple(
 )
 DBKSpecInfo = namedtuple(
     "DBKSpecInfo", ("linelum_bulge", "linelum_disk", "linelum_knots")
+)
+DBKWeights = namedtuple(
+    "DBKWeights",
+    (
+        "ssp_weights_bulge",
+        "ssp_weights_disk",
+        "ssp_weights_knots",
+        "mstar_bulge",
+        "mstar_disk",
+        "mstar_knots",
+    ),
 )

--- a/diffsky/experimental/kernels/gd_dbk_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_kernels.py
@@ -70,7 +70,9 @@ def get_dbk_weights_rq(
     mstar_knots = fknot * mstar_ddk  # mass of knots
     mstar_dd = mstar_ddk - mstar_knots  # mass of diffuse disk
 
-    # m_ddk*W_ddk = m_dd*W_dd + m_k*W_k
+    mstar_ddk_smooth = mstar_ddk - mstar_burst
+
+    # m_tot*W_tot = m_ddk*W_ddk + m_bulge*W_bulge
     _A = mstar_tot.reshape((n_gals, 1)) * age_weights_tot
     _B = mstar_bulge.reshape((n_gals, 1)) * age_weights_bulge
     age_weights_ddk = (_A - _B) / mstar_ddk.reshape((n_gals, 1))
@@ -83,7 +85,6 @@ def get_dbk_weights_rq(
     # m_ddk*W_ddk = m_ddk_smooth*W_ddk_smooth + m_burst*W_burst
     _C = mstar_ddk.reshape((n_gals, 1)) * age_weights_ddk
     _D = mstar_burst.reshape((n_gals, 1)) * age_weights_pureburst
-    mstar_ddk_smooth = mstar_ddk - mstar_burst
     age_weights_ddk_smooth = (_C - _D) / mstar_ddk_smooth.reshape((n_gals, 1))
 
     # m_k*W_k = m_ks_smooth*W_ddk_smooth + m_burst_knot*W_burst
@@ -94,6 +95,7 @@ def get_dbk_weights_rq(
     _F = mstar_knots_burst.reshape((n_gals, 1)) * age_weights_pureburst
     age_weights_knots = (_E + _F) / mstar_knots.reshape((n_gals, 1))
 
+    # m_dd*W_dd = m_dds*W_ddk_smooth + m_ddb*W_burst
     mstar_dd_burst = jnp.where(mburst_by_mknot > 1, mstar_burst - mstar_knots, 0.0)
     mstar_dd_smooth = mstar_dd - mstar_dd_burst
     _G = mstar_dd_smooth.reshape((n_gals, 1)) * age_weights_ddk_smooth

--- a/diffsky/experimental/kernels/gd_dbk_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_kernels.py
@@ -1,5 +1,7 @@
 """"""
 
+from collections import namedtuple
+
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import vmap
@@ -136,3 +138,68 @@ def get_bulge_age_weights_rq(
     )
 
     return age_weights_bulge_rq, mstar_bulge
+
+
+@jjit
+def _get_dbk_phot_from_dbk_weights(
+    ssp_photflux_table, dbk_weights, dust_frac_trans, frac_ssp_err
+):
+    n_gals, n_bands, n_met, n_age = ssp_photflux_table.shape
+
+    # Reshape arrays before calculating galaxy magnitudes
+    _ftrans = dust_frac_trans.reshape((n_gals, n_bands, 1, n_age))
+
+    _ferr_ssp = frac_ssp_err.reshape((n_gals, n_bands, 1, 1))
+
+    _w_bulge = dbk_weights.ssp_weights_bulge.reshape((n_gals, 1, n_met, n_age))
+    _w_dd = dbk_weights.ssp_weights_disk.reshape((n_gals, 1, n_met, n_age))
+    _w_knot = dbk_weights.ssp_weights_knots.reshape((n_gals, 1, n_met, n_age))
+
+    _mstar_bulge = dbk_weights.mstar_bulge.reshape((n_gals, 1))
+    _mstar_disk = dbk_weights.mstar_disk.reshape((n_gals, 1))
+    _mstar_knots = dbk_weights.mstar_knots.reshape((n_gals, 1))
+
+    integrand_bulge = ssp_photflux_table * _w_bulge * _ftrans * _ferr_ssp
+    flux_bulge = jnp.sum(integrand_bulge, axis=(2, 3)) * _mstar_bulge
+    obs_mags_bulge = -2.5 * jnp.log10(flux_bulge)
+
+    integrand_disk = ssp_photflux_table * _w_dd * _ftrans * _ferr_ssp
+    flux_disk = jnp.sum(integrand_disk, axis=(2, 3)) * _mstar_disk
+    obs_mags_disk = -2.5 * jnp.log10(flux_disk)
+
+    integrand_knots = ssp_photflux_table * _w_knot * _ftrans * _ferr_ssp
+    flux_knots = jnp.sum(integrand_knots, axis=(2, 3)) * _mstar_knots
+    obs_mags_knots = -2.5 * jnp.log10(flux_knots)
+
+    return DBKPhotInfo(obs_mags_bulge, obs_mags_disk, obs_mags_knots)
+
+
+@jjit
+def _get_dbk_linelum_decomposition(dbk_weights, spec_kern_results, ssp_data):
+    linelum_bulge = sspwk._compute_linelum_from_weights(
+        jnp.log10(dbk_weights.mstar_bulge),
+        spec_kern_results.dust_ftrans_lines,
+        ssp_data,
+        dbk_weights.ssp_weights_bulge,
+    )
+    linelum_disk = sspwk._compute_linelum_from_weights(
+        jnp.log10(dbk_weights.mstar_disk),
+        spec_kern_results.dust_ftrans_lines,
+        ssp_data,
+        dbk_weights.ssp_weights_disk,
+    )
+    linelum_knots = sspwk._compute_linelum_from_weights(
+        jnp.log10(dbk_weights.mstar_knots),
+        spec_kern_results.dust_ftrans_lines,
+        ssp_data,
+        dbk_weights.ssp_weights_knots,
+    )
+    return DBKSpecInfo(linelum_bulge, linelum_disk, linelum_knots)
+
+
+DBKPhotInfo = namedtuple(
+    "DBKPhotInfo", ("obs_mags_bulge", "obs_mags_disk", "obs_mags_knots")
+)
+DBKSpecInfo = namedtuple(
+    "DBKSpecInfo", ("linelum_bulge", "linelum_disk", "linelum_knots")
+)

--- a/diffsky/experimental/kernels/gd_dbk_sed_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_sed_kernels.py
@@ -7,15 +7,13 @@ from jax import jit as jjit
 from jax import numpy as jnp
 
 from .. import mc_diffstarpop_wrappers as mcdw
-from . import dbk_kernels
-from . import sed_kernels_merging as sedkm
+from . import dbk_kernels, gd_sed_kernels
 
 
 @partial(jjit, static_argnames=["n_t_table"])
 def _dbk_sed_kern(
     phot_randoms,
     dbk_randoms,
-    merging_randoms,
     sfh_params,
     z_obs,
     t_obs,
@@ -32,20 +30,25 @@ def _dbk_sed_kern(
     logmhost_infall,
     t_infall,
     is_central,
-    sat_weights,
     halo_indx,
-    mc_merge,
     *,
     n_t_table=mcdw.N_T_TABLE,
 ):
     """"""
-    sed_info = sedkm._sed_kern(
+    upid = jnp.where(is_central == 1, -1, halo_indx).astype(int)
+    lgmu_infall = logmp_infall - logmhost_infall
+    gyr_since_infall = t_obs - t_infall
+
+    sed_info = gd_sed_kernels._sed_kern(
         phot_randoms,
-        merging_randoms,
         sfh_params,
         z_obs,
         t_obs,
         mah_params,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
         ssp_data,
         mzr_params,
         spspop_params,
@@ -54,13 +57,6 @@ def _dbk_sed_kern(
         merging_params,
         cosmo_params,
         fb,
-        logmp_infall,
-        logmhost_infall,
-        t_infall,
-        is_central,
-        sat_weights,
-        halo_indx,
-        mc_merge,
         n_t_table=n_t_table,
     )
 
@@ -77,41 +73,41 @@ def _dbk_sed_kern(
     n_gals = z_obs.size
     n_met, n_age, n_wave = ssp_data.ssp_flux.shape
 
-    _w_bulge = dbk_weights.ssp_weights_bulge.reshape((n_gals, n_met, n_age, 1))
-    _w_dd = dbk_weights.ssp_weights_disk.reshape((n_gals, n_met, n_age, 1))
-    _w_knot = dbk_weights.ssp_weights_knots.reshape((n_gals, n_met, n_age, 1))
+    # _w_bulge = dbk_weights.ssp_weights_bulge.reshape((n_gals, n_met, n_age, 1))
+    # _w_dd = dbk_weights.ssp_weights_disk.reshape((n_gals, n_met, n_age, 1))
+    # _w_knot = dbk_weights.ssp_weights_knots.reshape((n_gals, n_met, n_age, 1))
 
-    mb_in_situ = dbk_weights.mstar_bulge
-    md_in_situ = dbk_weights.mstar_disk
-    mk_in_situ = dbk_weights.mstar_knots
-    mstar_in_situ = mb_in_situ + md_in_situ + mk_in_situ
-    mstar_obs = 10**sed_info.logsm_obs
-    mass_ratio = mstar_obs / mstar_in_situ
-    dbk_weights = dbk_weights._replace(
-        mstar_bulge=mass_ratio * mb_in_situ,
-        mstar_disk=mass_ratio * md_in_situ,
-        mstar_knots=mass_ratio * mk_in_situ,
-    )
-    mb_obs = dbk_weights.mstar_bulge.reshape((n_gals, 1))
-    md_obs = dbk_weights.mstar_disk.reshape((n_gals, 1))
-    mk_obs = dbk_weights.mstar_knots.reshape((n_gals, 1))
+    # mb_in_situ = dbk_weights.mstar_bulge
+    # md_in_situ = dbk_weights.mstar_disk
+    # mk_in_situ = dbk_weights.mstar_knots
+    # mstar_in_situ = mb_in_situ + md_in_situ + mk_in_situ
+    # mstar_obs = 10**sed_info.logsm_obs
+    # mass_ratio = mstar_obs / mstar_in_situ
+    # dbk_weights = dbk_weights._replace(
+    #     mstar_bulge=mass_ratio * mb_in_situ,
+    #     mstar_disk=mass_ratio * md_in_situ,
+    #     mstar_knots=mass_ratio * mk_in_situ,
+    # )
+    # mb_obs = dbk_weights.mstar_bulge.reshape((n_gals, 1))
+    # md_obs = dbk_weights.mstar_disk.reshape((n_gals, 1))
+    # mk_obs = dbk_weights.mstar_knots.reshape((n_gals, 1))
 
-    a = sed_info.dust_frac_trans.reshape((n_gals, 1, n_age, n_wave))
-    b = sed_info.frac_ssp_errors.reshape((n_gals, 1, 1, n_wave))
-    d = ssp_data.ssp_flux.reshape((1, n_met, n_age, n_wave))
+    # a = sed_info.dust_frac_trans.reshape((n_gals, 1, n_age, n_wave))
+    # b = sed_info.frac_ssp_errors.reshape((n_gals, 1, 1, n_wave))
+    # d = ssp_data.ssp_flux.reshape((1, n_met, n_age, n_wave))
 
-    sed_bulge = jnp.sum(a * b * _w_bulge * d, axis=(1, 2)) * mb_obs
-    sed_disk = jnp.sum(a * b * _w_dd * d, axis=(1, 2)) * md_obs
-    sed_knots = jnp.sum(a * b * _w_knot * d, axis=(1, 2)) * mk_obs
+    # sed_bulge = jnp.sum(a * b * _w_bulge * d, axis=(1, 2)) * mb_obs
+    # sed_disk = jnp.sum(a * b * _w_dd * d, axis=(1, 2)) * md_obs
+    # sed_knots = jnp.sum(a * b * _w_knot * d, axis=(1, 2)) * mk_obs
 
-    new_keys = ["rest_sed_bulge", "rest_sed_disk", "rest_sed_knots"]
+    # new_keys = ["rest_sed_bulge", "rest_sed_disk", "rest_sed_knots"]
 
-    fields = list(sed_info._fields) + new_keys
-    SEDInfo = namedtuple("SEDInfo", fields)
-    sed_info = SEDInfo(
-        **sed_info._asdict(),
-        rest_sed_bulge=sed_bulge,
-        rest_sed_disk=sed_disk,
-        rest_sed_knots=sed_knots,
-    )
+    # fields = list(sed_info._fields) + new_keys
+    # SEDInfo = namedtuple("SEDInfo", fields)
+    # sed_info = SEDInfo(
+    #     **sed_info._asdict(),
+    #     rest_sed_bulge=sed_bulge,
+    #     rest_sed_disk=sed_disk,
+    #     rest_sed_knots=sed_knots,
+    # )
     return sed_info

--- a/diffsky/experimental/kernels/gd_dbk_sed_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_sed_kernels.py
@@ -6,8 +6,9 @@ from functools import partial
 from jax import jit as jjit
 from jax import numpy as jnp
 
+from ...merging import merging_model
 from .. import mc_diffstarpop_wrappers as mcdw
-from . import dbk_kernels, gd_sed_kernels
+from . import gd_dbk_kernels, gd_sed_kernels
 
 
 @partial(jjit, static_argnames=["n_t_table"])
@@ -60,7 +61,12 @@ def _dbk_sed_kern(
         n_t_table=n_t_table,
     )
 
-    dbk_weights, disk_bulge_history = dbk_kernels._dbk_kern(
+    p_merge_smooth = merging_model.get_p_merge_from_merging_params(
+        merging_params, logmp_infall, logmhost_infall, t_obs, t_infall, upid
+    )
+
+    age_weights = jnp.sum(sed_info.ssp_weights, axis=1)
+    args = (
         t_obs,
         ssp_data,
         sed_info.t_table,
@@ -68,7 +74,11 @@ def _dbk_sed_kern(
         sed_info.burst_params,
         sed_info.lgmet_weights,
         dbk_randoms,
+        sed_info.logsm_obs,
+        age_weights,
+        p_merge_smooth,
     )
+    dbk_weights, disk_bulge_history = gd_dbk_kernels._dbk_kern(*args)
 
     n_gals = z_obs.size
     n_met, n_age, n_wave = ssp_data.ssp_flux.shape

--- a/diffsky/experimental/kernels/gd_dbk_sed_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_sed_kernels.py
@@ -99,14 +99,25 @@ def _dbk_sed_kern(
     mk = dbk_weights.mstar_knots.reshape((n_gals, 1))
     sed_knots = jnp.sum(a * b * c_k * d, axis=(1, 2)) * mk
 
-    new_keys = ["rest_sed_bulge", "rest_sed_disk", "rest_sed_knots"]
-
-    fields = list(sed_info._fields) + new_keys
-    SEDInfo = namedtuple("SEDInfo", fields)
-    sed_info = SEDInfo(
+    sed_info = DBKSEDInfo(
         **sed_info._asdict(),
         rest_sed_bulge=sed_bulge,
         rest_sed_disk=sed_disk,
         rest_sed_knots=sed_knots,
+        mstar_bulge=dbk_weights.mstar_bulge,
+        mstar_disk=dbk_weights.mstar_disk,
+        mstar_knots=dbk_weights.mstar_knots,
     )
     return sed_info
+
+
+_DBK_SED_EXTRA_FIELDS = [
+    "rest_sed_bulge",
+    "rest_sed_disk",
+    "rest_sed_knots",
+    "mstar_bulge",
+    "mstar_disk",
+    "mstar_knots",
+]
+_DBK_SED_FIELDS = list(gd_sed_kernels.SEDKernResults._fields) + _DBK_SED_EXTRA_FIELDS
+DBKSEDInfo = namedtuple("DBKSEDInfo", _DBK_SED_FIELDS)

--- a/diffsky/experimental/kernels/gd_dbk_sed_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_sed_kernels.py
@@ -1,0 +1,117 @@
+""""""
+
+from collections import namedtuple
+from functools import partial
+
+from jax import jit as jjit
+from jax import numpy as jnp
+
+from .. import mc_diffstarpop_wrappers as mcdw
+from . import dbk_kernels
+from . import sed_kernels_merging as sedkm
+
+
+@partial(jjit, static_argnames=["n_t_table"])
+def _dbk_sed_kern(
+    phot_randoms,
+    dbk_randoms,
+    merging_randoms,
+    sfh_params,
+    z_obs,
+    t_obs,
+    mah_params,
+    ssp_data,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    merging_params,
+    cosmo_params,
+    fb,
+    logmp_infall,
+    logmhost_infall,
+    t_infall,
+    is_central,
+    sat_weights,
+    halo_indx,
+    mc_merge,
+    *,
+    n_t_table=mcdw.N_T_TABLE,
+):
+    """"""
+    sed_info = sedkm._sed_kern(
+        phot_randoms,
+        merging_randoms,
+        sfh_params,
+        z_obs,
+        t_obs,
+        mah_params,
+        ssp_data,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        merging_params,
+        cosmo_params,
+        fb,
+        logmp_infall,
+        logmhost_infall,
+        t_infall,
+        is_central,
+        sat_weights,
+        halo_indx,
+        mc_merge,
+        n_t_table=n_t_table,
+    )
+
+    dbk_weights, disk_bulge_history = dbk_kernels._dbk_kern(
+        t_obs,
+        ssp_data,
+        sed_info.t_table,
+        sed_info.sfh_table,
+        sed_info.burst_params,
+        sed_info.lgmet_weights,
+        dbk_randoms,
+    )
+
+    n_gals = z_obs.size
+    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+
+    _w_bulge = dbk_weights.ssp_weights_bulge.reshape((n_gals, n_met, n_age, 1))
+    _w_dd = dbk_weights.ssp_weights_disk.reshape((n_gals, n_met, n_age, 1))
+    _w_knot = dbk_weights.ssp_weights_knots.reshape((n_gals, n_met, n_age, 1))
+
+    mb_in_situ = dbk_weights.mstar_bulge
+    md_in_situ = dbk_weights.mstar_disk
+    mk_in_situ = dbk_weights.mstar_knots
+    mstar_in_situ = mb_in_situ + md_in_situ + mk_in_situ
+    mstar_obs = 10**sed_info.logsm_obs
+    mass_ratio = mstar_obs / mstar_in_situ
+    dbk_weights = dbk_weights._replace(
+        mstar_bulge=mass_ratio * mb_in_situ,
+        mstar_disk=mass_ratio * md_in_situ,
+        mstar_knots=mass_ratio * mk_in_situ,
+    )
+    mb_obs = dbk_weights.mstar_bulge.reshape((n_gals, 1))
+    md_obs = dbk_weights.mstar_disk.reshape((n_gals, 1))
+    mk_obs = dbk_weights.mstar_knots.reshape((n_gals, 1))
+
+    a = sed_info.dust_frac_trans.reshape((n_gals, 1, n_age, n_wave))
+    b = sed_info.frac_ssp_errors.reshape((n_gals, 1, 1, n_wave))
+    d = ssp_data.ssp_flux.reshape((1, n_met, n_age, n_wave))
+
+    sed_bulge = jnp.sum(a * b * _w_bulge * d, axis=(1, 2)) * mb_obs
+    sed_disk = jnp.sum(a * b * _w_dd * d, axis=(1, 2)) * md_obs
+    sed_knots = jnp.sum(a * b * _w_knot * d, axis=(1, 2)) * mk_obs
+
+    new_keys = ["rest_sed_bulge", "rest_sed_disk", "rest_sed_knots"]
+
+    fields = list(sed_info._fields) + new_keys
+    SEDInfo = namedtuple("SEDInfo", fields)
+    sed_info = SEDInfo(
+        **sed_info._asdict(),
+        rest_sed_bulge=sed_bulge,
+        rest_sed_disk=sed_disk,
+        rest_sed_knots=sed_knots,
+    )
+    return sed_info

--- a/diffsky/experimental/kernels/gd_dbk_sed_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_sed_kernels.py
@@ -83,41 +83,30 @@ def _dbk_sed_kern(
     n_gals = z_obs.size
     n_met, n_age, n_wave = ssp_data.ssp_flux.shape
 
-    # _w_bulge = dbk_weights.ssp_weights_bulge.reshape((n_gals, n_met, n_age, 1))
-    # _w_dd = dbk_weights.ssp_weights_disk.reshape((n_gals, n_met, n_age, 1))
-    # _w_knot = dbk_weights.ssp_weights_knots.reshape((n_gals, n_met, n_age, 1))
+    a = sed_info.dust_frac_trans.reshape((n_gals, 1, n_age, n_wave))
+    b = sed_info.frac_ssp_errors.reshape((n_gals, 1, 1, n_wave))
+    d = ssp_data.ssp_flux.reshape((1, n_met, n_age, n_wave))
 
-    # mb_in_situ = dbk_weights.mstar_bulge
-    # md_in_situ = dbk_weights.mstar_disk
-    # mk_in_situ = dbk_weights.mstar_knots
-    # mstar_in_situ = mb_in_situ + md_in_situ + mk_in_situ
-    # mstar_obs = 10**sed_info.logsm_obs
-    # mass_ratio = mstar_obs / mstar_in_situ
-    # dbk_weights = dbk_weights._replace(
-    #     mstar_bulge=mass_ratio * mb_in_situ,
-    #     mstar_disk=mass_ratio * md_in_situ,
-    #     mstar_knots=mass_ratio * mk_in_situ,
-    # )
-    # mb_obs = dbk_weights.mstar_bulge.reshape((n_gals, 1))
-    # md_obs = dbk_weights.mstar_disk.reshape((n_gals, 1))
-    # mk_obs = dbk_weights.mstar_knots.reshape((n_gals, 1))
+    c_b = dbk_weights.ssp_weights_bulge.reshape((n_gals, n_met, n_age, 1))
+    mb = dbk_weights.mstar_bulge.reshape((n_gals, 1))
+    sed_bulge = jnp.sum(a * b * c_b * d, axis=(1, 2)) * mb
 
-    # a = sed_info.dust_frac_trans.reshape((n_gals, 1, n_age, n_wave))
-    # b = sed_info.frac_ssp_errors.reshape((n_gals, 1, 1, n_wave))
-    # d = ssp_data.ssp_flux.reshape((1, n_met, n_age, n_wave))
+    c_dd = dbk_weights.ssp_weights_disk.reshape((n_gals, n_met, n_age, 1))
+    mdd = dbk_weights.mstar_disk.reshape((n_gals, 1))
+    sed_disk = jnp.sum(a * b * c_dd * d, axis=(1, 2)) * mdd
 
-    # sed_bulge = jnp.sum(a * b * _w_bulge * d, axis=(1, 2)) * mb_obs
-    # sed_disk = jnp.sum(a * b * _w_dd * d, axis=(1, 2)) * md_obs
-    # sed_knots = jnp.sum(a * b * _w_knot * d, axis=(1, 2)) * mk_obs
+    c_k = dbk_weights.ssp_weights_knots.reshape((n_gals, n_met, n_age, 1))
+    mk = dbk_weights.mstar_knots.reshape((n_gals, 1))
+    sed_knots = jnp.sum(a * b * c_k * d, axis=(1, 2)) * mk
 
-    # new_keys = ["rest_sed_bulge", "rest_sed_disk", "rest_sed_knots"]
+    new_keys = ["rest_sed_bulge", "rest_sed_disk", "rest_sed_knots"]
 
-    # fields = list(sed_info._fields) + new_keys
-    # SEDInfo = namedtuple("SEDInfo", fields)
-    # sed_info = SEDInfo(
-    #     **sed_info._asdict(),
-    #     rest_sed_bulge=sed_bulge,
-    #     rest_sed_disk=sed_disk,
-    #     rest_sed_knots=sed_knots,
-    # )
+    fields = list(sed_info._fields) + new_keys
+    SEDInfo = namedtuple("SEDInfo", fields)
+    sed_info = SEDInfo(
+        **sed_info._asdict(),
+        rest_sed_bulge=sed_bulge,
+        rest_sed_disk=sed_disk,
+        rest_sed_knots=sed_knots,
+    )
     return sed_info

--- a/diffsky/experimental/kernels/gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_dbk_sed_kernels_merging.py
@@ -1,0 +1,122 @@
+""""""
+
+from collections import namedtuple
+from functools import partial
+
+from jax import jit as jjit
+from jax import numpy as jnp
+
+from .. import mc_diffstarpop_wrappers as mcdw
+from . import gd_dbk_kernels
+from . import gd_sed_kernels_merging as gd_sedkm
+
+
+@partial(jjit, static_argnames=["n_t_table"])
+def _dbk_sed_kern(
+    phot_randoms,
+    dbk_randoms,
+    merging_randoms,
+    sfh_params,
+    z_obs,
+    t_obs,
+    mah_params,
+    ssp_data,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    merging_params,
+    cosmo_params,
+    fb,
+    logmp_infall,
+    logmhost_infall,
+    t_infall,
+    is_central,
+    sat_weights,
+    halo_indx,
+    mc_merge,
+    *,
+    n_t_table=mcdw.N_T_TABLE,
+):
+    """"""
+    sed_info = gd_sedkm._sed_kern(
+        phot_randoms,
+        merging_randoms,
+        sfh_params,
+        z_obs,
+        t_obs,
+        mah_params,
+        ssp_data,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        merging_params,
+        cosmo_params,
+        fb,
+        logmp_infall,
+        logmhost_infall,
+        t_infall,
+        is_central,
+        sat_weights,
+        halo_indx,
+        mc_merge,
+        n_t_table=n_t_table,
+    )
+
+    age_weights = jnp.sum(sed_info.ssp_weights, axis=1)
+    args = (
+        t_obs,
+        ssp_data,
+        sed_info.t_table,
+        sed_info.sfh_table,
+        sed_info.burst_params,
+        sed_info.lgmet_weights,
+        dbk_randoms,
+        sed_info.logsm_obs,
+        age_weights,
+        sed_info.p_merge_smooth,
+    )
+    dbk_weights, disk_bulge_history = gd_dbk_kernels._dbk_kern(*args)
+
+    n_gals = z_obs.size
+    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+
+    _w_bulge = dbk_weights.ssp_weights_bulge.reshape((n_gals, n_met, n_age, 1))
+    _w_dd = dbk_weights.ssp_weights_disk.reshape((n_gals, n_met, n_age, 1))
+    _w_knot = dbk_weights.ssp_weights_knots.reshape((n_gals, n_met, n_age, 1))
+
+    mb_in_situ = dbk_weights.mstar_bulge
+    md_in_situ = dbk_weights.mstar_disk
+    mk_in_situ = dbk_weights.mstar_knots
+    mstar_in_situ = mb_in_situ + md_in_situ + mk_in_situ
+    mstar_obs = 10**sed_info.logsm_obs
+    mass_ratio = mstar_obs / mstar_in_situ
+    dbk_weights = dbk_weights._replace(
+        mstar_bulge=mass_ratio * mb_in_situ,
+        mstar_disk=mass_ratio * md_in_situ,
+        mstar_knots=mass_ratio * mk_in_situ,
+    )
+    mb_obs = dbk_weights.mstar_bulge.reshape((n_gals, 1))
+    md_obs = dbk_weights.mstar_disk.reshape((n_gals, 1))
+    mk_obs = dbk_weights.mstar_knots.reshape((n_gals, 1))
+
+    a = sed_info.dust_frac_trans.reshape((n_gals, 1, n_age, n_wave))
+    b = sed_info.frac_ssp_errors.reshape((n_gals, 1, 1, n_wave))
+    d = ssp_data.ssp_flux.reshape((1, n_met, n_age, n_wave))
+
+    sed_bulge = jnp.sum(a * b * _w_bulge * d, axis=(1, 2)) * mb_obs
+    sed_disk = jnp.sum(a * b * _w_dd * d, axis=(1, 2)) * md_obs
+    sed_knots = jnp.sum(a * b * _w_knot * d, axis=(1, 2)) * mk_obs
+
+    new_keys = ["rest_sed_bulge", "rest_sed_disk", "rest_sed_knots"]
+
+    fields = list(sed_info._fields) + new_keys
+    SEDInfo = namedtuple("SEDInfo", fields)
+    sed_info = SEDInfo(
+        **sed_info._asdict(),
+        rest_sed_bulge=sed_bulge,
+        rest_sed_disk=sed_disk,
+        rest_sed_knots=sed_knots,
+    )
+    return sed_info

--- a/diffsky/experimental/kernels/gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_dbk_sed_kernels_merging.py
@@ -64,6 +64,7 @@ def _dbk_sed_kern(
         n_t_table=n_t_table,
     )
 
+    lgmet_weights = jnp.sum(sed_info.ssp_weights, axis=2)
     age_weights = jnp.sum(sed_info.ssp_weights, axis=1)
     args = (
         t_obs,
@@ -71,7 +72,7 @@ def _dbk_sed_kern(
         sed_info.t_table,
         sed_info.sfh_table,
         sed_info.burst_params,
-        sed_info.lgmet_weights,
+        lgmet_weights,
         dbk_randoms,
         sed_info.logsm_obs,
         age_weights,

--- a/diffsky/experimental/kernels/gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_dbk_sed_kernels_merging.py
@@ -7,8 +7,8 @@ from jax import jit as jjit
 from jax import numpy as jnp
 
 from .. import mc_diffstarpop_wrappers as mcdw
-from . import gd_dbk_kernels
-from . import gd_sed_kernels_merging as gd_sedkm
+from . import gd_dbk_sed_kernels as gd_sedk
+from . import gd_sed_kernels_merging
 
 
 @partial(jjit, static_argnames=["n_t_table"])
@@ -39,9 +39,9 @@ def _dbk_sed_kern(
     n_t_table=mcdw.N_T_TABLE,
 ):
     """"""
-    sed_info = gd_sedkm._sed_kern(
+    dbk_sed_info_in_situ = gd_sedk._dbk_sed_kern(
         phot_randoms,
-        merging_randoms,
+        dbk_randoms,
         sfh_params,
         z_obs,
         t_obs,
@@ -58,66 +58,123 @@ def _dbk_sed_kern(
         logmhost_infall,
         t_infall,
         is_central,
-        sat_weights,
         halo_indx,
-        mc_merge,
         n_t_table=n_t_table,
     )
 
-    lgmet_weights = jnp.sum(sed_info.ssp_weights, axis=2)
-    age_weights = jnp.sum(sed_info.ssp_weights, axis=1)
-    args = (
-        t_obs,
-        ssp_data,
-        sed_info.t_table,
-        sed_info.sfh_table,
-        sed_info.burst_params,
-        lgmet_weights,
-        dbk_randoms,
-        sed_info.logsm_obs,
-        age_weights,
-        sed_info.p_merge_smooth,
+    dbk_sed_merging_quantities = _get_dbk_sed_kern_merging_quantities(
+        dbk_sed_info_in_situ,
+        merging_randoms,
+        sat_weights,
+        halo_indx,
+        mc_merge,
     )
-    dbk_weights, disk_bulge_history = gd_dbk_kernels._dbk_kern(*args)
 
-    n_gals = z_obs.size
-    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+    dbk_sed_info = _update_dbk_sed_kern_results_with_merging(
+        dbk_sed_info_in_situ, merging_randoms, *dbk_sed_merging_quantities
+    )
 
-    _w_bulge = dbk_weights.ssp_weights_bulge.reshape((n_gals, n_met, n_age, 1))
-    _w_dd = dbk_weights.ssp_weights_disk.reshape((n_gals, n_met, n_age, 1))
-    _w_knot = dbk_weights.ssp_weights_knots.reshape((n_gals, n_met, n_age, 1))
+    return dbk_sed_info
 
-    mb_in_situ = dbk_weights.mstar_bulge
-    md_in_situ = dbk_weights.mstar_disk
-    mk_in_situ = dbk_weights.mstar_knots
+
+@jjit
+def _get_dbk_sed_kern_merging_quantities(
+    dbk_sed_info_in_situ,
+    merging_randoms,
+    sat_weights,
+    halo_indx,
+    mc_merge,
+):
+    _res = gd_sed_kernels_merging._get_sed_kern_merging_quantities(
+        dbk_sed_info_in_situ, merging_randoms, sat_weights, halo_indx, mc_merge
+    )
+    (
+        mstar_in_situ,
+        mstar_obs,
+        rest_sed_in_situ,
+        rest_sed,
+        p_merge,
+        ssp_weights,
+        ssp_weights_in_situ,
+    ) = _res
+
+    mb_in_situ = dbk_sed_info_in_situ.mstar_bulge
+    md_in_situ = dbk_sed_info_in_situ.mstar_disk
+    mk_in_situ = dbk_sed_info_in_situ.mstar_knots
     mstar_in_situ = mb_in_situ + md_in_situ + mk_in_situ
-    mstar_obs = 10**sed_info.logsm_obs
+    mstar_obs = 10**dbk_sed_info_in_situ.logsm_obs
     mass_ratio = mstar_obs / mstar_in_situ
-    dbk_weights = dbk_weights._replace(
-        mstar_bulge=mass_ratio * mb_in_situ,
-        mstar_disk=mass_ratio * md_in_situ,
-        mstar_knots=mass_ratio * mk_in_situ,
+
+    n_gals = mstar_obs.shape[0]
+
+    mstar_bulge = mass_ratio * mb_in_situ
+    mstar_disk = mass_ratio * md_in_situ
+    mstar_knots = mass_ratio * mk_in_situ
+
+    mb = mstar_bulge.reshape((n_gals, 1))
+    md = mstar_disk.reshape((n_gals, 1))
+    mk = mstar_knots.reshape((n_gals, 1))
+
+    rest_sed_bulge = mb * dbk_sed_info_in_situ.rest_sed_bulge
+    rest_sed_disk = md * dbk_sed_info_in_situ.rest_sed_disk
+    rest_sed_knots = mk * dbk_sed_info_in_situ.rest_sed_knots
+
+    return (
+        mstar_in_situ,
+        mstar_obs,
+        rest_sed_in_situ,
+        rest_sed,
+        p_merge,
+        mstar_bulge,
+        mstar_disk,
+        mstar_knots,
+        rest_sed_bulge,
+        rest_sed_disk,
+        rest_sed_knots,
     )
-    mb_obs = dbk_weights.mstar_bulge.reshape((n_gals, 1))
-    md_obs = dbk_weights.mstar_disk.reshape((n_gals, 1))
-    mk_obs = dbk_weights.mstar_knots.reshape((n_gals, 1))
 
-    a = sed_info.dust_frac_trans.reshape((n_gals, 1, n_age, n_wave))
-    b = sed_info.frac_ssp_errors.reshape((n_gals, 1, 1, n_wave))
-    d = ssp_data.ssp_flux.reshape((1, n_met, n_age, n_wave))
 
-    sed_bulge = jnp.sum(a * b * _w_bulge * d, axis=(1, 2)) * mb_obs
-    sed_disk = jnp.sum(a * b * _w_dd * d, axis=(1, 2)) * md_obs
-    sed_knots = jnp.sum(a * b * _w_knot * d, axis=(1, 2)) * mk_obs
+@jjit
+def _update_dbk_sed_kern_results_with_merging(
+    dbk_sed_info_in_situ,
+    merging_randoms,
+    mstar_in_situ,
+    mstar_obs,
+    rest_sed_in_situ,
+    rest_sed,
+    p_merge,
+    mstar_bulge,
+    mstar_disk,
+    mstar_knots,
+    rest_sed_bulge,
+    rest_sed_disk,
+    rest_sed_knots,
+):
+    ex_situ_dict = dict()
+    ex_situ_dict["logsm_obs"] = jnp.log10(mstar_obs)
+    ex_situ_dict["rest_sed"] = rest_sed
+    ex_situ_dict["mstar_bulge"] = mstar_bulge
+    ex_situ_dict["mstar_disk"] = mstar_disk
+    ex_situ_dict["mstar_knots"] = mstar_knots
 
-    new_keys = ["rest_sed_bulge", "rest_sed_disk", "rest_sed_knots"]
+    ex_situ_dict["rest_sed_bulge"] = rest_sed_bulge
+    ex_situ_dict["rest_sed_disk"] = rest_sed_disk
+    ex_situ_dict["rest_sed_knots"] = rest_sed_knots
 
-    fields = list(sed_info._fields) + new_keys
-    SEDInfo = namedtuple("SEDInfo", fields)
-    sed_info = SEDInfo(
-        **sed_info._asdict(),
-        rest_sed_bulge=sed_bulge,
-        rest_sed_disk=sed_disk,
-        rest_sed_knots=sed_knots,
+    dbk_sed_info = dbk_sed_info_in_situ._replace(**ex_situ_dict)
+
+    in_situ_dict = dict()
+    in_situ_dict["logsm_obs" + "_in_situ"] = jnp.log10(mstar_in_situ)
+    in_situ_dict["rest_sed_in_situ"] = rest_sed_in_situ
+
+    new_keys = ["logsm_obs_in_situ", "rest_sed_in_situ", "p_merge", "uran_pmerge"]
+    fields = list(dbk_sed_info._fields) + new_keys
+    DBKSEDInfo = namedtuple("DBKSEDInfo", fields)
+
+    dbk_sed_info = DBKSEDInfo(
+        **dbk_sed_info._asdict(),
+        **in_situ_dict,
+        p_merge=p_merge,
+        uran_pmerge=merging_randoms.uran_pmerge,
     )
-    return sed_info
+    return dbk_sed_info

--- a/diffsky/experimental/kernels/gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_dbk_sed_kernels_merging.py
@@ -111,13 +111,11 @@ def _get_dbk_sed_kern_merging_quantities(
     mstar_disk = mass_ratio * md_in_situ
     mstar_knots = mass_ratio * mk_in_situ
 
-    mb = mstar_bulge.reshape((n_gals, 1))
-    md = mstar_disk.reshape((n_gals, 1))
-    mk = mstar_knots.reshape((n_gals, 1))
+    ratio = mass_ratio.reshape((n_gals, 1))
 
-    rest_sed_bulge = mb * dbk_sed_info_in_situ.rest_sed_bulge
-    rest_sed_disk = md * dbk_sed_info_in_situ.rest_sed_disk
-    rest_sed_knots = mk * dbk_sed_info_in_situ.rest_sed_knots
+    rest_sed_bulge = ratio * dbk_sed_info_in_situ.rest_sed_bulge
+    rest_sed_disk = ratio * dbk_sed_info_in_situ.rest_sed_disk
+    rest_sed_knots = ratio * dbk_sed_info_in_situ.rest_sed_knots
 
     return (
         mstar_in_situ,

--- a/diffsky/experimental/kernels/gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_dbk_sed_kernels_merging.py
@@ -105,17 +105,17 @@ def _get_dbk_sed_kern_merging_quantities(
     mstar_obs = 10**dbk_sed_info_in_situ.logsm_obs
     mass_ratio = mstar_obs / mstar_in_situ
 
-    n_gals = mstar_obs.shape[0]
-
     mstar_bulge = mass_ratio * mb_in_situ
     mstar_disk = mass_ratio * md_in_situ
     mstar_knots = mass_ratio * mk_in_situ
 
-    ratio = mass_ratio.reshape((n_gals, 1))
+    frac_sed_bulge = dbk_sed_info_in_situ.rest_sed_bulge / rest_sed_in_situ
+    frac_sed_disk = dbk_sed_info_in_situ.rest_sed_disk / rest_sed_in_situ
+    frac_sed_knots = dbk_sed_info_in_situ.rest_sed_knots / rest_sed_in_situ
 
-    rest_sed_bulge = ratio * dbk_sed_info_in_situ.rest_sed_bulge
-    rest_sed_disk = ratio * dbk_sed_info_in_situ.rest_sed_disk
-    rest_sed_knots = ratio * dbk_sed_info_in_situ.rest_sed_knots
+    rest_sed_bulge = frac_sed_bulge * rest_sed
+    rest_sed_disk = frac_sed_disk * rest_sed
+    rest_sed_knots = frac_sed_knots * rest_sed
 
     return (
         mstar_in_situ,

--- a/diffsky/experimental/kernels/gd_dbk_specphot_kernels.py
+++ b/diffsky/experimental/kernels/gd_dbk_specphot_kernels.py
@@ -9,13 +9,7 @@ from jax import numpy as jnp
 from ...merging import merging_model
 from ...ssp_err_model import ssp_err_model
 from ..disk_bulge_modeling import disk_bulge_kernels as dbk
-from . import (
-    dbk_kernels,
-    gd_dbk_kernels,
-    gd_linelum_kernels,
-    gd_phot_kernels,
-    mc_randoms,
-)
+from . import gd_dbk_kernels, gd_linelum_kernels, gd_phot_kernels, mc_randoms
 from . import ssp_weight_kernels as sspwk
 
 
@@ -140,7 +134,7 @@ def _dbk_phot_kern(
         p_merge_smooth,
     )
 
-    _ret3 = dbk_kernels._get_dbk_phot_from_dbk_weights(
+    _ret3 = gd_dbk_kernels._get_dbk_phot_from_dbk_weights(
         phot_kern_results.ssp_photflux_table,
         dbk_weights,
         phot_kern_results.dust_frac_trans,
@@ -288,7 +282,7 @@ def _dbk_specphot_kern(
         fb,
     )
 
-    _ret3 = dbk_kernels._get_dbk_phot_from_dbk_weights(
+    _ret3 = gd_dbk_kernels._get_dbk_phot_from_dbk_weights(
         phot_kern_results.ssp_photflux_table,
         dbk_weights,
         phot_kern_results.dust_frac_trans,
@@ -296,7 +290,7 @@ def _dbk_specphot_kern(
     )
     obs_mags_bulge, obs_mags_disk, obs_mags_knots = _ret3
 
-    _dbk_line_res = dbk_kernels._get_dbk_linelum_decomposition(
+    _dbk_line_res = gd_dbk_kernels._get_dbk_linelum_decomposition(
         dbk_weights, spec_kern_results, ssp_data
     )
     linelum_bulge, linelum_disk, linelum_knots = _dbk_line_res

--- a/diffsky/experimental/kernels/gd_sed_kernels.py
+++ b/diffsky/experimental/kernels/gd_sed_kernels.py
@@ -124,6 +124,7 @@ def _sed_kern(
         burstiness_info.burst_params_mc,
         t_table,
         sfh_table,
+        p_merge_smooth,
     )
     return sed_kern_results
 
@@ -140,5 +141,6 @@ SEDKernResults = namedtuple(
         "burst_params",
         "t_table",
         "sfh_table",
+        "p_merge_smooth",
     ),
 )

--- a/diffsky/experimental/kernels/gd_sed_kernels.py
+++ b/diffsky/experimental/kernels/gd_sed_kernels.py
@@ -112,7 +112,7 @@ def _sed_kern(
     mstar = 10 ** logsm_obs.reshape((n_gals, 1))
     rest_sed = jnp.sum(a * b * c * d, axis=(1, 2)) * mstar
 
-    lgmet_weights = jnp.sum(burstiness_info.ssp_weights_mc, axis=1)
+    lgmet_weights = jnp.sum(burstiness_info.ssp_weights_mc, axis=2)
 
     sed_kern_results = SEDKernResults(
         rest_sed,

--- a/diffsky/experimental/kernels/gd_sed_kernels.py
+++ b/diffsky/experimental/kernels/gd_sed_kernels.py
@@ -1,0 +1,144 @@
+""""""
+
+from collections import namedtuple
+from functools import partial
+
+from jax import jit as jjit
+from jax import numpy as jnp
+
+from ...merging import merging_model
+from ...ssp_err_model import ssp_err_model
+from .. import mc_diffstarpop_wrappers as mcdw
+from . import rapid_quenching as rq
+from . import ssp_weight_kernels as sspwk
+from .constants import LGMET_SCATTER
+
+
+@partial(jjit, static_argnames=["n_t_table"])
+def _sed_kern(
+    phot_randoms,
+    sfh_params,
+    z_obs,
+    t_obs,
+    mah_params,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
+    ssp_data,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    merging_params,
+    cosmo_params,
+    fb,
+    *,
+    n_t_table=mcdw.N_T_TABLE,
+):
+    """"""
+
+    t_table, sfh_table, logsm_obs, logssfr_obs = mcdw.compute_diffstar_info(
+        mah_params, sfh_params, t_obs, cosmo_params, fb, n_t_table
+    )
+
+    t_infall = t_obs - gyr_since_infall
+    logmp_infall = lgmu_infall + logmhost_infall
+    p_merge_smooth = merging_model.get_p_merge_from_merging_params(
+        merging_params, logmp_infall, logmhost_infall, t_obs, t_infall, upid
+    )
+
+    smooth_ssp_weights = rq.get_smooth_ssp_weights_rq(
+        t_table,
+        sfh_table,
+        logsm_obs,
+        ssp_data,
+        t_obs,
+        mzr_params,
+        LGMET_SCATTER,
+        p_merge_smooth,
+    )
+
+    burstiness_info = rq.get_burstiness_rq(
+        phot_randoms.uran_pburst,
+        phot_randoms.mc_is_q,
+        logsm_obs,
+        logssfr_obs,
+        smooth_ssp_weights.age_weights,
+        smooth_ssp_weights.lgmet_weights,
+        ssp_data,
+        spspop_params.burstpop_params,
+        p_merge_smooth,
+    )
+
+    # For each filter, calculate λ_eff in the restframe of each galaxy
+    n_gals = logsm_obs.shape[0]
+    wave_eff_galpop = jnp.tile(ssp_data.ssp_wave, n_gals).reshape((n_gals, -1))
+
+    dust_frac_trans, dust_params = sspwk.compute_dust_attenuation(
+        phot_randoms.uran_av,
+        phot_randoms.uran_delta,
+        phot_randoms.uran_funo,
+        logsm_obs,
+        logssfr_obs,
+        ssp_data,
+        z_obs,
+        wave_eff_galpop,
+        spspop_params.dustpop_params,
+        scatter_params,
+    )
+    dust_params = dust_params._replace(
+        av=dust_params.av[:, 0, -1],
+        delta=dust_params.delta[:, 0],
+        funo=dust_params.funo[:, 0],
+    )
+
+    # Calculate mean fractional change to the SSP fluxes in each band for each galaxy
+    # L'_SSP(λ_eff) = L_SSP(λ_eff) & F_SSP(λ_eff)
+    frac_ssp_errors = ssp_err_model.frac_ssp_err_at_z_obs_galpop(
+        ssperr_params, logsm_obs, z_obs, wave_eff_galpop
+    )
+    frac_ssp_errors = ssp_err_model.get_noisy_frac_ssp_errors(
+        wave_eff_galpop, frac_ssp_errors, phot_randoms.delta_mag_ssp_scatter
+    )
+
+    n_met, n_age, n_wave = ssp_data.ssp_flux.shape
+    dust_frac_trans = dust_frac_trans.swapaxes(1, 2)  # (n_gals, n_age, n_wave)
+
+    a = dust_frac_trans.reshape((n_gals, 1, n_age, n_wave))
+    b = frac_ssp_errors.reshape((n_gals, 1, 1, n_wave))
+    c = burstiness_info.ssp_weights_mc.reshape((n_gals, n_met, n_age, 1))
+    d = ssp_data.ssp_flux.reshape((1, n_met, n_age, n_wave))
+    mstar = 10 ** logsm_obs.reshape((n_gals, 1))
+    rest_sed = jnp.sum(a * b * c * d, axis=(1, 2)) * mstar
+
+    lgmet_weights = jnp.sum(burstiness_info.ssp_weights_mc, axis=1)
+
+    sed_kern_results = SEDKernResults(
+        rest_sed,
+        dust_frac_trans,
+        frac_ssp_errors,
+        burstiness_info.ssp_weights_mc,
+        lgmet_weights,
+        logsm_obs,
+        burstiness_info.burst_params_mc,
+        t_table,
+        sfh_table,
+    )
+    return sed_kern_results
+
+
+SEDKernResults = namedtuple(
+    "SEDKernResults",
+    (
+        "rest_sed",
+        "dust_frac_trans",
+        "frac_ssp_errors",
+        "ssp_weights",
+        "lgmet_weights",
+        "logsm_obs",
+        "burst_params",
+        "t_table",
+        "sfh_table",
+    ),
+)

--- a/diffsky/experimental/kernels/gd_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_sed_kernels_merging.py
@@ -65,7 +65,15 @@ def _sed_kern(
     _res = _get_sed_kern_merging_quantities(
         in_situ_sed_results, merging_randoms, sat_weights, halo_indx, mc_merge
     )
-    mstar_in_situ, mstar_obs, rest_sed_in_situ, rest_sed, p_merge = _res
+    (
+        mstar_in_situ,
+        mstar_obs,
+        rest_sed_in_situ,
+        rest_sed,
+        p_merge,
+        ssp_weights,
+        ssp_weights_in_situ,
+    ) = _res
 
     sed_results = _update_sed_kern_results_with_merging(
         in_situ_sed_results,
@@ -75,6 +83,8 @@ def _sed_kern(
         rest_sed,
         p_merge,
         merging_randoms.uran_pmerge,
+        ssp_weights,
+        ssp_weights_in_situ,
     )
     return sed_results
 
@@ -101,7 +111,25 @@ def _get_sed_kern_merging_quantities(
         sat_weights[:, jnp.newaxis],
         halo_indx,
     )
-    return mstar_in_situ, mstar_obs, rest_sed_in_situ, rest_sed, p_merge
+
+    ssp_weights_in_situ = sed_kern_results.ssp_weights
+    ssp_weights = merging_kernels.get_in_plus_ex_situ_ssp_weights(
+        mstar_in_situ,
+        ssp_weights_in_situ,
+        p_merge,
+        sat_weights,
+        halo_indx,
+    )
+
+    return (
+        mstar_in_situ,
+        mstar_obs,
+        rest_sed_in_situ,
+        rest_sed,
+        p_merge,
+        ssp_weights,
+        ssp_weights_in_situ,
+    )
 
 
 @jjit
@@ -113,18 +141,28 @@ def _update_sed_kern_results_with_merging(
     rest_sed,
     p_merge,
     uran_pmerge,
+    ssp_weights,
+    ssp_weights_in_situ,
 ):
     ex_situ_dict = dict()
     ex_situ_dict["logsm_obs"] = jnp.log10(mstar_obs)
     ex_situ_dict["rest_sed"] = rest_sed
+    ex_situ_dict["ssp_weights"] = ssp_weights
 
     in_situ_sed_results = in_situ_sed_results._replace(**ex_situ_dict)
 
     in_situ_dict = dict()
     in_situ_dict["logsm_obs" + "_in_situ"] = jnp.log10(mstar_in_situ)
     in_situ_dict["rest_sed" + "_in_situ"] = rest_sed_in_situ
+    in_situ_dict["ssp_weights" + "_in_situ"] = ssp_weights_in_situ
 
-    new_keys = ["logsm_obs_in_situ", "rest_sed_in_situ", "p_merge", "uran_pmerge"]
+    new_keys = [
+        "logsm_obs_in_situ",
+        "rest_sed_in_situ",
+        "p_merge",
+        "uran_pmerge",
+        "ssp_weights_in_situ",
+    ]
     fields = list(in_situ_sed_results._fields) + new_keys
     SEDResults = namedtuple("SEDResults", fields)
 

--- a/diffsky/experimental/kernels/gd_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_sed_kernels_merging.py
@@ -1,0 +1,153 @@
+""""""
+
+from collections import namedtuple
+from . import sed_kernels
+from functools import partial
+
+from jax import jit as jjit
+from jax import numpy as jnp
+
+
+from .. import mc_diffstarpop_wrappers as mcdw
+from ...merging import merging_model, merging_kernels
+
+
+@partial(jjit, static_argnames=["n_t_table"])
+def _sed_kern(
+    phot_randoms,
+    merging_randoms,
+    sfh_params,
+    z_obs,
+    t_obs,
+    mah_params,
+    ssp_data,
+    mzr_params,
+    spspop_params,
+    scatter_params,
+    ssperr_params,
+    merging_params,
+    cosmo_params,
+    fb,
+    logmp_infall,
+    logmhost_infall,
+    t_infall,
+    is_central,
+    sat_weights,
+    halo_indx,
+    mc_merge,
+    *,
+    n_t_table=mcdw.N_T_TABLE,
+):
+    """"""
+    in_situ_sed_results = sed_kernels._sed_kern(
+        phot_randoms,
+        sfh_params,
+        z_obs,
+        t_obs,
+        mah_params,
+        ssp_data,
+        mzr_params,
+        spspop_params,
+        scatter_params,
+        ssperr_params,
+        cosmo_params,
+        fb,
+        n_t_table=n_t_table,
+    )
+    _res = _get_sed_kern_merging_quantities(
+        in_situ_sed_results,
+        merging_randoms,
+        t_obs,
+        merging_params,
+        logmp_infall,
+        logmhost_infall,
+        t_infall,
+        is_central,
+        sat_weights,
+        halo_indx,
+        mc_merge,
+    )
+    mstar_in_situ, mstar_obs, rest_sed_in_situ, rest_sed, p_merge = _res
+
+    sed_results = _update_sed_kern_results_with_merging(
+        in_situ_sed_results,
+        mstar_in_situ,
+        mstar_obs,
+        rest_sed_in_situ,
+        rest_sed,
+        p_merge,
+        merging_randoms.uran_pmerge,
+    )
+    return sed_results
+
+
+@jjit
+def _get_sed_kern_merging_quantities(
+    sed_kern_results,
+    merging_randoms,
+    t_obs,
+    merging_params,
+    logmp_infall,
+    logmhost_infall,
+    t_infall,
+    is_central,
+    sat_weights,
+    halo_indx,
+    mc_merge,
+):
+    upids = jnp.where(is_central == 1, -1.0, 0.0)
+    p_merge = merging_model.get_p_merge_from_merging_params(
+        merging_params, logmp_infall, logmhost_infall, t_obs, t_infall, upids
+    )
+
+    # If mc_merge=1, implement Monte Carlo merging, else p_merge is a float
+    mc_p_merge = merging_kernels.get_mc_p_merge(merging_randoms.uran_pmerge, p_merge)
+    p_merge = jnp.where(mc_merge < 1, p_merge, mc_p_merge)
+
+    mstar_in_situ = 10**sed_kern_results.logsm_obs
+    mstar_obs = merging_kernels.compute_x_tot_from_x_in_situ(
+        mstar_in_situ, p_merge, sat_weights, halo_indx
+    )
+
+    rest_sed_in_situ = sed_kern_results.rest_sed
+    rest_sed = merging_kernels.compute_x_tot_from_x_in_situ(
+        rest_sed_in_situ,
+        p_merge[:, jnp.newaxis],
+        sat_weights[:, jnp.newaxis],
+        halo_indx,
+    )
+    return mstar_in_situ, mstar_obs, rest_sed_in_situ, rest_sed, p_merge
+
+
+@jjit
+def _update_sed_kern_results_with_merging(
+    in_situ_sed_results,
+    mstar_in_situ,
+    mstar_obs,
+    rest_sed_in_situ,
+    rest_sed,
+    p_merge,
+    uran_pmerge,
+):
+    ex_situ_dict = dict()
+    ex_situ_dict["logsm_obs"] = jnp.log10(mstar_obs)
+    ex_situ_dict["rest_sed"] = rest_sed
+
+    in_situ_sed_results = in_situ_sed_results._replace(**ex_situ_dict)
+
+    in_situ_dict = dict()
+    in_situ_dict["logsm_obs" + "_in_situ"] = jnp.log10(mstar_in_situ)
+    in_situ_dict["rest_sed" + "_in_situ"] = rest_sed_in_situ
+
+    new_keys = ["logsm_obs_in_situ", "rest_sed_in_situ", "p_merge", "uran_pmerge"]
+    fields = list(in_situ_sed_results._fields) + new_keys
+    SEDResults = namedtuple("PhotKernResults", fields)
+
+    sed_results = SEDResults(
+        **in_situ_sed_results._asdict(),
+        **in_situ_dict,
+        p_merge=p_merge,
+        uran_pmerge=uran_pmerge,
+    )
+
+    return sed_results

--- a/diffsky/experimental/kernels/gd_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/gd_sed_kernels_merging.py
@@ -1,15 +1,14 @@
 """"""
 
 from collections import namedtuple
-from . import sed_kernels
 from functools import partial
 
 from jax import jit as jjit
 from jax import numpy as jnp
 
-
+from ...merging import merging_kernels
 from .. import mc_diffstarpop_wrappers as mcdw
-from ...merging import merging_model, merging_kernels
+from . import gd_sed_kernels
 
 
 @partial(jjit, static_argnames=["n_t_table"])
@@ -39,33 +38,32 @@ def _sed_kern(
     n_t_table=mcdw.N_T_TABLE,
 ):
     """"""
-    in_situ_sed_results = sed_kernels._sed_kern(
+    upid = jnp.where(is_central == 1, -1, halo_indx)
+    lgmu_infall = logmp_infall - logmhost_infall
+    gyr_since_infall = t_obs - t_infall
+
+    in_situ_sed_results = gd_sed_kernels._sed_kern(
         phot_randoms,
         sfh_params,
         z_obs,
         t_obs,
         mah_params,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
         ssp_data,
         mzr_params,
         spspop_params,
         scatter_params,
         ssperr_params,
+        merging_params,
         cosmo_params,
         fb,
         n_t_table=n_t_table,
     )
     _res = _get_sed_kern_merging_quantities(
-        in_situ_sed_results,
-        merging_randoms,
-        t_obs,
-        merging_params,
-        logmp_infall,
-        logmhost_infall,
-        t_infall,
-        is_central,
-        sat_weights,
-        halo_indx,
-        mc_merge,
+        in_situ_sed_results, merging_randoms, sat_weights, halo_indx, mc_merge
     )
     mstar_in_situ, mstar_obs, rest_sed_in_situ, rest_sed, p_merge = _res
 
@@ -83,26 +81,13 @@ def _sed_kern(
 
 @jjit
 def _get_sed_kern_merging_quantities(
-    sed_kern_results,
-    merging_randoms,
-    t_obs,
-    merging_params,
-    logmp_infall,
-    logmhost_infall,
-    t_infall,
-    is_central,
-    sat_weights,
-    halo_indx,
-    mc_merge,
+    sed_kern_results, merging_randoms, sat_weights, halo_indx, mc_merge
 ):
-    upids = jnp.where(is_central == 1, -1.0, 0.0)
-    p_merge = merging_model.get_p_merge_from_merging_params(
-        merging_params, logmp_infall, logmhost_infall, t_obs, t_infall, upids
-    )
-
     # If mc_merge=1, implement Monte Carlo merging, else p_merge is a float
-    mc_p_merge = merging_kernels.get_mc_p_merge(merging_randoms.uran_pmerge, p_merge)
-    p_merge = jnp.where(mc_merge < 1, p_merge, mc_p_merge)
+    mc_p_merge = merging_kernels.get_mc_p_merge(
+        merging_randoms.uran_pmerge, sed_kern_results.p_merge_smooth
+    )
+    p_merge = jnp.where(mc_merge < 1, sed_kern_results.p_merge_smooth, mc_p_merge)
 
     mstar_in_situ = 10**sed_kern_results.logsm_obs
     mstar_obs = merging_kernels.compute_x_tot_from_x_in_situ(
@@ -141,7 +126,7 @@ def _update_sed_kern_results_with_merging(
 
     new_keys = ["logsm_obs_in_situ", "rest_sed_in_situ", "p_merge", "uran_pmerge"]
     fields = list(in_situ_sed_results._fields) + new_keys
-    SEDResults = namedtuple("PhotKernResults", fields)
+    SEDResults = namedtuple("SEDResults", fields)
 
     sed_results = SEDResults(
         **in_situ_sed_results._asdict(),

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels.py
@@ -9,8 +9,7 @@ from jax import vmap
 
 from ....param_utils import diffsky_param_wrapper_merging as dpwm
 from ...tests import test_lightcone_generators as tlcg
-from .. import gd_dbk_sed_kernels as gdbksk
-from .. import gd_phot_kernels, gd_sed_kernels, mc_randoms
+from .. import gd_dbk_sed_kernels, gd_phot_kernels, gd_sed_kernels, mc_randoms
 
 _A = [None, 0, None, None, 0, *[None] * 4]
 calc_obs_mags_galpop = vmap(phk.calc_obs_mag, in_axes=_A)
@@ -67,6 +66,24 @@ def test_dbk_sed_kern(num_halos=50):
         fb,
     )
 
+    dbk_sed_kern_results = gd_dbk_sed_kernels._dbk_sed_kern(
+        phot_randoms,
+        dbk_randoms,
+        sfh_params,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        lc_data.ssp_data,
+        *dpwm.DEFAULT_PARAM_COLLECTION[1:],
+        DEFAULT_COSMOLOGY,
+        fb,
+        lc_data.logmp_infall,
+        lc_data.logmhost_infall,
+        lc_data.t_infall,
+        lc_data.is_central,
+        lc_data.halo_indx,
+    )
+
     # Enforce agreement between precomputed vs exact magnitudes
     n_bands = phot_kern_results.obs_mags.shape[1]
     for iband in range(n_bands):
@@ -77,7 +94,7 @@ def test_dbk_sed_kern(num_halos=50):
         )
         args = (
             lc_data.ssp_data.ssp_wave,
-            sed_kern_results.rest_sed,
+            dbk_sed_kern_results.rest_sed,
             lc_data.ssp_data.ssp_wave,
             trans_iband,
             lc_data.z_obs,

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels.py
@@ -84,6 +84,12 @@ def test_dbk_sed_kern(num_halos=50):
         lc_data.halo_indx,
     )
 
+    assert np.allclose(
+        np.log10(sed_kern_results.rest_sed),
+        np.log10(dbk_sed_kern_results.rest_sed),
+        atol=0.1,
+    )
+
     # Enforce agreement between precomputed vs exact magnitudes
     n_bands = phot_kern_results.obs_mags.shape[1]
     for iband in range(n_bands):

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels.py
@@ -1,0 +1,88 @@
+""""""
+
+import numpy as np
+from diffstar import DEFAULT_DIFFSTAR_PARAMS
+from dsps.cosmology import DEFAULT_COSMOLOGY
+from dsps.photometry import photometry_kernels as phk
+from jax import random as jran
+from jax import vmap
+
+from ....param_utils import diffsky_param_wrapper_merging as dpwm
+from ...tests import test_lightcone_generators as tlcg
+from .. import gd_dbk_sed_kernels as gdbksk
+from .. import gd_phot_kernels, gd_sed_kernels, mc_randoms
+
+_A = [None, 0, None, None, 0, *[None] * 4]
+calc_obs_mags_galpop = vmap(phk.calc_obs_mag, in_axes=_A)
+
+
+def test_dbk_sed_kern(num_halos=50):
+    ran_key = jran.key(0)
+    lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
+        num_halos=num_halos
+    )
+    fb = 0.176
+
+    n_gals = lc_data.z_obs.size
+    phot_key, dbk_key = jran.split(ran_key, 2)
+    dbk_randoms = mc_randoms.get_mc_dbk_randoms(dbk_key, n_gals)
+
+    upid = np.where(lc_data.is_central == 1, -1, lc_data.halo_indx).astype(int)
+    lgmu_infall = lc_data.logmp_infall - lc_data.logmhost_infall
+    gyr_since_infall = lc_data.t_obs - lc_data.t_infall
+    phot_kern_results, phot_randoms, merging_randoms = gd_phot_kernels._mc_phot_kern(
+        phot_key,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        upid,
+        lgmu_infall,
+        lc_data.logmhost_infall,
+        gyr_since_infall,
+        lc_data.ssp_data,
+        lc_data.precomputed_ssp_mag_table,
+        lc_data.z_phot_table,
+        lc_data.wave_eff_table,
+        *dpwm.DEFAULT_PARAM_COLLECTION,
+        DEFAULT_COSMOLOGY,
+        fb,
+    )
+
+    sfh_params = DEFAULT_DIFFSTAR_PARAMS._make(
+        [getattr(phot_kern_results, key) for key in DEFAULT_DIFFSTAR_PARAMS._fields]
+    )
+    sed_kern_results = gd_sed_kernels._sed_kern(
+        phot_randoms,
+        sfh_params,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        upid,
+        lgmu_infall,
+        lc_data.logmhost_infall,
+        gyr_since_infall,
+        lc_data.ssp_data,
+        *dpwm.DEFAULT_PARAM_COLLECTION[1:],
+        DEFAULT_COSMOLOGY,
+        fb,
+    )
+
+    # Enforce agreement between precomputed vs exact magnitudes
+    n_bands = phot_kern_results.obs_mags.shape[1]
+    for iband in range(n_bands):
+        trans_iband = np.interp(
+            lc_data.ssp_data.ssp_wave,
+            tcurves[iband].wave,
+            tcurves[iband].transmission,
+        )
+        args = (
+            lc_data.ssp_data.ssp_wave,
+            sed_kern_results.rest_sed,
+            lc_data.ssp_data.ssp_wave,
+            trans_iband,
+            lc_data.z_obs,
+            *DEFAULT_COSMOLOGY,
+        )
+
+        mags = calc_obs_mags_galpop(*args)
+        assert np.allclose(mags, phot_kern_results.obs_mags[:, iband], rtol=0.01)

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels.py
@@ -15,7 +15,7 @@ _A = [None, 0, None, None, 0, *[None] * 4]
 calc_obs_mags_galpop = vmap(phk.calc_obs_mag, in_axes=_A)
 
 
-def test_dbk_sed_kern(num_halos=50):
+def test_dbk_sed_kern(num_halos=20):
     ran_key = jran.key(0)
     lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
         num_halos=num_halos

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels.py
@@ -112,3 +112,11 @@ def test_dbk_sed_kern(num_halos=50):
         + dbk_sed_kern_results.rest_sed_knots
     )
     assert np.allclose(log_sed_composite, log_sed_sum, atol=0.1)
+
+    # Enforce component masses sum to composite mass
+    mstar_sum = (
+        dbk_sed_kern_results.mstar_bulge
+        + dbk_sed_kern_results.mstar_disk
+        + dbk_sed_kern_results.mstar_knots
+    )
+    assert np.allclose(np.log10(mstar_sum), dbk_sed_kern_results.logsm_obs, atol=0.01)

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels.py
@@ -103,3 +103,12 @@ def test_dbk_sed_kern(num_halos=50):
 
         mags = calc_obs_mags_galpop(*args)
         assert np.allclose(mags, phot_kern_results.obs_mags[:, iband], rtol=0.01)
+
+    # Enforce agreement between composite SED and sum of component SEDs
+    log_sed_composite = np.log10(dbk_sed_kern_results.rest_sed)
+    log_sed_sum = np.log10(
+        dbk_sed_kern_results.rest_sed_bulge
+        + dbk_sed_kern_results.rest_sed_disk
+        + dbk_sed_kern_results.rest_sed_knots
+    )
+    assert np.allclose(log_sed_composite, log_sed_sum, atol=0.1)

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
@@ -96,7 +96,8 @@ def test_sed_kern(mc_merge, num_halos=5, return_results=False):
         mc_merge,
     )
 
-    return dbk_sed_info, sed_kern_results, lc_data
+    if return_results:
+        return dbk_sed_info, sed_kern_results, lc_data
 
     rest_sed_dbk_recomputed = (
         dbk_sed_info.rest_sed_bulge
@@ -108,9 +109,6 @@ def test_sed_kern(mc_merge, num_halos=5, return_results=False):
     assert np.allclose(
         np.log10(rest_sed_dbk_recomputed), np.log10(rest_sed_recomputed), atol=0.2
     )
-
-    if return_results:
-        return sed_kern_results, phot_kern_results, lc_data, tcurves
 
     # Enforce agreement between precomputed vs exact magnitudes
     n_bands = phot_kern_results.obs_mags.shape[1]

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
@@ -117,33 +117,33 @@ def test_sed_kern(mc_merge, num_halos=25, return_results=False):
         np.log10(rest_sed_dbk_recomputed), np.log10(sed_info.rest_sed), atol=0.2
     )
 
-    # # Enforce agreement between precomputed vs exact magnitudes
-    # n_bands = phot_kern_results.obs_mags.shape[1]
-    # for iband in range(n_bands):
-    #     trans_iband = np.interp(
-    #         lc_data.ssp_data.ssp_wave,
-    #         tcurves[iband].wave,
-    #         tcurves[iband].transmission,
-    #     )
-    #     args = (
-    #         lc_data.ssp_data.ssp_wave,
-    #         rest_sed_recomputed,
-    #         lc_data.ssp_data.ssp_wave,
-    #         trans_iband,
-    #         lc_data.z_obs,
-    #         *DEFAULT_COSMOLOGY,
-    #     )
+    # Enforce agreement between precomputed vs exact magnitudes
+    n_bands = phot_kern_results.obs_mags.shape[1]
+    for iband in range(n_bands):
+        trans_iband = np.interp(
+            lc_data.ssp_data.ssp_wave,
+            tcurves[iband].wave,
+            tcurves[iband].transmission,
+        )
+        args = (
+            lc_data.ssp_data.ssp_wave,
+            sed_info.rest_sed,
+            lc_data.ssp_data.ssp_wave,
+            trans_iband,
+            lc_data.z_obs,
+            *DEFAULT_COSMOLOGY,
+        )
 
-    #     recomputed_obs_mags = calc_obs_mags_galpop(*args)
-    #     n_nan_cens = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 1]))
-    #     n_nan_sats = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 0]))
+        recomputed_obs_mags = calc_obs_mags_galpop(*args)
+        n_nan_cens = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 1]))
+        n_nan_sats = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 0]))
 
-    #     dmag = recomputed_obs_mags - phot_kern_results.obs_mags[:, iband]
+        dmag = recomputed_obs_mags - phot_kern_results.obs_mags[:, iband]
 
-    #     assert n_nan_sats == 0, "Some sats have NaN recomputed photometry"
-    #     msg = "Discrepancy in recomputed photometry for sats"
-    #     assert np.allclose(dmag[lc_data.is_central == 0], 0.0, atol=0.1), msg
+        assert n_nan_sats == 0, "Some sats have NaN recomputed photometry"
+        msg = "Discrepancy in recomputed photometry for sats"
+        assert np.allclose(dmag[lc_data.is_central == 0], 0.0, atol=0.1), msg
 
-    #     assert n_nan_cens == 0, "Some cens have NaN recomputed photometry"
-    #     msg = "Discrepancy in recomputed photometry for cens"
-    #     assert np.allclose(dmag[lc_data.is_central == 1], 0.0, atol=0.1), msg
+        assert n_nan_cens == 0, "Some cens have NaN recomputed photometry"
+        msg = "Discrepancy in recomputed photometry for cens"
+        assert np.allclose(dmag[lc_data.is_central == 1], 0.0, atol=0.1), msg

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
@@ -19,8 +19,8 @@ _A = [None, 0, None, None, 0, *[None] * 4]
 calc_obs_mags_galpop = vmap(phk.calc_obs_mag, in_axes=_A)
 
 
-# @pytest.mark.parametrize("mc_merge", [0, 1])
-def test_sed_kern(mc_merge=1, num_halos=25, return_results=False):
+@pytest.mark.parametrize("mc_merge", [0, 1])
+def test_sed_kern(mc_merge, num_halos=25, return_results=False):
     ran_key = jran.key(0)
     lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
         num_halos=num_halos

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
@@ -96,8 +96,16 @@ def test_sed_kern(mc_merge, num_halos=25, return_results=False):
         mc_merge,
     )
 
+    ret = (
+        lc_data,
+        phot_kern_results,
+        phot_randoms,
+        merging_randoms,
+        dbk_sed_info,
+        sed_kern_results,
+    )
     if return_results:
-        return dbk_sed_info, sed_kern_results, lc_data
+        return ret
 
     rest_sed_dbk_recomputed = (
         dbk_sed_info.rest_sed_bulge

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
@@ -55,7 +55,7 @@ def test_sed_kern(mc_merge, num_halos=25, return_results=False):
     sfh_params = DEFAULT_DIFFSTAR_PARAMS._make(
         [getattr(phot_kern_results, key) for key in DEFAULT_DIFFSTAR_PARAMS._fields]
     )
-    sed_kern_results = gd_sedkm._sed_kern(
+    sed_info = gd_sedkm._sed_kern(
         phot_randoms,
         merging_randoms,
         sfh_params,
@@ -102,7 +102,7 @@ def test_sed_kern(mc_merge, num_halos=25, return_results=False):
         phot_randoms,
         merging_randoms,
         dbk_sed_info,
-        sed_kern_results,
+        sed_info,
     )
     if return_results:
         return ret
@@ -112,39 +112,38 @@ def test_sed_kern(mc_merge, num_halos=25, return_results=False):
         + dbk_sed_info.rest_sed_disk
         + dbk_sed_info.rest_sed_knots
     )
-    rest_sed_recomputed = sed_kern_results.rest_sed
 
     assert np.allclose(
-        np.log10(rest_sed_dbk_recomputed), np.log10(rest_sed_recomputed), atol=0.2
+        np.log10(rest_sed_dbk_recomputed), np.log10(sed_info.rest_sed), atol=0.2
     )
 
-    # Enforce agreement between precomputed vs exact magnitudes
-    n_bands = phot_kern_results.obs_mags.shape[1]
-    for iband in range(n_bands):
-        trans_iband = np.interp(
-            lc_data.ssp_data.ssp_wave,
-            tcurves[iband].wave,
-            tcurves[iband].transmission,
-        )
-        args = (
-            lc_data.ssp_data.ssp_wave,
-            rest_sed_recomputed,
-            lc_data.ssp_data.ssp_wave,
-            trans_iband,
-            lc_data.z_obs,
-            *DEFAULT_COSMOLOGY,
-        )
+    # # Enforce agreement between precomputed vs exact magnitudes
+    # n_bands = phot_kern_results.obs_mags.shape[1]
+    # for iband in range(n_bands):
+    #     trans_iband = np.interp(
+    #         lc_data.ssp_data.ssp_wave,
+    #         tcurves[iband].wave,
+    #         tcurves[iband].transmission,
+    #     )
+    #     args = (
+    #         lc_data.ssp_data.ssp_wave,
+    #         rest_sed_recomputed,
+    #         lc_data.ssp_data.ssp_wave,
+    #         trans_iband,
+    #         lc_data.z_obs,
+    #         *DEFAULT_COSMOLOGY,
+    #     )
 
-        recomputed_obs_mags = calc_obs_mags_galpop(*args)
-        n_nan_cens = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 1]))
-        n_nan_sats = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 0]))
+    #     recomputed_obs_mags = calc_obs_mags_galpop(*args)
+    #     n_nan_cens = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 1]))
+    #     n_nan_sats = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 0]))
 
-        dmag = recomputed_obs_mags - phot_kern_results.obs_mags[:, iband]
+    #     dmag = recomputed_obs_mags - phot_kern_results.obs_mags[:, iband]
 
-        assert n_nan_sats == 0, "Some sats have NaN recomputed photometry"
-        msg = "Discrepancy in recomputed photometry for sats"
-        assert np.allclose(dmag[lc_data.is_central == 0], 0.0, atol=0.1), msg
+    #     assert n_nan_sats == 0, "Some sats have NaN recomputed photometry"
+    #     msg = "Discrepancy in recomputed photometry for sats"
+    #     assert np.allclose(dmag[lc_data.is_central == 0], 0.0, atol=0.1), msg
 
-        assert n_nan_cens == 0, "Some cens have NaN recomputed photometry"
-        msg = "Discrepancy in recomputed photometry for cens"
-        assert np.allclose(dmag[lc_data.is_central == 1], 0.0, atol=0.1), msg
+    #     assert n_nan_cens == 0, "Some cens have NaN recomputed photometry"
+    #     msg = "Discrepancy in recomputed photometry for cens"
+    #     assert np.allclose(dmag[lc_data.is_central == 1], 0.0, atol=0.1), msg

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
@@ -20,7 +20,7 @@ calc_obs_mags_galpop = vmap(phk.calc_obs_mag, in_axes=_A)
 
 
 @pytest.mark.parametrize("mc_merge", [0, 1])
-def test_sed_kern(mc_merge, num_halos=5, return_results=False):
+def test_sed_kern(mc_merge, num_halos=25, return_results=False):
     ran_key = jran.key(0)
     lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
         num_halos=num_halos

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
@@ -96,6 +96,8 @@ def test_sed_kern(mc_merge, num_halos=5, return_results=False):
         mc_merge,
     )
 
+    return dbk_sed_info, sed_kern_results, lc_data
+
     rest_sed_dbk_recomputed = (
         dbk_sed_info.rest_sed_bulge
         + dbk_sed_info.rest_sed_disk

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
@@ -19,8 +19,8 @@ _A = [None, 0, None, None, 0, *[None] * 4]
 calc_obs_mags_galpop = vmap(phk.calc_obs_mag, in_axes=_A)
 
 
-@pytest.mark.parametrize("mc_merge", [0, 1])
-def test_sed_kern(mc_merge, num_halos=25, return_results=False):
+# @pytest.mark.parametrize("mc_merge", [0, 1])
+def test_sed_kern(mc_merge=1, num_halos=25, return_results=False):
     ran_key = jran.key(0)
     lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
         num_halos=num_halos

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
@@ -11,7 +11,7 @@ from jax import vmap
 from ....param_utils import diffsky_param_wrapper_merging as dpwm
 from ...tests import test_lightcone_generators as tlcg
 from .. import gd_dbk_sed_kernels_merging as gd_dbk_sedkm
-from .. import gd_phot_kernels_merging as gd_pkm
+from .. import gd_dbk_specphot_kernels_merging
 from .. import gd_sed_kernels_merging as gd_sedkm
 from .. import mc_randoms
 
@@ -19,20 +19,26 @@ _A = [None, 0, None, None, 0, *[None] * 4]
 calc_obs_mags_galpop = vmap(phk.calc_obs_mag, in_axes=_A)
 
 
-@pytest.mark.parametrize("mc_merge", [0, 1])
-def test_sed_kern(mc_merge, num_halos=25, return_results=False):
+@pytest.mark.parametrize("z_med", [0.5, 2.5])
+def test_sed_kern(z_med, mc_merge=1, num_halos=25, return_results=False, dz=0.05):
     ran_key = jran.key(0)
+    z_min, z_max = z_med - dz, z_med + dz
     lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
-        num_halos=num_halos
+        num_halos=num_halos, z_min=z_min, z_max=z_max
     )
     fb = 0.176
 
-    n_gals = lc_data.z_obs.size
-    phot_key, dbk_key = jran.split(ran_key, 2)
-    dbk_randoms = mc_randoms.get_mc_dbk_randoms(dbk_key, n_gals)
+    phot_randoms, sfh_params, dbk_randoms, merging_randoms = (
+        mc_randoms.get_mc_dbk_phot_merge_randoms(
+            ran_key,
+            dpwm.DEFAULT_PARAM_COLLECTION.diffstarpop_params,
+            lc_data.mah_params,
+            DEFAULT_COSMOLOGY,
+        )
+    )
 
-    phot_kern_results, phot_randoms, merging_randoms = gd_pkm._mc_phot_kern_merging(
-        phot_key,
+    args = (
+        ran_key,
         lc_data.z_obs,
         lc_data.t_obs,
         lc_data.mah_params,
@@ -40,6 +46,7 @@ def test_sed_kern(mc_merge, num_halos=25, return_results=False):
         lc_data.precomputed_ssp_mag_table,
         lc_data.z_phot_table,
         lc_data.wave_eff_table,
+        lc_data.line_wave_table,
         *dpwm.DEFAULT_PARAM_COLLECTION,
         DEFAULT_COSMOLOGY,
         fb,
@@ -51,9 +58,11 @@ def test_sed_kern(mc_merge, num_halos=25, return_results=False):
         lc_data.halo_indx,
         mc_merge,
     )
+    _res = gd_dbk_specphot_kernels_merging._mc_dbk_specphot_kern_merging(*args)
+    dbk_specphot_info, dbk_weights = _res
 
     sfh_params = DEFAULT_DIFFSTAR_PARAMS._make(
-        [getattr(phot_kern_results, key) for key in DEFAULT_DIFFSTAR_PARAMS._fields]
+        [getattr(dbk_specphot_info, key) for key in DEFAULT_DIFFSTAR_PARAMS._fields]
     )
     sed_info = gd_sedkm._sed_kern(
         phot_randoms,
@@ -98,7 +107,8 @@ def test_sed_kern(mc_merge, num_halos=25, return_results=False):
 
     ret = (
         lc_data,
-        phot_kern_results,
+        tcurves,
+        dbk_specphot_info,
         phot_randoms,
         merging_randoms,
         dbk_sed_info,
@@ -113,37 +123,49 @@ def test_sed_kern(mc_merge, num_halos=25, return_results=False):
         + dbk_sed_info.rest_sed_knots
     )
 
+    msg = "Sum of DBK rest SEDs disagrees with composite SED"
     assert np.allclose(
-        np.log10(rest_sed_dbk_recomputed), np.log10(sed_info.rest_sed), atol=0.2
-    )
+        np.log10(rest_sed_dbk_recomputed), np.log10(sed_info.rest_sed), atol=0.1
+    ), msg
 
-    # Enforce agreement between precomputed vs exact magnitudes
-    n_bands = phot_kern_results.obs_mags.shape[1]
+    # Enforce agreement between gd_dbk_sed_kernels_merging vs gd_dbk_specphot_kernels_merging
+    n_bands = dbk_specphot_info.obs_mags.shape[1]
     for iband in range(n_bands):
         trans_iband = np.interp(
             lc_data.ssp_data.ssp_wave,
             tcurves[iband].wave,
             tcurves[iband].transmission,
         )
-        args = (
-            lc_data.ssp_data.ssp_wave,
-            sed_info.rest_sed,
-            lc_data.ssp_data.ssp_wave,
-            trans_iband,
-            lc_data.z_obs,
-            *DEFAULT_COSMOLOGY,
-        )
 
-        recomputed_obs_mags = calc_obs_mags_galpop(*args)
-        n_nan_cens = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 1]))
-        n_nan_sats = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 0]))
+        components = ("", "_bulge", "_disk", "_knots")
+        for component in components:
+            sed = getattr(dbk_sed_info, "rest_sed" + component)
+            obs_mags = getattr(dbk_specphot_info, "obs_mags" + component)
 
-        dmag = recomputed_obs_mags - phot_kern_results.obs_mags[:, iband]
+            args = (
+                lc_data.ssp_data.ssp_wave,
+                sed,
+                lc_data.ssp_data.ssp_wave,
+                trans_iband,
+                lc_data.z_obs,
+                *DEFAULT_COSMOLOGY,
+            )
 
-        assert n_nan_sats == 0, "Some sats have NaN recomputed photometry"
-        msg = "Discrepancy in recomputed photometry for sats"
-        assert np.allclose(dmag[lc_data.is_central == 0], 0.0, atol=0.1), msg
+            recomputed_obs_mags = calc_obs_mags_galpop(*args)
+            specphot_obs_mags = obs_mags[:, iband]
+            dmag = recomputed_obs_mags - specphot_obs_mags
 
-        assert n_nan_cens == 0, "Some cens have NaN recomputed photometry"
-        msg = "Discrepancy in recomputed photometry for cens"
-        assert np.allclose(dmag[lc_data.is_central == 1], 0.0, atol=0.1), msg
+            assert np.median(dmag) < 0.1, "Systematic offset in recomputed magnitudes"
+
+            # compute trimmed variance
+            dmag_lo, dmag_hi = np.percentile(dmag, (5, 95))
+            msk_trim = (dmag > dmag_lo) & (dmag < dmag_hi)
+            std_trim = np.std(dmag[msk_trim])
+            assert std_trim < 0.1, "Large scatter in recomputed magnitudes"
+
+            # compute outlier fraction
+            num_outliers = np.sum(np.abs(dmag)) > 0.1
+            frac_outliers = num_outliers / dmag.size
+            assert (
+                frac_outliers < 0.01
+            ), "Large outlier fraction in recomputed magnitudes"

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_sed_kernels_merging.py
@@ -1,0 +1,142 @@
+""""""
+
+import numpy as np
+import pytest
+from diffstar import DEFAULT_DIFFSTAR_PARAMS
+from dsps.cosmology import DEFAULT_COSMOLOGY
+from dsps.photometry import photometry_kernels as phk
+from jax import random as jran
+from jax import vmap
+
+from ....param_utils import diffsky_param_wrapper_merging as dpwm
+from ...tests import test_lightcone_generators as tlcg
+from .. import gd_dbk_sed_kernels_merging as gd_dbk_sedkm
+from .. import gd_phot_kernels_merging as gd_pkm
+from .. import gd_sed_kernels_merging as gd_sedkm
+from .. import mc_randoms
+
+_A = [None, 0, None, None, 0, *[None] * 4]
+calc_obs_mags_galpop = vmap(phk.calc_obs_mag, in_axes=_A)
+
+
+@pytest.mark.parametrize("mc_merge", [0, 1])
+def test_sed_kern(mc_merge, num_halos=5, return_results=False):
+    ran_key = jran.key(0)
+    lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
+        num_halos=num_halos
+    )
+    fb = 0.176
+
+    n_gals = lc_data.z_obs.size
+    phot_key, dbk_key = jran.split(ran_key, 2)
+    dbk_randoms = mc_randoms.get_mc_dbk_randoms(dbk_key, n_gals)
+
+    phot_kern_results, phot_randoms, merging_randoms = gd_pkm._mc_phot_kern_merging(
+        phot_key,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        lc_data.ssp_data,
+        lc_data.precomputed_ssp_mag_table,
+        lc_data.z_phot_table,
+        lc_data.wave_eff_table,
+        *dpwm.DEFAULT_PARAM_COLLECTION,
+        DEFAULT_COSMOLOGY,
+        fb,
+        lc_data.logmp_infall,
+        lc_data.logmhost_infall,
+        lc_data.t_infall,
+        lc_data.is_central,
+        lc_data.sat_weight,
+        lc_data.halo_indx,
+        mc_merge,
+    )
+
+    sfh_params = DEFAULT_DIFFSTAR_PARAMS._make(
+        [getattr(phot_kern_results, key) for key in DEFAULT_DIFFSTAR_PARAMS._fields]
+    )
+    sed_kern_results = gd_sedkm._sed_kern(
+        phot_randoms,
+        merging_randoms,
+        sfh_params,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        lc_data.ssp_data,
+        *dpwm.DEFAULT_PARAM_COLLECTION[1:],
+        DEFAULT_COSMOLOGY,
+        fb,
+        lc_data.logmp_infall,
+        lc_data.logmhost_infall,
+        lc_data.t_infall,
+        lc_data.is_central,
+        lc_data.sat_weight,
+        lc_data.halo_indx,
+        mc_merge,
+    )
+
+    dbk_sed_info = gd_dbk_sedkm._dbk_sed_kern(
+        phot_randoms,
+        dbk_randoms,
+        merging_randoms,
+        sfh_params,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        lc_data.ssp_data,
+        *dpwm.DEFAULT_PARAM_COLLECTION[1:],
+        DEFAULT_COSMOLOGY,
+        fb,
+        lc_data.logmp_infall,
+        lc_data.logmhost_infall,
+        lc_data.t_infall,
+        lc_data.is_central,
+        lc_data.sat_weight,
+        lc_data.halo_indx,
+        mc_merge,
+    )
+
+    rest_sed_dbk_recomputed = (
+        dbk_sed_info.rest_sed_bulge
+        + dbk_sed_info.rest_sed_disk
+        + dbk_sed_info.rest_sed_knots
+    )
+    rest_sed_recomputed = sed_kern_results.rest_sed
+
+    assert np.allclose(
+        np.log10(rest_sed_dbk_recomputed), np.log10(rest_sed_recomputed), atol=0.2
+    )
+
+    if return_results:
+        return sed_kern_results, phot_kern_results, lc_data, tcurves
+
+    # Enforce agreement between precomputed vs exact magnitudes
+    n_bands = phot_kern_results.obs_mags.shape[1]
+    for iband in range(n_bands):
+        trans_iband = np.interp(
+            lc_data.ssp_data.ssp_wave,
+            tcurves[iband].wave,
+            tcurves[iband].transmission,
+        )
+        args = (
+            lc_data.ssp_data.ssp_wave,
+            rest_sed_recomputed,
+            lc_data.ssp_data.ssp_wave,
+            trans_iband,
+            lc_data.z_obs,
+            *DEFAULT_COSMOLOGY,
+        )
+
+        recomputed_obs_mags = calc_obs_mags_galpop(*args)
+        n_nan_cens = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 1]))
+        n_nan_sats = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 0]))
+
+        dmag = recomputed_obs_mags - phot_kern_results.obs_mags[:, iband]
+
+        assert n_nan_sats == 0, "Some sats have NaN recomputed photometry"
+        msg = "Discrepancy in recomputed photometry for sats"
+        assert np.allclose(dmag[lc_data.is_central == 0], 0.0, atol=0.1), msg
+
+        assert n_nan_cens == 0, "Some cens have NaN recomputed photometry"
+        msg = "Discrepancy in recomputed photometry for cens"
+        assert np.allclose(dmag[lc_data.is_central == 1], 0.0, atol=0.1), msg

--- a/diffsky/experimental/kernels/tests/test_gd_dbk_specphot_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_dbk_specphot_kernels_merging.py
@@ -61,6 +61,15 @@ def check_dbk_specphot_kern_merging_results(dbk_specphot_info, dbk_weights, lc_d
     msk_cen = lc_data.is_central == 1
     msk_sat = ~msk_cen
 
+    # Enforce component magnitudes add to composite magnitudes
+    obs_flux_sum = (
+        10 ** (-0.4 * dbk_specphot_info.obs_mags_bulge)
+        + 10 ** (-0.4 * dbk_specphot_info.obs_mags_disk)
+        + 10 ** (-0.4 * dbk_specphot_info.obs_mags_knots)
+    )
+    obs_mags_sum = -2.5 * np.log10(obs_flux_sum)
+    assert np.allclose(obs_mags_sum, dbk_specphot_info.obs_mags, atol=0.01)
+
     # Enforce centrals can only get more massive and satellites less massive
     name = "logsm_obs"
     x = getattr(dbk_specphot_info, name)

--- a/diffsky/experimental/kernels/tests/test_gd_sed_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_sed_kernels.py
@@ -14,7 +14,7 @@ _A = [None, 0, None, None, 0, *[None] * 4]
 calc_obs_mags_galpop = vmap(phk.calc_obs_mag, in_axes=_A)
 
 
-def test_sed_kern(num_halos=150):
+def test_sed_kern(num_halos=20):
     ran_key = jran.key(0)
     # lc_data, tcurves = tmclh._get_weighted_lc_data_for_unit_testing(num_halos=num_halos)
     lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(

--- a/diffsky/experimental/kernels/tests/test_gd_sed_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_sed_kernels.py
@@ -65,6 +65,9 @@ def test_sed_kern(num_halos=150):
     )
     rest_sed_recomputed = sed_kern_results[0]
 
+    n_met = lc_data.ssp_data.ssp_lgmet.size
+    assert sed_kern_results.lgmet_weights.shape[1] == n_met
+
     # Enforce agreement between precomputed vs exact magnitudes
     n_bands = phot_kern_results.obs_mags.shape[1]
     for iband in range(n_bands):

--- a/diffsky/experimental/kernels/tests/test_gd_sed_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_sed_kernels.py
@@ -1,7 +1,6 @@
 """"""
 
 import numpy as np
-from diffstar import DEFAULT_DIFFSTAR_PARAMS
 from dsps.cosmology import DEFAULT_COSMOLOGY
 from dsps.photometry import photometry_kernels as phk
 from jax import random as jran

--- a/diffsky/experimental/kernels/tests/test_gd_sed_kernels.py
+++ b/diffsky/experimental/kernels/tests/test_gd_sed_kernels.py
@@ -1,0 +1,86 @@
+""""""
+
+import numpy as np
+from diffstar import DEFAULT_DIFFSTAR_PARAMS
+from dsps.cosmology import DEFAULT_COSMOLOGY
+from dsps.photometry import photometry_kernels as phk
+from jax import random as jran
+from jax import vmap
+
+from ....param_utils import diffsky_param_wrapper_merging as dpwm
+from ...tests import test_lightcone_generators as tlcg
+from .. import gd_phot_kernels, gd_sed_kernels
+
+_A = [None, 0, None, None, 0, *[None] * 4]
+calc_obs_mags_galpop = vmap(phk.calc_obs_mag, in_axes=_A)
+
+
+def test_sed_kern(num_halos=150):
+    ran_key = jran.key(0)
+    # lc_data, tcurves = tmclh._get_weighted_lc_data_for_unit_testing(num_halos=num_halos)
+    lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
+        num_halos=num_halos
+    )
+
+    fb = 0.116
+    ran_key, phot_key = jran.split(ran_key, 2)
+
+    upid = np.where(lc_data.is_central == 1, -1, lc_data.halo_indx)
+    lgmu_infall = lc_data.logmp_infall - lc_data.logmhost_infall
+    gyr_since_infall = lc_data.t_obs - lc_data.t_infall
+    phot_kern_results, phot_randoms, diffstarpop_results = (
+        gd_phot_kernels._mc_phot_kern(
+            ran_key,
+            lc_data.z_obs,
+            lc_data.t_obs,
+            lc_data.mah_params,
+            upid,
+            lgmu_infall,
+            lc_data.logmhost_infall,
+            gyr_since_infall,
+            lc_data.ssp_data,
+            lc_data.precomputed_ssp_mag_table,
+            lc_data.z_phot_table,
+            lc_data.wave_eff_table,
+            *dpwm.DEFAULT_PARAM_COLLECTION,
+            DEFAULT_COSMOLOGY,
+            fb,
+        )
+    )
+
+    sed_kern_results = gd_sed_kernels._sed_kern(
+        phot_randoms,
+        diffstarpop_results.sfh_params,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        upid,
+        lgmu_infall,
+        lc_data.logmhost_infall,
+        gyr_since_infall,
+        lc_data.ssp_data,
+        *dpwm.DEFAULT_PARAM_COLLECTION[1:],
+        DEFAULT_COSMOLOGY,
+        fb,
+    )
+    rest_sed_recomputed = sed_kern_results[0]
+
+    # Enforce agreement between precomputed vs exact magnitudes
+    n_bands = phot_kern_results.obs_mags.shape[1]
+    for iband in range(n_bands):
+        trans_iband = np.interp(
+            lc_data.ssp_data.ssp_wave,
+            tcurves[iband].wave,
+            tcurves[iband].transmission,
+        )
+        args = (
+            lc_data.ssp_data.ssp_wave,
+            rest_sed_recomputed,
+            lc_data.ssp_data.ssp_wave,
+            trans_iband,
+            lc_data.z_obs,
+            *DEFAULT_COSMOLOGY,
+        )
+
+        mags = calc_obs_mags_galpop(*args)
+        assert np.allclose(mags, phot_kern_results.obs_mags[:, iband], rtol=0.01)

--- a/diffsky/experimental/kernels/tests/test_gd_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_sed_kernels_merging.py
@@ -1,0 +1,105 @@
+""""""
+
+import numpy as np
+import pytest
+from diffstar import DEFAULT_DIFFSTAR_PARAMS
+from dsps.cosmology import DEFAULT_COSMOLOGY
+from dsps.photometry import photometry_kernels as phk
+from jax import random as jran
+from jax import vmap
+
+from ....param_utils import diffsky_param_wrapper_merging as dpwm
+from ...tests import test_lightcone_generators as tlcg
+from .. import gd_sed_kernels_merging as gd_sedkm
+from .. import phot_kernels_merging as pkm
+
+_A = [None, 0, None, None, 0, *[None] * 4]
+calc_obs_mags_galpop = vmap(phk.calc_obs_mag, in_axes=_A)
+
+
+@pytest.mark.parametrize("mc_merge", [0, 1])
+def test_sed_kern(mc_merge, num_halos=5, return_results=False):
+    ran_key = jran.key(0)
+    lc_data, tcurves = tlcg._get_weighted_lc_photdata_for_unit_testing(
+        num_halos=num_halos
+    )
+    fb = 0.176
+
+    phot_kern_results, phot_randoms, merging_randoms = pkm._mc_phot_kern_merging(
+        ran_key,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        lc_data.ssp_data,
+        lc_data.precomputed_ssp_mag_table,
+        lc_data.z_phot_table,
+        lc_data.wave_eff_table,
+        *dpwm.DEFAULT_PARAM_COLLECTION,
+        DEFAULT_COSMOLOGY,
+        fb,
+        lc_data.logmp_infall,
+        lc_data.logmhost_infall,
+        lc_data.t_infall,
+        lc_data.is_central,
+        lc_data.sat_weight,
+        lc_data.halo_indx,
+        mc_merge,
+    )
+
+    sfh_params = DEFAULT_DIFFSTAR_PARAMS._make(
+        [getattr(phot_kern_results, key) for key in DEFAULT_DIFFSTAR_PARAMS._fields]
+    )
+    sed_kern_results = gd_sedkm._sed_kern(
+        phot_randoms,
+        merging_randoms,
+        sfh_params,
+        lc_data.z_obs,
+        lc_data.t_obs,
+        lc_data.mah_params,
+        lc_data.ssp_data,
+        *dpwm.DEFAULT_PARAM_COLLECTION[1:],
+        DEFAULT_COSMOLOGY,
+        fb,
+        lc_data.logmp_infall,
+        lc_data.logmhost_infall,
+        lc_data.t_infall,
+        lc_data.is_central,
+        lc_data.sat_weight,
+        lc_data.halo_indx,
+        mc_merge,
+    )
+    rest_sed_recomputed = sed_kern_results.rest_sed
+
+    if return_results:
+        return sed_kern_results, phot_kern_results, lc_data, tcurves
+
+    # Enforce agreement between precomputed vs exact magnitudes
+    n_bands = phot_kern_results.obs_mags.shape[1]
+    for iband in range(n_bands):
+        trans_iband = np.interp(
+            lc_data.ssp_data.ssp_wave,
+            tcurves[iband].wave,
+            tcurves[iband].transmission,
+        )
+        args = (
+            lc_data.ssp_data.ssp_wave,
+            rest_sed_recomputed,
+            lc_data.ssp_data.ssp_wave,
+            trans_iband,
+            lc_data.z_obs,
+            *DEFAULT_COSMOLOGY,
+        )
+
+        recomputed_obs_mags = calc_obs_mags_galpop(*args)
+        n_nan_cens = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 1]))
+        n_nan_sats = np.sum(~np.isfinite(recomputed_obs_mags[lc_data.is_central == 0]))
+
+        dmag = recomputed_obs_mags - phot_kern_results.obs_mags[:, iband]
+
+        assert n_nan_sats == 0, "Some sats have NaN recomputed photometry"
+        msg = "Discrepancy in recomputed photometry for sats"
+        assert np.allclose(dmag[lc_data.is_central == 0], 0.0, atol=0.1), msg
+
+        assert n_nan_cens == 0, "Some cens have NaN recomputed photometry"
+        msg = "Discrepancy in recomputed photometry for cens"
+        assert np.allclose(dmag[lc_data.is_central == 1], 0.0, atol=0.1), msg

--- a/diffsky/experimental/kernels/tests/test_gd_sed_kernels_merging.py
+++ b/diffsky/experimental/kernels/tests/test_gd_sed_kernels_merging.py
@@ -10,8 +10,8 @@ from jax import vmap
 
 from ....param_utils import diffsky_param_wrapper_merging as dpwm
 from ...tests import test_lightcone_generators as tlcg
+from .. import gd_phot_kernels_merging as gd_pkm
 from .. import gd_sed_kernels_merging as gd_sedkm
-from .. import phot_kernels_merging as pkm
 
 _A = [None, 0, None, None, 0, *[None] * 4]
 calc_obs_mags_galpop = vmap(phk.calc_obs_mag, in_axes=_A)
@@ -25,7 +25,7 @@ def test_sed_kern(mc_merge, num_halos=5, return_results=False):
     )
     fb = 0.176
 
-    phot_kern_results, phot_randoms, merging_randoms = pkm._mc_phot_kern_merging(
+    phot_kern_results, phot_randoms, merging_randoms = gd_pkm._mc_phot_kern_merging(
         ran_key,
         lc_data.z_obs,
         lc_data.t_obs,

--- a/diffsky/experimental/tests/test_lightcone_generators.py
+++ b/diffsky/experimental/tests/test_lightcone_generators.py
@@ -51,11 +51,12 @@ def _get_weighted_lc_halos_photdata_for_unit_testing(num_halos=75):
     return lc_data, tcurves
 
 
-def _get_weighted_lc_photdata_for_unit_testing(num_halos=75, n_lines=3):
+def _get_weighted_lc_photdata_for_unit_testing(
+    num_halos=75, n_lines=3, z_min=0.1, z_max=3.0, n_z_phot_table=15
+):
     ran_key = jran.key(0)
 
     lgmp_min, lgmp_max = 10.0, 15.0
-    z_min, z_max = 0.1, 3.0
     sky_area_degsq = 100.0
 
     ssp_data = load_ssp_data.load_fake_ssp_data()
@@ -68,7 +69,6 @@ def _get_weighted_lc_photdata_for_unit_testing(num_halos=75, n_lines=3):
     TransmissionCurves = namedtuple("TransmissionCurves", names)
     tcurves = TransmissionCurves(*tcurve_list)
 
-    n_z_phot_table = 15
     z_phot_table = 10 ** np.linspace(np.log10(z_min), np.log10(z_max), n_z_phot_table)
 
     args = (

--- a/diffsky/merging/merging_kernels.py
+++ b/diffsky/merging/merging_kernels.py
@@ -59,3 +59,19 @@ def compute_x_tot_from_x_in_situ(
 def get_mc_p_merge(uran, p_merge):
     mc_p_merge = jnp.where(uran < p_merge, MC_P_MERGE_MAX, 0.0)
     return mc_p_merge
+
+
+@jjit
+def get_in_plus_ex_situ_ssp_weights(
+    mstar_in_situ, ssp_weights_in_situ, p_merge, sat_weights, halo_indx
+):
+    x_in_situ = ssp_weights_in_situ * mstar_in_situ.reshape((-1, 1, 1))
+    x_tot = compute_x_tot_from_x_in_situ(
+        x_in_situ,
+        p_merge[:, jnp.newaxis, jnp.newaxis],
+        sat_weights[:, jnp.newaxis, jnp.newaxis],
+        halo_indx,
+    )
+    norm = jnp.sum(x_tot, axis=(1, 2))
+    ssp_weights = x_tot / norm.reshape((-1, 1, 1))
+    return ssp_weights


### PR DESCRIPTION
This PR brings in `gd_`-versions of all the SED kernels, e.g.,`gd_sed_kernels.py`,`gd_dbk_sed_kernels_merging.py`, etc. This completes the effort began  in #421, #425, and #429 to incorporate rapid satellite quenching into the kernels.

The next step from here will be to modify the mock production script to use the `gd_` versions of the kernels instead of the current ones that do not include rapid quenching.