### PR TITLE
Update CI workflows to use diffsky-data instead of NERSC portal

### DIFF
--- a/.github/workflows/mockgen_opencosmo_main.yaml
+++ b/.github/workflows/mockgen_opencosmo_main.yaml
@@ -92,21 +92,20 @@ jobs:
 
           # Download data
           cd dsps_drn
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/ssp_data_fsps_v3.2_emlines.sparse.hdf5
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.sparse.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/ssp-data-v1/fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.sparse.h5
 
           cd filters
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_u_transmission.h5
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_g_transmission.h5
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_r_transmission.h5
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_i_transmission.h5
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_z_transmission.h5
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_y_transmission.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_u_transmission.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_g_transmission.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_r_transmission.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_i_transmission.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_z_transmission.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_y_transmission.h5
           cd ..
           cd ..
 
           # download lc_cores-decomposition.txt
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/diffsky_data/LastJourney/lc_cores-decomposition.txt
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/hacc-data-lastjourney-v1/lc_cores-decomposition.txt
 
           # Set environment variable
           export DSPS_DRN="${GITHUB_WORKSPACE}/dsps_drn"

--- a/.github/workflows/mockgen_opencosmo_release.yaml
+++ b/.github/workflows/mockgen_opencosmo_release.yaml
@@ -87,20 +87,20 @@ jobs:
 
           # Download data
           cd dsps_drn
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/ssp_data_fsps_v3.2_emlines.sparse.hdf5
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.sparse.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/ssp-data-v1/fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.sparse.h5
+
           cd filters
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_u_transmission.h5
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_g_transmission.h5
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_r_transmission.h5
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_i_transmission.h5
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_z_transmission.h5
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_y_transmission.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_u_transmission.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_g_transmission.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_r_transmission.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_i_transmission.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_z_transmission.h5
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_y_transmission.h5
           cd ..
           cd ..
 
           # download lc_cores-decomposition.txt
-          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/diffsky_data/LastJourney/lc_cores-decomposition.txt
+          wget $WGET_OPTS https://github.com/ArgonneCPAC/diffsky-data/releases/download/hacc-data-lastjourney-v1/lc_cores-decomposition.txt
 
           # Set environment variable
           export DSPS_DRN="${GITHUB_WORKSPACE}/dsps_drn"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,27 +11,25 @@ build:
     pre_build:
       # Download DSPS SSP data and LSST filter curves
       - mkdir -p dsps_drn/filters
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/ssp_data_fsps_v3.2_emlines.sparse.hdf5 -P dsps_drn
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.sparse.h5 -P dsps_drn
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_u_transmission.h5 -P dsps_drn/filters
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_g_transmission.h5 -P dsps_drn/filters
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_r_transmission.h5 -P dsps_drn/filters
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_i_transmission.h5 -P dsps_drn/filters
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_z_transmission.h5 -P dsps_drn/filters
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_y_transmission.h5 -P dsps_drn/filters
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/ssp-data-v1/fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.sparse.h5 -P dsps_drn
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_u_transmission.h5 -P dsps_drn/filters
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_g_transmission.h5 -P dsps_drn/filters
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_r_transmission.h5 -P dsps_drn/filters
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_i_transmission.h5 -P dsps_drn/filters
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_z_transmission.h5 -P dsps_drn/filters
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/filters-v1/lsst_y_transmission.h5 -P dsps_drn/filters
       - export DSPS_DRN="dsps_drn"
 
       # Download a pre-computed example mock for use in demo notebooks
       - mkdir -p docs/source/mock_download_dir
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/diffsky_data/sparse_cosmos_260316_05_03_2026/lc_cores-decomposition.txt -P docs/source/mock_download_dir
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/diffsky_data/sparse_cosmos_260316_05_03_2026/diffsky_cosmos_260316_05_03_2026_param_collection.hdf5 -P docs/source/mock_download_dir
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/diffsky_data/sparse_cosmos_260316_05_03_2026/diffsky_cosmos_260316_05_03_2026_ssp_data.hdf5 -P docs/source/mock_download_dir
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/diffsky_data/sparse_cosmos_260316_05_03_2026/diffsky_cosmos_260316_05_03_2026_transmission_curves.hdf5 -P docs/source/mock_download_dir
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/diffsky_data/sparse_cosmos_260316_05_03_2026/diffsky_cosmos_260316_05_03_2026_t_table.hdf5 -P docs/source/mock_download_dir
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/diffsky_data/sparse_cosmos_260316_05_03_2026/lc_cores-442.0.diffsky_gals.hdf5 -P docs/source/mock_download_dir
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/diffsky_data/sparse_cosmos_260316_05_03_2026/lc_cores-453.0.diffsky_gals.hdf5 -P docs/source/mock_download_dir
-      - wget -q https://portal.nersc.gov/project/hacc/aphearin/diffsky_data/sparse_cosmos_260316_05_03_2026/lc_cores-decomposition.txt -P docs/source/mock_download_dir
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/hacc-data-lastjourney-v1/lc_cores-decomposition.txt -P docs/source/mock_download_dir
 
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/mock-galaxies-v1/diffsky_cosmos_260316_05_03_2026_param_collection.hdf5 -P docs/source/mock_download_dir
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/mock-galaxies-v1/diffsky_cosmos_260316_05_03_2026_ssp_data.hdf5 -P docs/source/mock_download_dir
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/mock-galaxies-v1/diffsky_cosmos_260316_05_03_2026_transmission_curves.hdf5 -P docs/source/mock_download_dir
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/mock-galaxies-v1/diffsky_cosmos_260316_05_03_2026_t_table.hdf5 -P docs/source/mock_download_dir
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/mock-galaxies-v1/lc_cores-442.0.diffsky_gals.hdf5 -P docs/source/mock_download_dir
+      - wget -q https://github.com/ArgonneCPAC/diffsky-data/releases/download/mock-galaxies-v1/lc_cores-453.0.diffsky_gals.hdf5 -P docs/source/mock_download_dir
 
       # # Generate the mock
       # - export DSPS_DRN="${PWD}/dsps_drn" && python scripts/LJ_LC_MOCKS/make_lj_mock.py scripts/LJ_LC_MOCKS/testing_lj_mock_config.yaml


### PR DESCRIPTION
Update CI workflows to use diffsky-data instead of NERSC portal