### PR TITLE
Modify default parameters of disk/bulge sizes and axis ratios

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@
 - Remove obsolete prototype calibrations and bring in new models (https://github.com/ArgonneCPAC/diffsky/pull/466)
 - Fix bug in `ra, dec` for synthetic halos (https://github.com/ArgonneCPAC/diffsky/pull/469)
 - Fix bug in ellipsoidal shapes (https://github.com/ArgonneCPAC/diffsky/pull/468)
+- Retune disk axis ratio distribution and size--mass relation (https://github.com/ArgonneCPAC/diffsky/pull/470)
 
 
 0.3.6 (2026-06-12)

--- a/diffsky/ellipsoidal_shapes/disk_shapes.py
+++ b/diffsky/ellipsoidal_shapes/disk_shapes.py
@@ -11,9 +11,7 @@ AxisRatios = namedtuple("AxisRatios", ("b_over_a", "c_over_a"))
 DiskAxisRatioParams = namedtuple(
     "DiskAxisRatioParams", ("ba_min", "ba_max", "c_min", "c_max")
 )
-DEFAULT_DISK_PARAMS = DiskAxisRatioParams(
-    ba_min=0.5, ba_max=0.8, c_min=0.17, c_max=0.85
-)
+DEFAULT_DISK_PARAMS = DiskAxisRatioParams(ba_min=0.4, ba_max=0.8, c_min=0.15, c_max=0.7)
 
 
 @partial(jjit, static_argnames=["n_samples"])

--- a/diffsky/ellipsoidal_shapes/mc_disk_bulge_shapes.py
+++ b/diffsky/ellipsoidal_shapes/mc_disk_bulge_shapes.py
@@ -24,6 +24,8 @@ def mc_disk_bulge_ellipsoids(
     psi_noise_deg=20.0,
     envelop=True,
     ellipticity_type=0,
+    disk_params=disk_shapes.DEFAULT_DISK_PARAMS,
+    bulge_params=bulge_shapes.DEFAULT_BULGE_PARAMS,
 ):
     """Monte Carlo realization of disk/bulge axis ratios and orientations
 
@@ -50,8 +52,12 @@ def mc_disk_bulge_ellipsoids(
 
     ran_key, disk_shape_key, bulge_shape_key, los_key = jran.split(ran_key, 4)
 
-    disk_axis_ratios = disk_shapes.sample_disk_axis_ratios(disk_shape_key, n)
-    bulge_axis_ratios = bulge_shapes.sample_bulge_axis_ratios(bulge_shape_key, n)
+    disk_axis_ratios = disk_shapes.sample_disk_axis_ratios(
+        disk_shape_key, n, disk_params=disk_params
+    )
+    bulge_axis_ratios = bulge_shapes.sample_bulge_axis_ratios(
+        bulge_shape_key, n, bulge_params=bulge_params
+    )
 
     """
     The projection works in the following way:

--- a/diffsky/experimental/size_modeling/smzr_bulge.py
+++ b/diffsky/experimental/size_modeling/smzr_bulge.py
@@ -21,7 +21,7 @@ DEFAULT_BULGE_SIZE_PDICT = dict(
     z_x0_x0=1.0,
     z_x0_lo=10.2,
     z_x0_hi=11.6,
-    lgm_ytp=0.3,
+    lgm_ytp=0.461,
     lgm_slope_lo=0.14,
     lgm_slope_hi=0.25,
 )

--- a/diffsky/experimental/size_modeling/smzr_disk.py
+++ b/diffsky/experimental/size_modeling/smzr_disk.py
@@ -19,8 +19,8 @@ SLOPE_Z_K_DISK = 5.0
 
 DEFAULT_DISK_SIZE_PDICT = dict(
     ytp_x0=1.6,
-    ytp_lo=0.65,
-    ytp_hi=0.5,
+    ytp_lo=0.81,
+    ytp_hi=0.66,
     slope_x0=0.7,
     slope_lo=0.21,
     slope_hi=0.18,


### PR DESCRIPTION
This PR adjusts the model parameters that control the sizes and axis ratios of disks and bulges. In #468, the code used to derive a 2d shape from a 3d shape was corrected. That PR changed the distribution of ellipticity, as well as the size-mass relation. This PR retunes the model parameters so that the model based on the updated code produces mock galaxies with a very similar average ellipticity and size--mass relation as was previously calibrated to DP1 data. This PR closes #448. 

### Ellipticity recalibration

Upon inspecting a mock made with the new code compared to mocks made earlier this year, I found that `<ε_disk>=0.5` in the old mock, and `<ε_disk>=0.45` in the new mock. Meanwhile, I found a rather negligible change to the ellipticity of bulges.

So I fiddled with the parameters that control the 3d axis ratios of disks until the resulting mock has `<ε_disk>=0.5`. See the attached plot.
<img width="1060" height="785" alt="disk_ellipticity_recalibration" src="https://github.com/user-attachments/assets/398ecc74-7a38-4b67-91a7-05957e439cd1" />


### Size recalibration

Upon inspecting a mock made with the new code compared to mocks made earlier this year, I found that both of columns `r50_disk` and `r50_bulge` in the old mock were roughly 1.45x larger than mocks made with the updated code. So I modified the normalization parameter that controls the size--mass scaling relations for disks and bulges to increase the overall galaxy size by 1.45x. See the two plots below for the results.

<img width="1135" height="770" alt="size_mass_recalibration_bulge" src="https://github.com/user-attachments/assets/d28a4762-12e2-4e6e-9b62-d9b4732a2331" />
<img width="1128" height="770" alt="size_mass_recalibration_disk" src="https://github.com/user-attachments/assets/347bce0d-b757-4357-bd5e-f00086143b68" />
