### PR TITLE
Fix bug in abundance of very-low-redshift synthetic halos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,8 @@
 -------------------
 - Add HLTDS fields for image simulation: ELIAS-N1, EDFS_a, EDFS_b
 - Change littleh convention so that all spatial positions of mocks are now in Mpc (not Mpc/h) (https://github.com/ArgonneCPAC/diffsky/pull/478)
-
+- Fix bug in ra, dec of synthetic halos due to outdated LastJourney file (https://github.com/ArgonneCPAC/diffsky/pull/481)
+- Fix bug in abundance of low-redshift synthetic halos due to incorrect downsampling factor (https://github.com/ArgonneCPAC/diffsky/pull/482)
 
 0.3.7 (2026-08-05)
 -------------------

--- a/diffsky/data_loaders/hacc_utils/data_validation/validate_lc_mock.py
+++ b/diffsky/data_loaders/hacc_utils/data_validation/validate_lc_mock.py
@@ -10,6 +10,7 @@ from dsps.cosmology import flat_wcdm
 from dsps.photometry import photometry_kernels as phk
 from jax import vmap
 
+from ....experimental import mc_lightcone_halos as mclh
 from ....param_utils import diffsky_param_wrapper as dpw
 from .. import lc_mock as lcmp
 from .. import lightcone_utils, load_flat_hdf5, load_lc_cf, load_lc_mock, sed_from_mock
@@ -56,6 +57,10 @@ def get_lc_mock_data_report(fn_lc_mock, *, no_dbk, no_sed):
     msg = check_xyz_littleh(fn_lc_mock, data=data)
     if len(msg) > 0:
         report["xyz_littleh"] = msg
+
+    msg = check_expected_number_of_synthetic_galaxies(fn_lc_mock, data=data)
+    if len(msg) > 0:
+        report["ngal_expected"] = msg
 
     msg = check_host_pos_is_near_galaxy_pos(fn_lc_mock, data=data)
     if len(msg) > 0:
@@ -311,6 +316,51 @@ def check_metadata(fn_lc_mock):
         except:  # noqa
             s = "metadata is incorrect"
             msg.append(s)
+
+    return msg
+
+
+def check_expected_number_of_synthetic_galaxies(fn_lc_mock, data=None):
+    msg = []
+    bn_mock = os.path.basename(fn_lc_mock)
+    if "synthetic" not in bn_mock:
+        return msg
+
+    if data is None:
+        data = load_flat_hdf5(fn_lc_mock, dataset="data")
+
+    sizes = [x.shape[0] for x in data.values()]
+    ngals = int(sizes[0])
+
+    z_min = np.percentile(data["redshift_true"], 1)
+    z_max = np.percentile(data["redshift_true"], 99)
+
+    drn_mock = os.path.dirname(fn_lc_mock)
+    fn_list_yamls = glob(os.path.join(drn_mock, "*.yaml"))
+    fn_yaml = fn_list_yamls[0]
+    with open(fn_yaml, "r") as fobj:
+        config = yaml.safe_load(fobj)
+
+    lgmp_min = config["lgmp_min"]
+    lgmp_max = config["lgmp_max"]
+
+    metadata = load_lc_mock.load_mock_metadata(fn_lc_mock)
+    sim_name = metadata["nbody_info"]["sim_name"]
+    _res = lightcone_utils.read_hacc_lc_patch_decomposition(sim_name)
+    patch_decomposition, sky_frac, solid_angles = _res
+    stepnum, lc_patch = lcmp.infer_lc_patch_stepnum_from_bname(bn_mock)
+    sky_area_degsq = solid_angles[lc_patch]
+
+    nhalos_estimate = mclh.estimate_nhalos_in_lightcone(
+        lgmp_min, z_min, z_max, sky_area_degsq, lgmp_max=lgmp_max
+    )
+
+    ngal_ratio = ngals / nhalos_estimate
+    try:
+        assert np.all((ngal_ratio >= 0.5) & (ngal_ratio <= 2.0))
+    except AssertionError:
+        s = f"ngals={ngals:_} but nhalos_estimate={nhalos_estimate:_}"
+        msg.append(s)
 
     return msg
 

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -286,6 +286,7 @@ if __name__ == "__main__":
                 lc_patch_info.z_lo,
                 lc_patch_info.z_hi,
                 lc_patch_info.sky_area_degsq,
+                lgmp_max=lgmp_max,
             )
             nhalos_estimate = int(np.round(mean_nhalos))
             z_min_shell = lc_patch_info.z_lo

--- a/scripts/LJ_LC_MOCKS/make_lj_mock.py
+++ b/scripts/LJ_LC_MOCKS/make_lj_mock.py
@@ -315,7 +315,8 @@ if __name__ == "__main__":
         else:
             nchunks = nhalos_estimate // batch_size
         msg = f"Loading {nhalos_estimate} halos in {nchunks} chunks with batch_size={batch_size}"
-        print(msg)
+        if rank == 0:
+            print(msg)
 
         n_cuml_fn = 0
         for chunknum in range(0, nchunks):
@@ -336,6 +337,7 @@ if __name__ == "__main__":
                 )
             else:
                 downsample_factor = nhalos_estimate / batch_size
+                downsample_factor = max(downsample_factor, 1)
                 batch_key, synthetic_lc_key = jran.split(batch_key, 2)
                 lc_data_batch, diffsky_data_batch = llcs.load_lc_diffsky_patch_data(
                     fn_lc_cores,


### PR DESCRIPTION
This PR fixes a bug in the number density of synthetic mock galaxies at low redshift. When generating synthetic halos in the mock-production script, the code uses the `mc_lightcone_halos.estimate_nhalos_in_lightcone` function to calculate how many synthetic halos should be added to the lightcone file. When the number of halos needed exceeds `batch_size`, then a downsampling factor is applied to the MC generator:
```
downsample_factor = nhalos_estimate / batch_size
```

But at very low redshift, when the cosmological volume of the patch of sky is small, `downsample_factor<1`. In fact, at the lowest redshift, `downsample_factor~1e4`. And so vastly more synthetic halos were being generated at very low redshift. But in such cases, no downsampling should be done at all. The fix is very simple:
```
downsample_factor = nhalos_estimate / batch_size
downsample_factor = max(downsample_factor, 1)
```

This PR implements this fix. Additionally, there is a new unit test `check_expected_number_of_synthetic_galaxies` that enforces agreement between the expected number of galaxies, and the number of galaxies in the mock. I have verified that this test fails for mocks generated with the old code, and passes with the new code. Note that this test is only run on files storing synthetic galaxies.

Thanks to @MitraKaustav for discovering this bug.