### PR TITLE
Change littleh convention to Mpc (not Mpc/h) for all spatial positions in Diffsky mocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.3.8 (unreleased)
 -------------------
 - Add HLTDS fields for image simulation: ELIAS-N1, EDFS_a, EDFS_b
-- Add OpenUniverse2026 fields
+- Change littleh convention so that all spatial positions of mocks are now in Mpc (not Mpc/h) (https://github.com/ArgonneCPAC/diffsky/pull/478)
 
 
 0.3.7 (2026-08-05)

--- a/diffsky/data_loaders/hacc_utils/data_validation/validate_lc_mock.py
+++ b/diffsky/data_loaders/hacc_utils/data_validation/validate_lc_mock.py
@@ -6,6 +6,7 @@ from glob import glob
 import h5py
 import numpy as np
 import yaml
+from dsps.cosmology import flat_wcdm
 from dsps.photometry import photometry_kernels as phk
 from jax import vmap
 
@@ -51,6 +52,10 @@ def get_lc_mock_data_report(fn_lc_mock, *, no_dbk, no_sed):
     msg = check_all_columns_have_expected_shapes(fn_lc_mock, data=data)
     if len(msg) > 0:
         report["column_sizes"] = msg
+
+    msg = check_xyz_littleh(fn_lc_mock, data=data)
+    if len(msg) > 0:
+        report["xyz_littleh"] = msg
 
     msg = check_host_pos_is_near_galaxy_pos(fn_lc_mock, data=data)
     if len(msg) > 0:
@@ -704,3 +709,24 @@ def check_recomputed_dbk_sed(fn_lc_mock, *, nchunks, chunknum, return_results=Fa
         return mock_chunk, metadata, sed_info, phot_info, msg
     else:
         return msg
+
+
+def check_xyz_littleh(fn_lc_mock, data=None):
+    """Columns storing xyz should be in units of Mpc, not Mpc/h"""
+    if data is None:
+        data = load_flat_hdf5(fn_lc_mock)
+
+    metadata = load_lc_mock.load_mock_metadata(fn_lc_mock)
+
+    rcom_from_xyz = np.sqrt(data["x"] ** 2 + data["y"] ** 2 + data["z"] ** 2)
+    rcom_from_redshift = flat_wcdm.comoving_distance(
+        data["redshift_true"], *metadata["sim_info"].cosmo_params
+    )
+    msg = []
+    try:
+        s = "Discrepancy between xyz and redshift_true - likely due to littleh"
+        assert np.allclose(rcom_from_xyz, rcom_from_redshift, rtol=0.02)
+    except AssertionError:
+        msg.append(s)
+
+    return msg

--- a/diffsky/data_loaders/hacc_utils/haccsims.py
+++ b/diffsky/data_loaders/hacc_utils/haccsims.py
@@ -18,6 +18,27 @@ SIM_INFO = dict(
     DiscoveryW0WA=SimSpecs(969.9, 6720, 286943385.1781562),
 )
 
+LC_COLNAMES_MPCH = (
+    "x",
+    "y",
+    "z",
+    "lc_halo_x",
+    "lc_halo_y",
+    "lc_halo_z",
+    "top_host_infall_fof_halo_eigS1X",
+    "top_host_infall_fof_halo_eigS1Y",
+    "top_host_infall_fof_halo_eigS1Z",
+    "top_host_infall_fof_halo_eigS2X",
+    "top_host_infall_fof_halo_eigS2Y",
+    "top_host_infall_fof_halo_eigS2Z",
+    "top_host_infall_fof_halo_eigS3X",
+    "top_host_infall_fof_halo_eigS3Y",
+    "top_host_infall_fof_halo_eigS3Z",
+    "infall_fof_halo_center_x",
+    "infall_fof_halo_center_y",
+    "infall_fof_halo_center_z",
+)
+
 
 class HACCSim(object):
 

--- a/diffsky/data_loaders/hacc_utils/load_lc_cf.py
+++ b/diffsky/data_loaders/hacc_utils/load_lc_cf.py
@@ -20,6 +20,7 @@ from . import load_lc_cores as llcc
 SIM_INFO_KEYS = ("sim", "cosmo_params", "z_sim", "t_sim", "lgt0", "fb", "num_subvols")
 DiffskySimInfo = namedtuple("DiffskySimInfo", SIM_INFO_KEYS)
 
+
 try:
     import haccytrees  # noqa
 
@@ -55,13 +56,35 @@ def get_diffsky_info_from_hacc_sim(sim_name):
     return diffsky_info
 
 
-def load_lc_diffsky_patch_data(fn_lc_diffsky, indir_lc_data, *, istart=0, iend=None):
+def load_lc_diffsky_patch_data(
+    fn_lc_diffsky, indir_lc_data, *, sim_name, convert_mpch_to_mpc, istart=0, iend=None
+):
     diffsky_data = load_flat_hdf5(fn_lc_diffsky, istart=istart, iend=iend)
 
     bn_in = os.path.basename(fn_lc_diffsky)
     bn_lc = os.path.basename(bn_in).replace(".diffsky_data.hdf5", ".hdf5")
     fn_lc = os.path.join(indir_lc_data, bn_lc)
     lc_data = load_flat_hdf5(fn_lc, istart=istart, iend=iend, dataset="data")
+
+    if convert_mpch_to_mpc:
+        sim_info = get_diffsky_info_from_hacc_sim(sim_name)
+        littleh = sim_info.cosmo_params.h
+        for colname in haccsims.LC_COLNAMES_MPCH:
+            # Convert lc_data for any columns appearing in haccsims.LC_COLNAMES_MPCH
+            try:
+                distance_quantity_mpch = lc_data[colname]
+                distance_quantity_mpc = distance_quantity_mpch / littleh
+                lc_data[colname] = distance_quantity_mpc
+            except KeyError:
+                pass
+
+            # Convert diffsky_data for any columns appearing in haccsims.LC_COLNAMES_MPCH
+            try:
+                distance_quantity_mpch = diffsky_data[colname]
+                distance_quantity_mpc = distance_quantity_mpch / littleh
+                diffsky_data[colname] = distance_quantity_mpc
+            except KeyError:
+                pass
 
     lc_data["redshift_true"] = 1 / lc_data["scale_factor"] - 1
 
@@ -160,6 +183,8 @@ def load_lc_cf_chunk(
     *,
     nchunks,
     chunknum,
+    sim_name,
+    convert_mpch_to_mpc,
     lc_cores_keys=None,
     convert_vcom_to_vphys=True,
 ):
@@ -181,6 +206,26 @@ def load_lc_cf_chunk(
         diffsky_data["vx"] = lc_data["scale_factor"] * diffsky_data["vx"]
         diffsky_data["vy"] = lc_data["scale_factor"] * diffsky_data["vy"]
         diffsky_data["vz"] = lc_data["scale_factor"] * diffsky_data["vz"]
+
+    if convert_mpch_to_mpc:
+        sim_info = get_diffsky_info_from_hacc_sim(sim_name)
+        littleh = sim_info.cosmo_params.h
+        for colname in haccsims.LC_COLNAMES_MPCH:
+            # Convert lc_data for any columns appearing in haccsims.LC_COLNAMES_MPCH
+            try:
+                distance_quantity_mpch = lc_data[colname]
+                distance_quantity_mpc = distance_quantity_mpch / littleh
+                lc_data[colname] = distance_quantity_mpc
+            except KeyError:
+                pass
+
+            # Convert diffsky_data for any columns appearing in haccsims.LC_COLNAMES_MPCH
+            try:
+                distance_quantity_mpch = diffsky_data[colname]
+                distance_quantity_mpc = distance_quantity_mpch / littleh
+                diffsky_data[colname] = distance_quantity_mpc
+            except KeyError:
+                pass
 
     lc_data["redshift_true"] = 1.0 / lc_data["scale_factor"] - 1.0
 

--- a/diffsky/data_loaders/hacc_utils/load_lc_cf_synthetic.py
+++ b/diffsky/data_loaders/hacc_utils/load_lc_cf_synthetic.py
@@ -29,6 +29,13 @@ def load_lc_diffsky_patch_data(
     read_start,
     downsample_factor=1.0,
 ):
+    """
+
+    Notes
+    -----
+    xyz and xyz_host are returned in units of Mpc
+
+    """
 
     sim_info = llcf.get_diffsky_info_from_hacc_sim(sim_name)
 
@@ -110,15 +117,12 @@ def load_lc_diffsky_patch_data(
         diffsky_data["redshift_true"],
         sim_info.cosmo_params,
     )
-    x_mpch = x_mpc * sim_info.cosmo_params.h
-    y_mpch = y_mpc * sim_info.cosmo_params.h
-    z_mpch = z_mpc * sim_info.cosmo_params.h
-    diffsky_data["x"] = x_mpch
-    diffsky_data["y"] = y_mpch
-    diffsky_data["z"] = z_mpch
-    diffsky_data["x_host"] = x_mpch
-    diffsky_data["y_host"] = y_mpch
-    diffsky_data["z_host"] = z_mpch
+    diffsky_data["x"] = x_mpc
+    diffsky_data["y"] = y_mpc
+    diffsky_data["z"] = z_mpc
+    diffsky_data["x_host"] = x_mpc
+    diffsky_data["y_host"] = y_mpc
+    diffsky_data["z_host"] = z_mpc
 
     ZZ = np.zeros(n_gals)
 

--- a/diffsky/data_loaders/hacc_utils/metadata_mock.py
+++ b/diffsky/data_loaders/hacc_utils/metadata_mock.py
@@ -199,19 +199,18 @@ def add_metadata_diffstar_columns(metadata, incl_in_situ=False):
 
 
 def add_metadata_nfw_columns(metadata):
-    unit_mpch = u.Mpc / cu.littleh
 
     metadata["x_nfw"] = (
-        str(unit_mpch),
-        "Comoving coord with NFW-repositioned satellites",
+        str(u.Mpc),
+        "Comoving coord with NFW-repositioned satellites in units of Mpc",
     )
     metadata["y_nfw"] = (
-        str(unit_mpch),
-        "Comoving coord with NFW-repositioned satellites",
+        str(u.Mpc),
+        "Comoving coord with NFW-repositioned satellites in units of Mpc",
     )
     metadata["z_nfw"] = (
-        str(unit_mpch),
-        "Comoving coord with NFW-repositioned satellites",
+        str(u.Mpc),
+        "Comoving coord with NFW-repositioned satellites in units of Mpc",
     )
 
     metadata["ra_nfw"] = (
@@ -227,35 +226,34 @@ def add_metadata_nfw_columns(metadata):
 
 
 def add_metadata_posvel_columns(metadata):
-    unit_mpch = u.Mpc / cu.littleh
 
     metadata["ra"] = (str(u.deg), "right ascension")
     metadata["dec"] = (str(u.deg), "declination")
 
     metadata["x"] = (
-        str(unit_mpch),
-        "Comoving coordinate of lightcone position",
+        str(u.Mpc),
+        "Comoving coordinate of lightcone position in units of Mpc",
     )
     metadata["y"] = (
-        str(unit_mpch),
-        "Comoving coordinate of lightcone position",
+        str(u.Mpc),
+        "Comoving coordinate of lightcone position in units of Mpc",
     )
     metadata["z"] = (
-        str(unit_mpch),
-        "Comoving coordinate of lightcone position",
+        str(u.Mpc),
+        "Comoving coordinate of lightcone position in units of Mpc",
     )
 
     metadata["x_host"] = (
-        str(unit_mpch),
-        "Comoving coord of host halo lightcone position",
+        str(u.Mpc),
+        "Comoving coord of host halo lightcone position in units of Mpc",
     )
     metadata["y_host"] = (
-        str(unit_mpch),
-        "Comoving coord of host halo lightcone position",
+        str(u.Mpc),
+        "Comoving coord of host halo lightcone position in units of Mpc",
     )
     metadata["z_host"] = (
-        str(unit_mpch),
-        "Comoving coord of host halo lightcone position",
+        str(u.Mpc),
+        "Comoving coord of host halo lightcone position in units of Mpc",
     )
 
     metadata["vpec"] = (
@@ -276,44 +274,42 @@ def add_metadata_inertia_tensor_columns(metadata):
     if not HAS_ASTROPY:
         raise ImportError("Must have astropy installed to attach units to metadata")
 
-    unit_mpch = u.Mpc / cu.littleh
-
     metadata["top_host_infall_fof_halo_eigS1X"] = (
-        str(unit_mpch),
+        str(u.Mpc),
         "x-component of first eigendirection of halo shape (unreduced inertia tensor)",
     )
     metadata["top_host_infall_fof_halo_eigS1Y"] = (
-        str(unit_mpch),
+        str(u.Mpc),
         "y-component of first eigendirection of halo shape (unreduced inertia tensor)",
     )
     metadata["top_host_infall_fof_halo_eigS1Z"] = (
-        str(unit_mpch),
+        str(u.Mpc),
         "z-component of first eigendirection of halo shape (unreduced inertia tensor)",
     )
 
     metadata["top_host_infall_fof_halo_eigS2X"] = (
-        str(unit_mpch),
+        str(u.Mpc),
         "x-component of second eigendirection of halo shape (unreduced inertia tensor)",
     )
     metadata["top_host_infall_fof_halo_eigS2Y"] = (
-        str(unit_mpch),
+        str(u.Mpc),
         "y-component of second eigendirection of halo shape (unreduced inertia tensor)",
     )
     metadata["top_host_infall_fof_halo_eigS2Z"] = (
-        str(unit_mpch),
+        str(u.Mpc),
         "z-component of second eigendirection of halo shape (unreduced inertia tensor)",
     )
 
     metadata["top_host_infall_fof_halo_eigS3X"] = (
-        str(unit_mpch),
+        str(u.Mpc),
         "x-component of third eigendirection of halo shape (unreduced inertia tensor)",
     )
     metadata["top_host_infall_fof_halo_eigS3Y"] = (
-        str(unit_mpch),
+        str(u.Mpc),
         "y-component of third eigendirection of halo shape (unreduced inertia tensor)",
     )
     metadata["top_host_infall_fof_halo_eigS3Z"] = (
-        str(unit_mpch),
+        str(u.Mpc),
         "z-component of third eigendirection of halo shape (unreduced inertia tensor)",
     )
     return metadata

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -329,6 +329,8 @@ if __name__ == "__main__":
                     indir_lc_data,
                     nchunks=nchunks,
                     chunknum=chunknum,
+                    sim_name=sim_name,
+                    convert_mpch_to_mpc=True,
                     convert_vcom_to_vphys=True,
                 )
             else:


### PR DESCRIPTION
This PR changes the convention used in the units of diffsky mocks: all columns storing spatial positions (such as `xyz` and `xyz_new`) are now output in units of Mpc instead of Mpc/h.

This resolves a bug reported by @JiachuanXu, who found an inconsistency between the `xyz` positions and the comoving distance to `redshift_true`.

There is now a new unit test that enforces agreement between spatial positions and redshift. The new test would have caught the previous bug, and so now protects against regressions in future.

The plot below reproduces the bug reported by @JiachuanXu and shows the fix with the updated code. The black points and blue points agree to sub-percent level - the plot manually offsets the black points by a tiny fraction for visual clarity.
<img width="1131" height="815" alt="xyz_mpc_unit_test" src="https://github.com/user-attachments/assets/2a864237-ba9b-41fc-99b9-94ab728e98cf" />
