### PR TITLE
Improve convenience of mock production script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 0.3.7 (Unreleased)
 -------------------
 - Reinstate OpenCosmo docs (https://github.com/ArgonneCPAC/diffsky/pull/439)
+- Migrate top-level modules into subdirectories
+    - https://github.com/ArgonneCPAC/diffsky/pull/449
+    - https://github.com/ArgonneCPAC/diffsky/pull/450
 
 
 0.3.6 (2026-06-12)

--- a/docs/source/gaussian_examples/double_gaussian.py
+++ b/docs/source/gaussian_examples/double_gaussian.py
@@ -1,11 +1,13 @@
 """Demo code to fit a 2d Gaussian model with soft histograms and jax.grad"""
 
+from collections import namedtuple
+
+from jax import jit as jjit
 from jax import numpy as jnp
 from jax import random as jran
-from jax import jit as jjit
 from jax import value_and_grad
-from collections import namedtuple
-from diffsky.signdhist_lomem import nnsig_ndhist
+
+from diffsky.soft_histograms.signdhist_lomem import nnsig_ndhist
 
 DGParams = namedtuple("DGParams", ("mu0", "sig0", "mu1", "sig1", "frac0"))
 DEFAULT_PARAMS = DGParams(mu0=-1.0, sig0=0.5, mu1=1.0, sig1=1.0, frac0=0.75)

--- a/docs/source/gaussian_examples/single_gaussian.py
+++ b/docs/source/gaussian_examples/single_gaussian.py
@@ -1,11 +1,13 @@
 """Demo code to fit a 1d Gaussian model with soft histograms and jax.grad"""
 
-from jax import numpy as jnp
+from collections import namedtuple
+
 from jax import jit as jjit
+from jax import numpy as jnp
 from jax import random as jran
 from jax import value_and_grad
-from collections import namedtuple
-from diffsky.signdhist_lomem import nnsig_ndhist
+
+from diffsky.soft_histograms.signdhist_lomem import nnsig_ndhist
 
 GParams = namedtuple("GParams", ("mu", "sig"))
 DEFAULT_PARAMS = GParams(mu=-1.0, sig=1.0)

--- a/scripts/LJ_LC_MOCKS/add_galaxy_id_to_mock.py
+++ b/scripts/LJ_LC_MOCKS/add_galaxy_id_to_mock.py
@@ -18,6 +18,12 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("config_yaml", help="YAML configuration file")
+    parser.add_argument(
+        "-infer_mockname",
+        help="Infer mock_version_name from directory",
+        action="store_true",
+    )
+
     args = parser.parse_args()
 
     cl_args = parser.parse_args()
@@ -27,7 +33,14 @@ if __name__ == "__main__":
 
     drn_out = config["drn_out"]
     mock_nickname = config["mock_nickname"]
-    mock_version_name = get_mock_version_name(mock_nickname)
+
+    if cl_args.infer_mockname:
+        fn_list = glob(os.path.join(drn_out, mock_nickname + "_*"))
+        drn_mock = fn_list[0]
+        mock_version_name = os.path.basename(drn_mock)
+    else:
+        mock_version_name = get_mock_version_name(mock_nickname)
+
     drn = os.path.join(drn_out, mock_version_name)
 
     fn_list = glob(os.path.join(drn, "lc_cores-*.hdf5"))

--- a/scripts/LJ_LC_MOCKS/inspect_lc_mock.py
+++ b/scripts/LJ_LC_MOCKS/inspect_lc_mock.py
@@ -39,23 +39,30 @@ if __name__ == "__main__":
         type=int,
     )
 
-    args = parser.parse_args()
-    config_yaml = args.config_yaml
-    bnpat = args.bnpat
-    drn_report = args.drn_report
-    no_dbk = args.no_dbk
-    no_sed = args.no_sed
-    n_files_to_check = args.n_files_to_check
+    cl_args = parser.parse_args()
+    config_yaml = cl_args.config_yaml
+    bnpat = cl_args.bnpat
+    drn_report = cl_args.drn_report
+    no_dbk = cl_args.no_dbk
+    no_sed = cl_args.no_sed
+    n_files_to_check = cl_args.n_files_to_check
 
     with open(config_yaml, "r") as f:
         config = yaml.safe_load(f)
 
     mock_nickname = config["mock_nickname"]
+    drn_out = config["drn_out"]
+
     mock_version_name_in = config.get("mock_version_name", "")
-    if mock_version_name_in == "":
-        mock_version_name = get_mock_version_name(mock_nickname)
+    if cl_args.infer_mockname:
+        fn_list = glob(os.path.join(drn_out, mock_nickname + "_*"))
+        drn_mock = fn_list[0]
+        mock_version_name = os.path.basename(drn_mock)
     else:
-        mock_version_name = mock_version_name_in
+        if mock_version_name_in == "":
+            mock_version_name = get_mock_version_name(mock_nickname)
+        else:
+            mock_version_name = mock_version_name_in
 
     drn_mock = os.path.join(config["drn_out"], mock_version_name)
 

--- a/scripts/LJ_LC_MOCKS/inspect_lc_mock.py
+++ b/scripts/LJ_LC_MOCKS/inspect_lc_mock.py
@@ -38,6 +38,11 @@ if __name__ == "__main__":
         default=5,
         type=int,
     )
+    parser.add_argument(
+        "-infer_mockname",
+        help="Infer mock_version_name from directory",
+        action="store_true",
+    )
 
     cl_args = parser.parse_args()
     config_yaml = cl_args.config_yaml

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -10,13 +10,14 @@ To run a local test on poboy:
 
 """
 
-# noqa
-
 import argparse
 import gc
 import os
 import shutil
 import sys
+
+# noqa
+from glob import glob
 from time import sleep, time
 
 import h5py
@@ -93,6 +94,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "-machine", help="Machine name. Overrides config_yaml", default=""
     )
+    parser.add_argument(
+        "-infer_mockname",
+        help="Infer mock_version_name from directory",
+        action="store_true",
+    )
 
     cl_args = parser.parse_args()
     config_path = cl_args.config_yaml
@@ -131,10 +137,15 @@ if __name__ == "__main__":
         # override the yaml file (convenient for job submission scripts)
         synthetic_cores = cl_args.synthetic_cores
 
-    if mock_version_name_in == "":
-        mock_version_name = get_mock_version_name(mock_nickname)
+    if cl_args.infer_mockname:
+        fn_list = glob(os.path.join(drn_out, mock_nickname + "_*"))
+        drn_mock = fn_list[0]
+        mock_version_name = os.path.basename(drn_mock)
     else:
-        mock_version_name = mock_version_name_in
+        if mock_version_name_in == "":
+            mock_version_name = get_mock_version_name(mock_nickname)
+        else:
+            mock_version_name = mock_version_name_in
 
     if lsst_only:
         OUTPUT_FILTER_NICKNAMES = (*LSST_FILTER_NICKNAMES,)


### PR DESCRIPTION
The new `infer_mockname` kwarg makes it simpler to automatically infer `mock_version_name` from the directory name within `drn_out`. This resolves the problem of when a script runs longer than midnight, causing the calendar date to update, leading to an incorrectly inferred `mock_version_name`.