### PR TITLE
Update info about latest mocks `c260710_08_24_2026` and `sdss_feniks_hizels_260710_08_24_2026` in `README`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,9 +35,10 @@ Latest version of diffsky mocks
 -------------------------------
 
 See `this OpenCosmo tutorial <https://argonnecpac.github.io/opencosmo-examples/demo-diffsky-nersc/>`_
-for information about how to access and query the latest mock with OpenCosmo, and `this tutorial <https://argonnecpac.github.io/opencosmo-examples/demo-diffmah-diffstar/>`_ about how to compute mass accretion and star formation histories. 
-The latest release of the mocks can be downloaded at this URL: 
+for information about how to access and query the latest mock with OpenCosmo, and `this tutorial <https://argonnecpac.github.io/opencosmo-examples/demo-diffmah-diffstar/>`_ about how to compute mass accretion and star formation histories.
+The latest release of the mocks can be downloaded at these URLs:
 
-    /global/cfs/cdirs/hacc/OpenCosmo/LastJourney/synthetic_galaxies/c260710_08_02_2026
+    /global/cfs/cdirs/hacc/OpenCosmo/LastJourney/synthetic_galaxies/c260710_08_24_2026
+    /global/cfs/cdirs/hacc/OpenCosmo/LastJourney/synthetic_galaxies/sdss_feniks_hizels_260710_08_24_2026
 
-See  `this PR <https://github.com/ArgonneCPAC/diffsky/pull/472/>`_ for further information about the latest mock.
+See  `this PR <https://github.com/ArgonneCPAC/diffsky/pull/486/>`_ for further information about the latest mock.


### PR DESCRIPTION
This PR updates the README with info about two new Diffsky mocks populating lightcones in the [Last Journey N-body simulation](https://arxiv.org/abs/2006.01697):
* `c260710_08_24_2026` - Diffsky parameter calibration led by Kaustav Mitra based on COSMOS-20 photometry
* `sdss_feniks_hizels_260710_08_24_2026` - Diffsky parameter calibration led by Kumail Zaidi based on photometry from SDSS and FENIKS, and Hα emission line functions in HiZELS.

The `c260710` model and the `sdss_feniks_hizels_260710` model are unchanged since the previous mock releases on 7/15.

Both mocks include synthetic central galaxies with lgmp_min=10.5, and so luminosity functions should be complete to i<~25-26.
Each mock spans `0<z<4` and occupies a contiguous sky area of 34.38 deg^2, a single `lc_patch` chosen to overlap with the LSST Deep Drilling Field `ECDFS` as shown below
<img width="1144" height="785" alt="ecdfs_field_overlap" src="https://github.com/user-attachments/assets/094dedbc-7c65-48d1-b8fc-64f41de40c17" />

* Both mocks include synthetic central galaxies with `lgmp_min=10.5`, and so luminosity functions should be complete to `i<~25-26`.
* Lensing effects are included on galaxy positions, photometry and emission lines by ray-tracing led by Patricia Larsen.
* Columns include broadband magnitudes through all LSST and Roman filters.
* Columns include emission line luminosities Hα, Hβ, [OII], [OIII], and [SIII].
* Columns include morphology information about disk and bulge components (photometry, size, ellipticity, orientation angle on the sky).