### PR TITLE
Fix bug in `load_lc_mock_chunk`

### DIFF
--- a/diffsky/data_loaders/hacc_utils/load_lc_mock.py
+++ b/diffsky/data_loaders/hacc_utils/load_lc_mock.py
@@ -5,11 +5,12 @@ from glob import glob
 
 import h5py
 import numpy as np
+
+from .. import load_flat_hdf5
 from . import hacc_core_utils as hcu
 from . import lc_mock as lcmp
-from . import load_lc_cores as llcc
 from . import lightcone_utils
-from .. import load_flat_hdf5
+from . import load_lc_cores as llcc
 
 
 def load_diffsky_lightcone(drn, sim_name, z_min, z_max, patch_list, keys=None):
@@ -129,6 +130,11 @@ def load_lc_mock_chunk(fn_lc_mock, *, nchunks, chunknum, lc_mock_keys=None):
     with h5py.File(fn_lc_mock, "r") as hdf:
         if lc_mock_keys is None:
             lc_mock_keys = list(hdf["data"].keys())
+
+        keys_to_throw_out = ["unlensed_magnitudes", "unlensed_fluxes"]
+        for key in keys_to_throw_out:
+            if key in lc_mock_keys:
+                lc_mock_keys.pop(lc_mock_keys.index(key))
 
         lc_mock, (istart, iend) = llcc._read_lc_cores_chunk(
             hdf, nchunks, chunknum, lc_mock_keys, index_dataset="metadata"


### PR DESCRIPTION
The function `load_lc_cf.load_lc_mock_chunk` loads a chunk of data stored in a lightcone mock. If the optional kwarg `lc_mock_keys` is not supplied, then by default _all_ keys appearing in `hdf['data']` are used. Naively, this would include `"unlensed_magnitudes"` and `"unlensed_fluxes"`, which are created as hdf datasets by the lensing code. But these keys store an hdf dataset, not a column and so the old code fails when trying to read, e.g., `unlensed_magnitudes` as column data. This PR provides a quick fix to prevent the reader from crashing in this situation. For the time being, there does not exist a convenience function within diffsky that provides a way to read the data stored in the `"unlensed_magnitudes"` and `"unlensed_fluxes"` datasets, not for diffsky-native data. This can be remedied in future upon request.

@AstroPatty does OpenCosmo-formatted data include support for the data stored in the `"unlensed_magnitudes"` and `"unlensed_fluxes"` datasets? I think this is not so critical for the time being, so for now it would be useful for posterity to just know the answer one way or another.