### PR TITLE
Use `DIFFSKY_FIT_PARAMS` dictionary in mock production script

### DIFF
--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -38,7 +38,7 @@ from diffsky.data_loaders.hacc_utils import metadata_mock
 from diffsky.data_loaders.mock_utils import get_mock_version_name
 from diffsky.experimental import mc_lightcone_halos as mclh
 from diffsky.experimental import precompute_ssp_phot as psspp
-from diffsky.param_utils import COSMOS_FIT_PARAMS
+from diffsky.param_utils import DIFFSKY_FIT_PARAMS
 from diffsky.param_utils import diffsky_param_wrapper_merging as dpwm
 
 DRN_LJ_CF_LCRC = "/lcrc/group/cosmodata/simulations/LastJourney/coretrees/forest"
@@ -218,7 +218,7 @@ if __name__ == "__main__":
     for line_name in emline_names:
         assert line_name in ssp_data.ssp_emline_wave._fields
 
-    param_collection = COSMOS_FIT_PARAMS[cosmos_fit]
+    param_collection = DIFFSKY_FIT_PARAMS[cosmos_fit]
     dpwm.check_param_collection_is_ok(param_collection)
 
     n_z_phot_table = 15


### PR DESCRIPTION
Was previously using `COSMOS_FIT_PARAMS`, which is a subset of `DIFFSKY_FIT_PARAMS`