### PR TITLE
OpenCosmo Tutorial Update

### DIFF
--- a/docs/source/demo_diffsky_recompute_from_mock.ipynb
+++ b/docs/source/demo_diffsky_recompute_from_mock.ipynb
@@ -5,9 +5,14 @@
    "id": "859eeb76-f3cc-4954-9416-ef12a8a61138",
    "metadata": {},
    "source": [
-    "# Getting started with Diffsky mocks\n",
+    "# Working with mocks stored in Diffsky-native format\n",
     "\n",
-    "This notebook shows how to load diffsky data, and compute photometry and high-res SEDs.\n",
+    "This notebook shows how to load diffsky data, and compute photometry and high-res SEDs, using mock data stored in the flat hdf5 format natively produced by Diffsky. \n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <Note:<b>Note: There are separate [OpenCosmo](https://opencosmo.readthedocs.io/en/stable/)-formatted data products that enable efficient querying and filtering with the OpenCosmo toolkit. We recommend most users work with OpenCosmo-formatted diffsky mocks, for which there is a separate tutorial.</b>\n",
+    "</div>\n",
+    "\n",
     "\n",
     "## Diffsky-native data format\n",
     "The mock data natively produced by diffsky is stored as a collection of flat hdf5 files.\n",
@@ -17,7 +22,9 @@
     "\n",
     "where `stepnum` specifies the N-body simulation snapshot, and `lc_patch` specifies the patch of sky. Galaxies with the same `stepnum` occupy the same narrow range of redshift, and galaxies with the same `lc_patch` fall within the same contiguous patch of `{ra, dec}`.\n",
     "\n",
-    "The next cell shows how to load all the mock data stored in a single such file. (If you only need a subset of the columns, you can pass the `keys` keyward argument to the load_diffsky_lc_patch)."
+    "By contrast, the OpenCosmo library reorganizes the diffsky-native format by collating all hdf5 files at the same redshift, `\"lc_cores-453.0.diffsky_gals.hdf5\"`, `\"lc_cores-453.1.diffsky_gals.hdf5\"`, etc., into a single hdf5 file, `\"lc_cores-453.diffsky_gals.hdf5\"`.\n",
+    "\n",
+    "The next cell shows how to load all the mock data stored in a single diffsky-native file, `\"lc_cores-453.0.diffsky_gals.hdf5\"`."
    ]
   },
   {
@@ -41,24 +48,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db72f4d3-4849-473e-8271-45172b9f0d70",
-   "metadata": {},
-   "source": [
-    "### OpenCosmo-formatted data\n",
-    "\n",
-    "There are separate [OpenCosmo](https://opencosmo.readthedocs.io/en/stable/)-formatted data products that enable efficient querying and filtering with the OpenCosmo toolkit.\n",
-    "\n",
-    "This notebook demonstrates how to load and analyze diffsky-native data. A separate OpenCosmo-based tutorial is coming soon."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "874d4f92-e125-4f53-be7d-952ec5d3675f",
    "metadata": {},
    "source": [
     "### Inspect the mock data\n",
     "\n",
-    "The `diffsky_lc_patch` dictionary stores every column of the mock, along with supplementary metadata needed to compute photometry.\n",
+    "The `diffsky_lc_patch` dictionary stores every column of the mock, along with supplementary metadata needed to compute photometry. Note that if you only need a subset of the columns, you can pass the `keys` keyward argument to the `load_diffsky_lc_patch` function.\n",
     "\n",
     "In this next cell we'll take a look at a histogram of specific star formation rate, sSFR = log10(Mstar/SFR)."
    ]
@@ -123,7 +118,7 @@
    "source": [
     "## Recomputing mock photometry\n",
     "\n",
-    "In the next few cells, we'll recompute photometry through the `lsst_u` and `lsst_i` bands, and then compare the recomputed result to the corresponding columns of the mock.\n",
+    "In the next few cells, we'll recompute photometry through the `\"lsst_u\"` and `\"lsst_i\"` bands, and then compare the recomputed result to the corresponding columns of the mock.\n",
     "\n",
     "### Calculating photometry/SEDs in batches\n",
     "Depending on your available computing resources, you may need to compute photometry for only a chunk of the data at a time to avoid overflowing memory. \n",

--- a/docs/source/demo_diffsky_recompute_from_mock_opencosmo.ipynb
+++ b/docs/source/demo_diffsky_recompute_from_mock_opencosmo.ipynb
@@ -22,6 +22,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import healpy as hp\n",
     "from matplotlib import pyplot as plt"
    ]
   },
@@ -58,7 +59,45 @@
     "The catalog data is returned as an OpenCosmo dataset. The OpenCosmo toolkit provides extensive tooling for querying and analyzing diffsky data, allowing you to select the specific types of objects you are interested in and prototype analyses on small samples before scaling them up. More details on the toolkit and its capabilities are available [in the documentation](https://opencosmo.readthedocs.io).\n",
     "\n",
     "Additionally, the `load_diffsky_mock` function returns auxilliary data which is used by diffsky to compute photometry or SEDs. The most important thing in this auxilliary data is the transmission curves, which determines which bands you can compute photometry for.\n",
-    "\n"
+    "\n",
+    "We can quickly determine the sky area of the mock with a few simple function calls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46c28316-67e6-4e10-aa74-03276ae25494",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nside = 1024\n",
+    "pixels = ds.get_pixels(nside)\n",
+    "pixel_area = hp.nside2pixarea(nside, degrees=True)\n",
+    "print(f\"Total sky area is {len(pixels) * pixel_area:.2f} degrees\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9cf197c-8d0a-4075-b37a-820feb595e3a",
+   "metadata": {},
+   "source": [
+    "We can also plot a map of the sky coverage, though we note the coverage of this example mock is small compared to the whole sky."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1718f28-011c-43f0-b8d8-dac58fb9c884",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from healpy.visufunc import mollview\n",
+    "\n",
+    "npixels = hp.nside2npix(nside)\n",
+    "coverage = np.full(npixels, hp.UNSEEN)\n",
+    "coverage[pixels] = 0\n",
+    "mollview(coverage, nest=True)\n",
+    "plt.show()"
    ]
   },
   {
@@ -303,7 +342,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.11"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/docs/source/demo_diffsky_recompute_from_mock_opencosmo.ipynb
+++ b/docs/source/demo_diffsky_recompute_from_mock_opencosmo.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "nside = 1024\n",
-    "pixels = ds.get_pixels(nside)\n",
+    "pixels = catalog.get_pixels(nside)\n",
     "pixel_area = hp.nside2pixarea(nside, degrees=True)\n",
     "print(f\"Total sky area is {len(pixels) * pixel_area:.2f} degrees\")"
    ]

--- a/docs/source/demo_diffsky_recompute_from_mock_opencosmo.ipynb
+++ b/docs/source/demo_diffsky_recompute_from_mock_opencosmo.ipynb
@@ -13,9 +13,9 @@
     "\n",
     "The next two cells cells show how to load the mock files that are natively produced by the diffsky source code. For purposes of this demo, we will just work with a redshift slice, which will be downloaded in the next cell.\n",
     "\n",
-    "### Notes for beta testers: \n",
-    "2. You must be using `opencosmo 1.1.0` or above and the [opencosmo-utils branch](https://github.com/ArgonneCPAC/diffsky/tree/opencosmo-utils) of `diffsky` for this notebook to work correctly.\n",
-    "1. This notebook will eventually use the cell below to download a small opencosmo-formatted mock catalog for testing/example purposes. For now, just ignore it. Instead, the notebook will be written as though you are working with one of synthetic catalogs on Perlmutter\n"
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <Note:<b>Note: You must be using `opencosmo 1.3.0` or above for this notebook to work correctly.</b>\n",
+    "</div>"
    ]
   },
   {
@@ -109,6 +109,10 @@
    "id": "5e91c519-7ea7-4b43-bae7-bc63d13628ea",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <b>Note:</b> diffsky implements a merging model for more accurate photometry. Correctly computing the photometry and SEDs requires information about the central galaxy and all of its satellites. opencosmo automatically keeps systems together to ensure photometry can be calculated. As a result, the actual catalog produced by the line above will contain <i>more</i> than 300 objects\n",
+    "</div>\n",
+    "\n",
     "### Recompute mock photometry\n",
     "\n",
     "You can use the `compute_phot_from_diffsky_mock` function to compute mock photometry for any of the available bands. This function will compute photometry for the lsst_i and lsst_u bands, and insert them into the catalog as \"lsst_i_new\" and \"lsst_u_new\" (to avoid clashing with the exisiting lsst_i and lsst_u columns). It will then check that the computed photometry is very close to the original photometry present in the catalog.\n"
@@ -223,15 +227,9 @@
    "source": [
     "### Compute SED of diffsky galaxies\n",
     "\n",
-    "There is also a convenience function for computing the high-resolution SED of each diffsky galaxy. Be aware this computation is memory-intensive, and it is recommended you only compute it for at most ~1000 galaxies at a time.\n",
+    "Diffsky can produce high-resolution SED of each galaxy. Be aware this computation is memory-intensive, and it is recommended you only compute it for at most ~1000 galaxies at a time. You can control this by passing the `batch_size` argument. Because of the merging model (see note above) this argument actually controls the number of <i>systems</i> that are computed at once, rather than the exact number of objects. The photometry functions used above also support the `batch_size` argument. You can turn off batching by passing `batch_size = -1`. If you do not pass a batch size, `opencosmo` will use a fairly conservative default.\n",
     "\n",
-    "We can set a batch size to limit the number of galaxies that are computed at the same time. The photometry functions used above also support the `batch_size` argument. If the `batch_size` argument is not set, no batching gets performed.\n",
-    "\n",
-    "OpenCosmo can handle multi-dimension columns (such as an SED). However for this example we will set `insert = False` which just directly returns the SED to us instead of inserting it into the catalog.\n",
-    "\n",
-    "**Notes for beta testers**: \n",
-    "- `opencosmo` 1.1 includes the ability to automatically batch this computation over subsets of a much larger catalog. For the moment, we will just select a smaller subset of this data for example purposes\n",
-    "- This cell will ocassionally fail for reasons we are yet to track down, but seem to be related to the specific subset of rows selected in the `take` call. If this happens, just run the cell again to select a different sample of galaxies."
+    "OpenCosmo can handle multi-dimension columns (such as an SED). However for this example we will set `insert = False` which just directly returns the SED to us instead of inserting it into the catalog."
    ]
   },
   {
@@ -271,7 +269,7 @@
    "source": [
     "### Compute SED of disk/bulge/knot components\n",
     "\n",
-    "There is an additional convenience function for computing the high-resolution SED of each morphological component.\n",
+    "As with photomtery, we can compute the SEDs for each of a galaxy's individual morphological components.\n",
     "\n",
     "### Note to beta testers: This tool is not currently working"
    ]
@@ -283,8 +281,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# from diffsky.data_loaders.opencosmo_utils import compute_dbk_seds_from_diffsky_mock \n",
-    "# dbk_sed_info = compute_dbk_seds_from_diffsky_mock(sed_catalog, aux_data, bands = [\"lsst_u\", \"lsst_i\"], insert=False)"
+    "from diffsky.data_loaders.opencosmo_utils import compute_dbk_seds_from_diffsky_mock \n",
+    "dbk_sed_info = compute_dbk_seds_from_diffsky_mock(sed_catalog, aux_data, insert=False)"
    ]
   },
   {
@@ -294,17 +292,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# fig, ax = plt.subplots(1, 1)\n",
-    "# __=ax.loglog()\n",
-    "# xlim = ax.set_xlim(2_000, 200_000)\n",
-    "# ylim = ax.set_ylim(1e-8, 1e-4)\n",
+    "fig, ax = plt.subplots(1, 1)\n",
+    "__=ax.loglog()\n",
+    "xlim = ax.set_xlim(2_000, 200_000)\n",
+    "ylim = ax.set_ylim(1e-8, 1e-4)\n",
     "\n",
-    "# igal = 50\n",
-    "# __=ax.plot(diffsky_lc_patch['ssp_data'].ssp_wave, dbk_sed_info['rest_sed_bulge'][igal, :])\n",
-    "# __=ax.plot(diffsky_lc_patch['ssp_data'].ssp_wave, dbk_sed_info['rest_sed_disk'][igal, :])\n",
-    "# __=ax.plot(diffsky_lc_patch['ssp_data'].ssp_wave, dbk_sed_info['rest_sed_knots'][igal, :])\n",
-    "# xlabel = ax.set_xlabel('wavelength [angstroms]')\n",
-    "# ylabel = ax.set_ylabel('Lsun/Hz')"
+    "igal = 50\n",
+    "__=ax.plot(diffsky_lc_patch['ssp_data'].ssp_wave, dbk_sed_info['rest_sed_bulge'][igal, :])\n",
+    "__=ax.plot(diffsky_lc_patch['ssp_data'].ssp_wave, dbk_sed_info['rest_sed_disk'][igal, :])\n",
+    "__=ax.plot(diffsky_lc_patch['ssp_data'].ssp_wave, dbk_sed_info['rest_sed_knots'][igal, :])\n",
+    "xlabel = ax.set_xlabel('wavelength [angstroms]')\n",
+    "ylabel = ax.set_ylabel('Lsun/Hz')"
    ]
   },
   {
@@ -332,7 +330,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.11"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/docs/source/demo_diffsky_recompute_from_mock_opencosmo.ipynb
+++ b/docs/source/demo_diffsky_recompute_from_mock_opencosmo.ipynb
@@ -7,25 +7,11 @@
    "source": [
     "# Computing photometry and SEDs of galaxies in a diffsky mock\n",
     "\n",
-    "This notebook shows how to compute photometry through arbitrary bands of galaxies in a diffsky mock stored in the `opencosmo` format, and how to compute high-res SEDs.\n",
-    "\n",
-    "## Loading the mock data\n",
-    "\n",
-    "The next two cells cells show how to load the mock files that are natively produced by the diffsky source code. For purposes of this demo, we will just work with a redshift slice, which will be downloaded in the next cell.\n",
+    "This notebook shows how to compute photometry and high-res SEDs of galaxies in a diffsky mock stored in the `opencosmo` format.\n",
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "    <Note:<b>Note: You must be using `opencosmo 1.3.0` or above for this notebook to work correctly.</b>\n",
     "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "41daf3c4-c2bc-479f-8392-67ca69fe7f84",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ! wget -P ./download_dir -q -r -e robots=off -np -nH --cut-dirs=7 --reject \"index.html*\" https://portal.nersc.gov/project/hacc/aphearin/diffsky_data/smdpl_dr1_12_03_2025"
    ]
   },
   {
@@ -47,7 +33,8 @@
    "outputs": [],
    "source": [
     "from diffsky.data_loaders.opencosmo_utils import load_diffsky_mock\n",
-    "# Change to the directory of your favorite mock on Perlmutter\n",
+    "\n",
+    "# Change to the directory where your mock is stored\n",
     "directory = \"oc_download_dir\""
    ]
   },
@@ -75,18 +62,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "60065213-abf1-4f67-9855-5d3970af7e78",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# print(\"Transmission curves:\", aux_data[\"tcurves\"]._fields)\n",
-    "# print(catalog)\n",
-    "# # print(catalog.column"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "52f533bd-53b5-4b7b-a22f-35dd819aa8cc",
    "metadata": {},
@@ -110,12 +85,12 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
-    "    <b>Note:</b> diffsky implements a merging model for more accurate photometry. Correctly computing the photometry and SEDs requires information about the central galaxy and all of its satellites. opencosmo automatically keeps systems together to ensure photometry can be calculated. As a result, the actual catalog produced by the line above will contain <i>more</i> than 300 objects\n",
+    "    <b>Note:</b> The SEDs of diffsky galaxies include an ex-situ contribution from galaxy merging. Thus correctly computing the photometry and SEDs requires information about the central galaxy and all of its satellites. opencosmo automatically keeps cen-sat systems together to ensure photometry can be calculated. As a result, the actual catalog produced by the line above will contain <i>more</i> than 300 objects\n",
     "</div>\n",
     "\n",
     "### Recompute mock photometry\n",
     "\n",
-    "You can use the `compute_phot_from_diffsky_mock` function to compute mock photometry for any of the available bands. This function will compute photometry for the lsst_i and lsst_u bands, and insert them into the catalog as \"lsst_i_new\" and \"lsst_u_new\" (to avoid clashing with the exisiting lsst_i and lsst_u columns). It will then check that the computed photometry is very close to the original photometry present in the catalog.\n"
+    "You can use the `compute_phot_from_diffsky_mock` function to compute mock photometry for any of the available bands. The cells below will use this function to compute photometry for the `\"lsst_i\"` and `\"lsst_u\"` bands, and insert them into the catalog as `\"lsst_i_new\"` and `\"lsst_u_new\"` (to avoid clashing with the exisiting `\"lsst_i\"` and `\"lsst_u\"` columns). We then check that the computed photometry is consistent with the original photometry present in the catalog."
    ]
   },
   {
@@ -164,9 +139,9 @@
    "source": [
     "### Computing photometry in other bands\n",
     "\n",
-    "You can compute photometry in and band you like by simply providing new transmission curves\n",
+    "You can compute photometry in any band you like by simply providing new transmission curves\n",
     "\n",
-    "The next few cells show how to compute photometry through two fake bandpasses. We provide convinience functions for adding new transmission curves into the auxilliary data. This function expects tuples of (wavelength, tranmission_curve).\n",
+    "The next few cells show how to compute photometry through two fake bandpasses. We provide convenience functions for adding new transmission curves into the auxilliary data. This function expects tuples of (wavelength, tranmission_curve).\n",
     "\n",
     "If you are interested in writing your updated data out in `opencosmo` format so you can come back to it later, you can do so with:\n",
     "\n",
@@ -227,7 +202,7 @@
    "source": [
     "### Compute SED of diffsky galaxies\n",
     "\n",
-    "Diffsky can produce high-resolution SED of each galaxy. Be aware this computation is memory-intensive, and it is recommended you only compute it for at most ~1000 galaxies at a time. You can control this by passing the `batch_size` argument. Because of the merging model (see note above) this argument actually controls the number of <i>systems</i> that are computed at once, rather than the exact number of objects. The photometry functions used above also support the `batch_size` argument. You can turn off batching by passing `batch_size = -1`. If you do not pass a batch size, `opencosmo` will use a fairly conservative default.\n",
+    "Diffsky can produce high-resolution SED of each galaxy. Be aware this computation is memory-intensive, and it is recommended you only compute it for typically no more than ~1000 galaxies at a time (the optimal choice depends on the amount of memory available on the machine you are using). You can control this by passing the `batch_size` argument. Because of the merging model (see note above), this argument actually controls the number of <i>systems</i> that are computed at once, rather than the exact number of objects. The photometry functions used above also support the `batch_size` argument. You can turn off batching by passing `batch_size = -1`. If you do not pass a batch size, `opencosmo` will use a fairly conservative default.\n",
     "\n",
     "OpenCosmo can handle multi-dimension columns (such as an SED). However for this example we will set `insert = False` which just directly returns the SED to us instead of inserting it into the catalog."
    ]
@@ -269,9 +244,7 @@
    "source": [
     "### Compute SED of disk/bulge/knot components\n",
     "\n",
-    "As with photomtery, we can compute the SEDs for each of a galaxy's individual morphological components.\n",
-    "\n",
-    "### Note to beta testers: This tool is not currently working"
+    "As with photomtery, we can compute the SEDs for each of a galaxy's individual morphological components."
    ]
   },
   {
@@ -298,9 +271,9 @@
     "ylim = ax.set_ylim(1e-8, 1e-4)\n",
     "\n",
     "igal = 50\n",
-    "__=ax.plot(diffsky_lc_patch['ssp_data'].ssp_wave, dbk_sed_info['rest_sed_bulge'][igal, :])\n",
-    "__=ax.plot(diffsky_lc_patch['ssp_data'].ssp_wave, dbk_sed_info['rest_sed_disk'][igal, :])\n",
-    "__=ax.plot(diffsky_lc_patch['ssp_data'].ssp_wave, dbk_sed_info['rest_sed_knots'][igal, :])\n",
+    "__=ax.plot(aux_data['ssp_data'].ssp_wave, dbk_sed_info['rest_sed_bulge'][igal, :])\n",
+    "__=ax.plot(aux_data['ssp_data'].ssp_wave, dbk_sed_info['rest_sed_disk'][igal, :])\n",
+    "__=ax.plot(aux_data['ssp_data'].ssp_wave, dbk_sed_info['rest_sed_knots'][igal, :])\n",
     "xlabel = ax.set_xlabel('wavelength [angstroms]')\n",
     "ylabel = ax.set_ylabel('Lsun/Hz')"
    ]
@@ -330,7 +303,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/docs/source/demos.rst
+++ b/docs/source/demos.rst
@@ -10,8 +10,8 @@ Reading and analyzing Diffsky mocks
 .. toctree::
     :maxdepth: 1
 
-    demo_diffsky_recompute_from_mock.ipynb
     demo_diffsky_recompute_from_mock_opencosmo.ipynb
+    demo_diffsky_recompute_from_mock.ipynb
 
 
 Generating synthetic lightcones


### PR DESCRIPTION
Updates the tutorial for computing photometry and SEDs via the opencosmo interface:

- Removes the comments about "beta testing" as the interface is now more-or-less stable.
- Updates minimum opencosmo version note to 1.3
- Adds some discussion of the way the merging model affects the way opencosmo behaves
- Adds information about computing dbk SEDs, as that interface is now working.
