### PR TITLE
Include `redshift_obs` column in diffsky mocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - Change littleh convention so that all spatial positions of mocks are now in Mpc (not Mpc/h) (https://github.com/ArgonneCPAC/diffsky/pull/478)
 - Fix bug in ra, dec of synthetic halos due to outdated LastJourney file (https://github.com/ArgonneCPAC/diffsky/pull/481)
 - Fix bug in abundance of low-redshift synthetic halos due to incorrect downsampling factor (https://github.com/ArgonneCPAC/diffsky/pull/482)
+- Include `redshift_obs` column in diffsky mocks (https://github.com/ArgonneCPAC/diffsky/pull/483)
 
 0.3.7 (2026-08-05)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 - Change littleh convention so that all spatial positions of mocks are now in Mpc (not Mpc/h) (https://github.com/ArgonneCPAC/diffsky/pull/478)
 - Fix bug in ra, dec of synthetic halos due to outdated LastJourney file (https://github.com/ArgonneCPAC/diffsky/pull/481)
 - Fix bug in abundance of low-redshift synthetic halos due to incorrect downsampling factor (https://github.com/ArgonneCPAC/diffsky/pull/482)
-- Include `redshift_obs` column in diffsky mocks (https://github.com/ArgonneCPAC/diffsky/pull/483)
+- Include `redshift_obs` column in diffsky mocks (https://github.com/ArgonneCPAC/diffsky/pull/484)
 
 0.3.7 (2026-08-05)
 -------------------

--- a/diffsky/data_loaders/hacc_utils/data_validation/validate_lc_mock.py
+++ b/diffsky/data_loaders/hacc_utils/data_validation/validate_lc_mock.py
@@ -62,6 +62,10 @@ def get_lc_mock_data_report(fn_lc_mock, *, no_dbk, no_sed):
     if len(msg) > 0:
         report["ngal_expected"] = msg
 
+    msg = check_mock_has_observed_redshift(fn_lc_mock, data=data)
+    if len(msg) > 0:
+        report["z_obs_column_exists"] = msg
+
     msg = check_host_pos_is_near_galaxy_pos(fn_lc_mock, data=data)
     if len(msg) > 0:
         report["nfw_host_distance"] = msg
@@ -160,6 +164,20 @@ def check_yaml_config(fn_lc_mock, yaml_req_list=YAML_REQ_LIST):
         if len(missing_lines) > 0:
             s = f"{fn_config} is missing the following entries: {missing_lines}"
             msg.append(s)
+
+    return msg
+
+
+def check_mock_has_observed_redshift(fn_lc_mock, data=None):
+
+    if data is None:
+        data = load_flat_hdf5(fn_lc_mock, dataset="data")
+
+    msg = []
+    try:
+        assert "redshift_obs" in list(data.keys())
+    except AssertionError:
+        msg.append("Mock is missing `redshift_obs` column")
 
     return msg
 

--- a/diffsky/data_loaders/hacc_utils/lc_mock.py
+++ b/diffsky/data_loaders/hacc_utils/lc_mock.py
@@ -41,6 +41,7 @@ from ...fake_sats import nfw_config_space as nfwcs
 from ...fake_sats import vector_utilities as vecu
 from ...param_utils import diffsky_param_wrapper as dpw
 from ...param_utils import diffsky_param_wrapper_merging as dpwm
+from ...utils import cosmo_utils
 from .. import io_utils as iou
 from . import lightcone_utils as hlu
 from . import load_lc_cf
@@ -106,6 +107,7 @@ DIFFSKY_DATA_KEYS_OUT = (
     "vy",
     "vz",
     "vpec",
+    "redshift_obs",
     "msk_v0",
     "has_diffmah_fit",
     "logmp0",
@@ -452,6 +454,9 @@ def add_peculiar_velocity_to_mock(
     V = np.array((diffsky_data["vx"], diffsky_data["vy"], diffsky_data["vz"])).T
     Xnorm = vecu.normalized_vectors(X)
     diffsky_data["vpec"] = vecu.elementwise_dot(V, Xnorm)
+    diffsky_data["redshift_obs"] = cosmo_utils.get_redshift_obs_from_redshift_true(
+        lc_data["redshift_true"], diffsky_data["vpec"]
+    )
 
     return diffsky_data
 

--- a/diffsky/data_loaders/hacc_utils/metadata_mock.py
+++ b/diffsky/data_loaders/hacc_utils/metadata_mock.py
@@ -486,6 +486,10 @@ def add_metadata_lc_core_data_columns(metadata):
         str(u.dimensionless_unscaled),
         "True redshift",
     )
+    metadata["redshift_obs"] = (
+        str(u.dimensionless_unscaled),
+        "Observed redshift, accounting for line-of-sight peculiar velocity",
+    )
 
     metadata["stepnum"] = (
         str(u.dimensionless_unscaled),

--- a/diffsky/utils/cosmo_utils.py
+++ b/diffsky/utils/cosmo_utils.py
@@ -1,0 +1,27 @@
+""""""
+
+from dsps.cosmology.flat_wcdm import C_SPEED
+
+
+def get_redshift_obs_from_redshift_true(z_true, vpec_kms):
+    """Calculate effect of peculiar velocity on observed redshift
+
+    1 + z_obs = (1+z_true) * (1+v/c)
+
+    Parameters
+    ----------
+    z_true : array, shape (n, )
+
+    vpec_kms : array, shape (n, )
+        Peculiar velocity along the line of sight in km/s units
+
+    Returns
+    -------
+    redshift_obs : array, shape (n, )
+        Observed redshift
+
+    """
+    c_kms = C_SPEED / 1000.0
+    one_plus_zobs = (1 + z_true) * (1 + vpec_kms / c_kms)
+    redshift_obs = one_plus_zobs - 1.0
+    return redshift_obs

--- a/diffsky/utils/tests/test_cosmo_utils.py
+++ b/diffsky/utils/tests/test_cosmo_utils.py
@@ -1,0 +1,22 @@
+""""""
+
+import numpy as np
+from jax import random as jran
+
+from .. import cosmo_utils
+
+
+def test_get_redshift_obs_from_redshift_true():
+    ran_key = jran.key(0)
+    ngals = 100_000
+    z_min, z_max = 0.0001, 5.0
+
+    z_key, v_key = jran.split(ran_key, 2)
+    z_true = jran.uniform(z_key, minval=z_min, maxval=z_max, shape=(ngals,))
+
+    vpec_std = 1_000.0
+    vpec_kms = jran.normal(v_key, shape=(ngals,)) * vpec_std
+    redshift_obs = cosmo_utils.get_redshift_obs_from_redshift_true(z_true, vpec_kms)
+    assert np.all(np.isfinite(redshift_obs))
+    assert np.max(np.abs(redshift_obs - z_true)) < 0.2
+    assert np.abs(np.mean(redshift_obs - z_true)) < 1e-4


### PR DESCRIPTION
This PR brings in a new utility function that calculates the effect of line-of-sight peculiar velocity on the observed redshift of galaxies: `diffsky.utils.cosmo_utils.get_redshift_obs_from_redshift_true`. The calculated quantity, `redshift_obs`, is now included as a column in all diffsky mocks, enforced by a new mock validation test.

```
1 + z_obs = (1+z_true) * (1+v/c)
```

Note that negative values of `z_obs` can occur for very-low-redshift galaxies that are moving rapidly towards the observer.