### PR TITLE
Update latest release of `c260710` mock

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,8 @@ Latest version of diffsky mocks
 
 See `this OpenCosmo tutorial <https://github.com/ArgonneCPAC/opencosmo-examples/blob/main/03-Diffsky/demo_diffmah_diffstar.ipynb/>`_
 for information about how to access the latest mock with OpenCosmo.
-The latest release of the mocks can be downloaded at this URL:
+The latest release of the mocks is publicly available on NERSC:
 
-    https://portal.nersc.gov/project/hacc/aphearin/diffsky_data/cosmos_260316_06_13_2026
+    /global/cfs/cdirs/hacc/OpenCosmo/LastJourney/synthetic_galaxies/c260710_08_02_2026
+
+See  `this PR <https://github.com/ArgonneCPAC/diffsky/pull/472/>`_ for further information about the latest mock.


### PR DESCRIPTION
This PR updates the latest release of the `c260710` mock to be `c260710_08_02_2026`, a mock with sky area of `34.34 deg^2` spanning `0<z<4`. See https://github.com/ArgonneCPAC/diffsky/pull/463 for a comparison of this model's photometry to COSMOS. 

The latest release has several improvements upon earlier mocks based on this same model:
* Improved realism in distribution of 2d and 3d galaxy shapes (https://github.com/ArgonneCPAC/diffsky/pull/468)
* Fix bug in `{ra, dec}` definition, resolving issue with gg-lensing signal (https://github.com/ArgonneCPAC/diffsky/pull/456). 
* Recalibrate model of galaxy shapes and sizes to roughly agree with the scaling relations calibrated against LSST DP1 (https://github.com/ArgonneCPAC/diffsky/pull/470).
* Include additional emission lines: `Hα`, `Hβ`, `[OII]`, `[OIII]`, `[SIII]`.