### PR TITLE
Fix bug in Monte Carlo generation of `{ra, dec}` for synthetic halos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@
 - Add documentation of Monte Carlo lightcone generators based on diffhalos (https://github.com/ArgonneCPAC/diffsky/pull/458)
 - Ship physical km/s peculiar velocity instead of comoving km/s (https://github.com/ArgonneCPAC/diffsky/pull/464)
 - Remove obsolete prototype calibrations and bring in new models (https://github.com/ArgonneCPAC/diffsky/pull/466)
+- Fix bug in `ra, dec` for synthetic halos (https://github.com/ArgonneCPAC/diffsky/pull/469)
+
 
 0.3.6 (2026-06-12)
 -------------------

--- a/diffsky/experimental/lc_utils.py
+++ b/diffsky/experimental/lc_utils.py
@@ -44,21 +44,57 @@ def mc_lightcone_random_ra_dec(ran_key, npts, ra_min, ra_max, dec_min, dec_max):
         Random coords on the sphere within the input range
 
     """
-    ra_key, dec_key = jran.split(ran_key, 2)
+    phi_min = jnp.deg2rad(ra_min)
+    phi_max = jnp.deg2rad(ra_max)
 
-    # Sample uniformly in ra
-    ra = jran.uniform(ra_key, minval=ra_min, maxval=ra_max, shape=(npts,))
+    theta_min = jnp.deg2rad(90.0 - dec_max)
+    theta_max = jnp.deg2rad(90.0 - dec_min)
 
-    # Dec spans (-π/2, +π/2) so we sample uniformly in sin(dec)
-    dec_min_rad = jnp.deg2rad(dec_min)
-    dec_max_rad = jnp.deg2rad(dec_max)
-    sin_dec_min = jnp.sin(dec_min_rad)
-    sin_dec_max = jnp.sin(dec_max_rad)
-    sin_dec = jran.uniform(dec_key, (npts,), minval=sin_dec_min, maxval=sin_dec_max)
-    dec_rad = jnp.arcsin(sin_dec)
-    dec = jnp.rad2deg(dec_rad)
+    theta, phi = mc_lightcone_random_theta_phi(
+        ran_key, npts, theta_min, theta_max, phi_min, phi_max
+    )
+    ra, dec = _get_ra_dec_from_theta_phi(theta, phi)
 
     return ra, dec
+
+
+@partial(jjit, static_argnames=["npts"])
+def mc_lightcone_random_theta_phi(
+    ran_key, npts, theta_min, theta_max, phi_min, phi_max
+):
+    """Generate random theta, phi in the input patch of sky"""
+    theta_key, phi_key = jran.split(ran_key, 2)
+    # Sample uniformly in phi
+    phi = jran.uniform(phi_key, (npts,), minval=phi_min, maxval=phi_max)
+    # Sample uniformly in cos(theta)
+    cos_lo = jnp.cos(theta_max)
+    cos_hi = jnp.cos(theta_min)
+    cos_theta = jran.uniform(theta_key, (npts,), minval=cos_lo, maxval=cos_hi)
+    theta = jnp.arccos(cos_theta)
+
+    return theta, phi
+
+
+@jjit
+def _get_ra_dec_from_theta_phi(theta, phi):
+    """Change sky coordinates from {theta, phi} (radians) to {ra, dec} (degrees)
+
+    Copied from diffsky.data_loaders.hacc_utils.lightcone_utils.py
+    to avoid circular imports. This function should be deleted once lc_utils.py
+    is migrated out of diffsky.experimental
+    """
+    return _get_lon_lat_from_theta_phi(theta, phi)
+
+
+@jjit
+def _get_lon_lat_from_theta_phi(theta, phi):
+    """Copied from diffsky.data_loaders.hacc_utils.lightcone_utils.py
+    to avoid circular imports. This function should be deleted once lc_utils.py
+    is migrated out of diffsky.experimental
+    """
+    lon = jnp.degrees(phi)
+    lat = 90.0 - jnp.degrees(theta)
+    return lon, lat
 
 
 @partial(jjit, static_argnames=["npts"])


### PR DESCRIPTION
In https://github.com/ArgonneCPAC/diffsky/pull/456, a bug was fixed by @patricialarsen in the sky coordinate convention used for `{ra, dec}`. Briefly, the coordinate convention adopted in [haccytrees](https://github.com/ArgonneCPAC/HACCyTrees) was off by a 180 rotation from the common convention used to define ra, dec. The implementation in diffsky was just a re-implementation of the same source code in haccytrees, including a unit test that enforced exact agreement between the two, and so this error was inherited by diffsky and fixed in https://github.com/ArgonneCPAC/diffsky/pull/456.

However, this fix was never ported to the [mc_lightcone_random_ra_dec](https://github.com/ArgonneCPAC/diffsky/blob/c0a3ef2c1fb74305e9dc4c139ade028b5c87501e/diffsky/experimental/lc_utils.py#L24) function in the lc_utils.py module that implements the Monte Carlo generation of lightcone coordinates. This PR resolves this inconsistency. The figure below shows the old vs. new code for the particular sky patch `lc_patch=5`. The blue points show the underlying halo distribution, which correctly fall within the bounds; the orange points on the left show the old code used to generate a Monte Carlo distribution of `{ra, dec}` for this patch, the green points on the right show the new code brought in with this PR.

<img width="1702" height="815" alt="lc_utils_bugfix_plot" src="https://github.com/user-attachments/assets/860f1651-9812-428d-b45b-23f6feb97a35" />
