### PR TITLE
Update changelog for `v0.3.6`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.3.6 (2026-06-12)
+-------------------
+- Version of code used to produce cosmos_260316_06_05_2026
+
+
 0.3.5 (2026-05-29)
 -------------------
 - Update requirements for dsps>=0.4.8 and diffstar>=1.0.3 (https://github.com/ArgonneCPAC/diffsky/pull/428)


### PR DESCRIPTION
Update changelog for `v0.3.6`, the version of the code used to produce `cosmos_260316_06_05_2026`.

The purpose of this PR is to provide a tag associated with `cosmos_260316_06_05_2026`. That mock can serve as a prototype for updating image simulation pipelines to use diffsky mocks that include merging, and `v0.3.6` will be the tag associated with this mock.