### PR TITLE
Include intrinsic alignment as a standalone post-processing script

### DIFF
--- a/diffsky/ellipsoidal_shapes/ellipse_proj_kernels.py
+++ b/diffsky/ellipsoidal_shapes/ellipse_proj_kernels.py
@@ -23,7 +23,9 @@ Credits:
 from collections import namedtuple
 from functools import partial
 
+import jax
 from jax import jit as jjit
+from jax import lax
 from jax import numpy as jnp
 from jax import random as jran
 
@@ -75,7 +77,7 @@ def mc_orthonormal_vectors(ran_key, n):
 
     return A, B, C
 
-@partial(jjit, static_argnums=(7, 8))
+@partial(jjit, static_argnums=(8, 9))
 def compute_ellipse2d_in_sim_frame(A_v, B_v, C_v, a, b, c, obs_x, obs_y, envelop=True, ellipticity_type=0):
     """
     Calculate the observed 2D ellipse parameters of a 3D triaxial ellipsoid in the simulation frame,
@@ -619,7 +621,12 @@ def observer_frame_axes_from_pos_3D(pos_x, pos_y, pos_z):
 @jjit
 def assert_orthonormality(x_prime, y_prime, z_prime, atol=1e-6):
     """
-    Assert that the provided axes are orthonormal.
+    Warn if the provided axes are not orthonormal.
+
+    This is called from jitted functions, so the check can't be a Python-level
+    `assert` (the outcome is data-dependent, and a traced bool can't go through
+    Python's `assert`/`bool()`); instead it prints a runtime warning via a
+    `lax.cond`-gated `jax.debug.print`, without interrupting the computation.
 
     Parameters
     ----------
@@ -628,14 +635,24 @@ def assert_orthonormality(x_prime, y_prime, z_prime, atol=1e-6):
     atol : float
         Absolute tolerance for the checks.
     """
-    assert jnp.allclose(jnp.sum(x_prime * y_prime, axis=-1), 0.0, atol=atol)
-    assert jnp.allclose(jnp.sum(x_prime * z_prime, axis=-1), 0.0, atol=atol)
-    assert jnp.allclose(jnp.sum(y_prime * z_prime, axis=-1), 0.0, atol=atol)
-    assert jnp.allclose(jnp.linalg.norm(x_prime, axis=-1), 1.0, atol=atol)
-    assert jnp.allclose(jnp.linalg.norm(y_prime, axis=-1), 1.0, atol=atol)
-    assert jnp.allclose(jnp.linalg.norm(z_prime, axis=-1), 1.0, atol=atol)
-    assert jnp.allclose(
-        jnp.linalg.norm(jnp.cross(x_prime, y_prime) - z_prime, axis=-1), 0.0, atol=atol
+    ok = (
+        jnp.allclose(jnp.sum(x_prime * y_prime, axis=-1), 0.0, atol=atol)
+        & jnp.allclose(jnp.sum(x_prime * z_prime, axis=-1), 0.0, atol=atol)
+        & jnp.allclose(jnp.sum(y_prime * z_prime, axis=-1), 0.0, atol=atol)
+        & jnp.allclose(jnp.linalg.norm(x_prime, axis=-1), 1.0, atol=atol)
+        & jnp.allclose(jnp.linalg.norm(y_prime, axis=-1), 1.0, atol=atol)
+        & jnp.allclose(jnp.linalg.norm(z_prime, axis=-1), 1.0, atol=atol)
+        & jnp.allclose(
+            jnp.linalg.norm(jnp.cross(x_prime, y_prime) - z_prime, axis=-1), 0.0, atol=atol
+        )
+    )
+    lax.cond(
+        ok,
+        lambda _: None,
+        lambda _: jax.debug.print(
+            'assert_orthonormality: axes failed an orthonormality check (atol={atol})',
+            atol=atol),
+        operand=None,
     )
 
 @jjit

--- a/diffsky/ellipsoidal_shapes/ellipse_proj_kernels.py
+++ b/diffsky/ellipsoidal_shapes/ellipse_proj_kernels.py
@@ -62,6 +62,96 @@ def mc_ellipsoid_params(r50, b_over_a, c_over_a, ran_key, sample_omega=True):
     c = c_over_a * a
     return compute_ellipse2d(a, b, c, mu_ran, phi_ran, omega_ran)
 
+@jjit
+def mc_orthonormal_vectors(ran_key, n):
+    """Monte Carlo realization of 3D orthonormal vectors A, B, C
+
+    The vectors are uniformly random on the unit sphere, and are orthonormal to each other.
+    """
+    ran_key, key_A, key_B = jran.split(ran_key, 3)
+    A = random_unit_vectors_3d(key_A, n)
+    B = random_perpendicular_directions(A, key_B)
+    C = jnp.cross(A, B)
+
+    return A, B, C
+
+@partial(jjit, static_argnums=(7, 8))
+def compute_ellipse2d_in_sim_frame(A_v, B_v, C_v, a, b, c, obs_x, obs_y, envelop=True, ellipticity_type=0):
+    """
+    Calculate the observed 2D ellipse parameters of a 3D triaxial ellipsoid in the simulation frame,
+    given the ellipsoid's axes lengths (a, b, c) and the observed x and y axes in the simulation 
+    frame (obs_x, obs_y).
+    Parameters:
+    -----------
+    A_v, B_v, C_v : jax.numpy.ndarray, shape (N, 3)
+        The 3D unit axes (major/inter/minor) of the ellipsoid in the simulation frame.
+    a, b, c : jax.numpy.ndarray, shape (N,)
+        The lengths of the major, intermediate, and minor axes of the ellipsoid.
+    obs_x, obs_y : jax.numpy.ndarray, shape (N, 3)
+        The observed unit x and unit y axes in the simulation frame.
+    envelop : bool, optional
+        Whether to apply the envelope correction to the 2D ellipse parameters.
+    ellipticity_type : int, optional
+        The type of ellipticity to compute.
+    Returns:
+    --------
+    Ellipse2DParams : namedtuple of arrays of shape (N,)
+        The 2D ellipse parameters in the observed frame.
+    """
+    # Transform the West-North-LoS coordinate system into the ellipsoid body frame
+    u = _transform_axes_to_frame(obs_x, A_v, B_v, C_v)
+    v = _transform_axes_to_frame(obs_y, A_v, B_v, C_v)
+
+    # Get the projection angles in the ellipsoid body frame,
+    # which are the Euler angles of the ZXZ rotation from the body frame
+    # to the west-north-los frame
+    z1, x2, z3 = _get_eulerzxz_angle_from_basis(u, v)
+    mu_proj = jnp.cos(x2)
+    phi_proj = z1 - jnp.pi / 2.0
+    omega_proj = z3
+
+    # Get the coefficients of the projected ellipse quadratic form in the u-v plane
+    A_coeff, B_coeff, C_coeff = _compute_2d_ellipse_params(
+        a,
+        b,
+        c,
+        mu_proj,
+        phi_proj,
+        omega_proj,
+        envelop=envelop,
+    )
+    # Get the semi-major, semi-minor axes, and ellipticity of the projected ellipse
+    alpha, beta = _calculate_ellipse2d_axes(A_coeff, B_coeff, C_coeff)
+    q = beta / alpha
+    if ellipticity_type == 0:
+        ellipticity = 1.0 - q
+    elif ellipticity_type == 1:
+        ellipticity = (1.0 - q) / (1.0 + q)
+    elif ellipticity_type == 2:
+        ellipticity = (1.0 - q**2) / (1.0 + q**2)
+    elif ellipticity_type == 3:
+        ellipticity = -jnp.log(q)
+    else:
+        raise ValueError(
+            f"Invalid ellipticity_type: {ellipticity_type}. Must be 0, 1, 2, or 3."
+        )
+    # Get the angle psi between the semi-major axis and u-axis
+    psi = _calculate_ellipse2d_psi(A_coeff, B_coeff, C_coeff)
+    e_alpha, e_beta = _get_xy_coords_of_projected_semi_axes(psi)
+
+    # return the 2D ellipse parameters in the observed frame
+    return Ellipse2DParams(
+        alpha,
+        beta,
+        psi,
+        ellipticity,
+        e_alpha,
+        e_beta,
+        A_coeff,
+        B_coeff,
+        C_coeff,
+    )
+
 
 @partial(jjit, static_argnums=(6, 7))
 def compute_ellipse2d(a, b, c, mu, phi, omega, envelop=True, ellipticity_type=0):
@@ -381,3 +471,176 @@ def _transform_axes_to_frame(A, x_prime, y_prime, z_prime):
         )
 
     return _to_frame(A)
+
+
+@partial(jjit, static_argnums=(1,))
+def random_unit_vectors_3d(key, N):
+    """
+    Generate random 3D unit vectors.
+
+    Parameters
+    ----------
+    N : int
+        number of vectors
+    key : jax.random.PRNGKey
+        Random key for JAX random number generation.
+
+    Returns
+    -------
+    result : numpy.array
+        Numpy array of shape (N, 3) containing random unit vectors
+    """
+    x = jran.normal(key, shape=(N, 3))
+    return _unitize(x)
+
+@jjit
+def random_perpendicular_directions(v, key):
+    """
+    Given an input list of 3D vectors, v, return a list of 3D vectors
+    such that each returned vector has unit-length and is
+    orthogonal to the corresponding vector in v.
+
+    Parameters
+    ----------
+    v : ndarray
+        Numpy array of shape (N, 3) storing a collection of 3d vectors
+
+    key : jax.random.PRNGKey
+        Random key for JAX random number generation.
+
+    Returns
+    -------
+    result : ndarray
+        Numpy array of shape (N, 3)
+    """
+    v = _unitize(jnp.atleast_2d(v))
+    N = v.shape[0]
+
+    # build a deterministic orthonormal basis (v, b1, b2) instead of projecting
+    # a random 3d draw out of v: that projection suffers catastrophic
+    # cancellation whenever the draw lands close to +-v, which is the source
+    # of the ~1e-5 orthogonality error this replaces. alt is always at least
+    # ~26 degrees from v, so cross(v, alt) never cancels.
+    xhat = jnp.broadcast_to(jnp.array([1.0, 0.0, 0.0], dtype=v.dtype), v.shape)
+    yhat = jnp.broadcast_to(jnp.array([0.0, 1.0, 0.0], dtype=v.dtype), v.shape)
+    alt = jnp.where(jnp.abs(v[:, 0:1]) > 0.9, yhat, xhat)
+    b1 = _unitize(jnp.cross(v, alt))
+    b2 = jnp.cross(v, b1)
+
+    # a single random azimuthal angle recovers a uniform direction around v
+    phi = 2.0 * jnp.pi * jran.uniform(key, (N, 1))
+    v_perp = jnp.cos(phi) * b1 + jnp.sin(phi) * b2
+
+    # v_perp is already orthogonal to v to ~1 ULP, so this Gram-Schmidt
+    # polish is a small, cancellation-safe correction, not a risky one
+    v_perp = v_perp - jnp.sum(v_perp * v, axis=-1, keepdims=True) * v
+    return _unitize(v_perp)
+
+@partial(jjit, static_argnames=['ascending_ra_deg'])
+def observer_frame_axes_from_ra_dec(ra_deg, dec_deg, ascending_ra_deg=0.0):
+    """
+    Calculate observer frame unit vectors (West, North, -LOS) in the simulation frame from RA and Dec,
+    assuming the standard mapping: r̂ = (cos δ cos (α-ascending_ra_deg), cos δ sin (α-ascending_ra_deg), sin δ), where 
+    δ is declination and α is right ascension. 
+
+    Parameters
+    ----------
+    ra_deg, dec_deg : array_like, shape (N,)  [degrees]
+        ra_deg in [0, 360), dec_deg in [-90, 90]
+    ascending_ra_deg : float, optional [degrees]
+        Right ascension of the ascending node (default = 0, i.e. x-axis points toward RA=0, Dec=0).
+    Returns
+    -------
+    x_prime : ndarray (N, 3)  West = direction of decreasing RA
+    y_prime : ndarray (N, 3)  North = direction of increasing Dec
+    Parameters
+    ----------
+    ra_rad, dec_rad : array_like, shape (N,)  [radians]
+        ra_rad in [0, 2Pi), dec_rad in [-Pi/2, Pi/2]
+    ascending_ra_rad : float, optional
+        Right ascension of the ascending node (default = 0, i.e. x-axis points toward RA=0, Dec=0).
+    Returns
+    -------
+    x_prime : ndarray (N, 3)  West = direction of decreasing RA
+    y_prime : ndarray (N, 3)  North = direction of increasing Dec
+    z_prime : ndarray (N, 3)  -LOS = toward observer, z' = x' × y'
+    """
+    alpha  = jnp.asarray((ra_deg - ascending_ra_deg)/180*jnp.pi)
+    delta  = jnp.asarray(dec_deg/180*jnp.pi)
+    ca, sa = jnp.cos(alpha),  jnp.sin(alpha)
+    cd, sd = jnp.cos(delta), jnp.sin(delta)
+    zeros  = jnp.zeros_like(alpha)
+
+    x_prime = jnp.stack([ sa,       -ca,        zeros], axis=-1)   # West
+    y_prime = jnp.stack([-sd*ca,    -sd*sa,     cd   ], axis=-1)   # North
+    z_prime = jnp.stack([-cd*ca,    -cd*sa,    -sd   ], axis=-1)   # -LOS
+
+    assert_orthonormality(x_prime, y_prime, z_prime)
+
+    return x_prime, y_prime, z_prime
+
+@jjit
+def observer_frame_axes_from_pos_3D(pos_x, pos_y, pos_z):
+    """
+    Calculate observer frame unit vectors (West, North, -LOS) in the simulation frame from 3D position,
+    assuming the standard mapping: r̂ = (x, y, z)/|r|, where 
+    r is the 3D position vector. 
+
+    Parameters
+    ----------
+    pos_x, pos_y, pos_z : array_like, shape (N,)
+        3D position coordinates of the observer in the simulation frame.
+
+    Returns
+    -------
+    x_prime : ndarray (N, 3)  West = direction of decreasing RA
+    y_prime : ndarray (N, 3)  North = direction of increasing Dec
+    z_prime : ndarray (N, 3)  -LOS = toward observer, z' = x' × y'
+    """
+    NCP = jnp.array([0, 0, 1])
+    # LoS points to the observer
+    obs_z = -1 * _unitize(jnp.stack([pos_x, pos_y, pos_z], axis=-1))
+
+    # obs_x = NCP x obs_z vanishes exactly at the celestial poles (obs_z || NCP), where
+    # west/east is undefined anyway; fall back to a fixed default there. The vector fed
+    # to jnp.linalg.norm is swapped in *before* the norm is taken (not the norm's output
+    # afterward), so norm() is never evaluated at the zero vector -- its gradient (v/|v|)
+    # would be a 0/0 NaN there, and jnp.where can't rescue a NaN already computed on the
+    # discarded branch. This keeps the whole thing jit-safe with well-defined gradients.
+    obs_x_raw = jnp.cross(NCP, obs_z)
+    at_pole = jnp.linalg.norm(obs_x_raw, axis=-1, keepdims=True) < 1e-10
+    obs_x_default = jnp.array([1.0, 0.0, 0.0])
+    obs_x = _unitize(jnp.where(at_pole, obs_x_default, obs_x_raw))
+    obs_y = jnp.cross(obs_z, obs_x)
+    assert_orthonormality(obs_x, obs_y, obs_z)
+
+    return obs_x, obs_y, obs_z
+
+@jjit
+def assert_orthonormality(x_prime, y_prime, z_prime, atol=1e-6):
+    """
+    Assert that the provided axes are orthonormal.
+
+    Parameters
+    ----------
+    x_prime, y_prime, z_prime : array_like, shape (N, 3)
+        The axes to check for orthonormality.
+    atol : float
+        Absolute tolerance for the checks.
+    """
+    assert jnp.allclose(jnp.sum(x_prime * y_prime, axis=-1), 0.0, atol=atol)
+    assert jnp.allclose(jnp.sum(x_prime * z_prime, axis=-1), 0.0, atol=atol)
+    assert jnp.allclose(jnp.sum(y_prime * z_prime, axis=-1), 0.0, atol=atol)
+    assert jnp.allclose(jnp.linalg.norm(x_prime, axis=-1), 1.0, atol=atol)
+    assert jnp.allclose(jnp.linalg.norm(y_prime, axis=-1), 1.0, atol=atol)
+    assert jnp.allclose(jnp.linalg.norm(z_prime, axis=-1), 1.0, atol=atol)
+    assert jnp.allclose(
+        jnp.linalg.norm(jnp.cross(x_prime, y_prime) - z_prime, axis=-1), 0.0, atol=atol
+    )
+
+@jjit
+def _unitize(v: jnp.ndarray, eps: float = 1e-12) -> jnp.ndarray:
+    """
+    Normalize a tensor to have unit length.
+    """
+    return v / (jnp.linalg.norm(v, axis=-1, keepdims=True) + eps)

--- a/diffsky/ellipsoidal_shapes/mc_disk_bulge_shapes.py
+++ b/diffsky/ellipsoidal_shapes/mc_disk_bulge_shapes.py
@@ -75,130 +75,14 @@ def mc_disk_bulge_ellipsoids(
     project onto the simulation x-y frame. However, when intrinsic alignment is modeled, the (mu, phi, omega)
     expressed in the body frame are no longer uniformly random, and the rigorous projection is required.
     """
-    ### Old method: draw random (mu, phi, omega)
-    # (mu_ran, phi_ran, omega_ran) defines the 3D galaxy ellipsoid eigenaxes A, B, C in the simulation frame.
-    # The ellipsoid body frame x'-y'-z' is defined such that A=x', B=y', C=z'
-    # mu = cos(theta) where theta is the polar angle of C
-    # phi is the azimuthal angle of C
-    # omega is the angle between A and the pivot axis (z x z')
-    # Without intrinsic alignment, the (mu, phi, omega) are drawn from uniform random distribution.
-    #mu_ran, phi_ran, omega_ran = epk.mc_mu_phi_omega(n, los_key)
-
-    # Build the 3D vectors of A, B, and C in the simulation frame
-    #R = epk._get_eulerxzx_matrix_from_angles(
-    #    phi_ran + jnp.pi / 2.0, jnp.arccos(mu_ran), omega_ran
-    #)
-    #A, B, C = R[:, :, 0], R[:, :, 1], R[:, :, 2]
-
-    ### New method: draw random 3D orthonormal vectors A, B, C in the simulation frame
-    ### to be replaced by A, B, C = central_alignment/satellite_alignment in future
+    # Draw random 3D orthonormal vectors A, B, C in the simulation frame
+    # to be replaced by A, B, C = central_alignment/satellite_alignment in future
     A, B, C = epk.mc_orthonormal_vectors(ran_key, n)
 
     # Build the West-North-LoS coordinate system in the simulation frame
     obs_x, obs_y, obs_z = epk.observer_frame_axes_from_xyz(pos_x, pos_y, pos_z)
 
-    ### Old method
-    # Transform the West-North-LoS coordinate system into the ellipsoid body frame
-    #u = epk._transform_axes_to_frame(obs_x, A, B, C)
-    #v = epk._transform_axes_to_frame(obs_y, A, B, C)
-
-    # Get the projection angles in the ellipsoid body frame,
-    # which are the Euler angles of the ZXZ rotation from the body frame
-    # to the west-north-los frame
-    #z1, x2, z3 = epk._get_eulerzxz_angle_from_basis(u, v)
-    #mu_proj = jnp.cos(x2)
-    #phi_proj = z1 - jnp.pi / 2.0
-    #omega_proj = z3
-
-    # a_disk = r50_disk
-    # b_disk = disk_axis_ratios.b_over_a * a_disk
-    # c_disk = disk_axis_ratios.c_over_a * a_disk
-
-    #A_disk, B_disk, C_disk = epk._compute_2d_ellipse_params(
-    #    a_disk,
-    #    b_disk,
-    #    c_disk,
-    #    mu_proj,
-    #    phi_proj,
-    #    omega_proj,
-    #    envelop=envelop,
-    #)
-    #alpha_disk, beta_disk = epk._calculate_ellipse2d_axes(A_disk, B_disk, C_disk)
-    #q_disk = beta_disk / alpha_disk
-    #if ellipticity_type == 0:
-    #    ellipticity_disk = 1.0 - q_disk
-    #elif ellipticity_type == 1:
-    #    ellipticity_disk = (1.0 - q_disk) / (1.0 + q_disk)
-    #elif ellipticity_type == 2:
-    #    ellipticity_disk = (1.0 - q_disk**2) / (1.0 + q_disk**2)
-    #elif ellipticity_type == 3:
-    #    ellipticity_disk = -jnp.log(q_disk)
-    #else:
-    #    raise ValueError(
-    #        f"Invalid ellipticity_type: {ellipticity_type}. Must be 0, 1, 2, or 3."
-    #    )
-
-    # a_bulge = r50_bulge
-    # b_bulge = bulge_axis_ratios.b_over_a * a_bulge
-    # c_bulge = bulge_axis_ratios.c_over_a * a_bulge
-
-    #A_bulge, B_bulge, C_bulge = epk._compute_2d_ellipse_params(
-    #    a_bulge, b_bulge, c_bulge, mu_proj, phi_proj, omega_proj, envelop=envelop
-    #)
-    #alpha_bulge, beta_bulge = epk._calculate_ellipse2d_axes(A_bulge, B_bulge, C_bulge)
-    #q_bulge = beta_bulge / alpha_bulge
-    #if ellipticity_type == 0:
-    #    ellipticity_bulge = 1.0 - q_bulge
-    #elif ellipticity_type == 1:
-    #    ellipticity_bulge = (1.0 - q_bulge) / (1.0 + q_bulge)
-    #elif ellipticity_type == 2:
-    #    ellipticity_bulge = (1.0 - q_bulge**2) / (1.0 + q_bulge**2)
-    #elif ellipticity_type == 3:
-    #    ellipticity_bulge = -jnp.log(q_bulge)
-    #else:
-    #    raise ValueError(
-    #        f"Invalid ellipticity_type: {ellipticity_type}. Must be 0, 1, 2, or 3."
-    #    )
-
-    # How to deal with bulge-disk misalignment?
-    # psi_disk_key, psi_bulge_key = jran.split(ran_key, 2)
-    # psi_disk = jran.uniform(psi_disk_key, minval=-jnp.pi, maxval=jnp.pi, shape=n)
-    # psi_noise_rad = jnp.deg2rad(psi_noise_deg)
-    # delta_psi_rad = jran.normal(psi_bulge_key, shape=n) * psi_noise_rad
-    # psi_bulge = psi_disk + delta_psi_rad
-    # psi_noise_rad = jnp.deg2rad(psi_noise_deg)
-    # delta_psi_rad = jran.normal(ran_key, shape=n) * psi_noise_rad
-    #psi_disk = epk._calculate_ellipse2d_psi(A_disk, B_disk, C_disk)
-    #psi_bulge = epk._calculate_ellipse2d_psi(A_bulge, B_bulge, C_bulge) + delta_psi_rad
-
-    #e_alpha_disk, e_beta_disk = epk._get_xy_coords_of_projected_semi_axes(psi_disk)
-    #e_alpha_bulge, e_beta_bulge = epk._get_xy_coords_of_projected_semi_axes(psi_bulge)
-
-    # disk_ellipse = Ellipse2DParams(
-    #     alpha_disk,
-    #     beta_disk,
-    #     psi_disk,
-    #     ellipticity_disk,
-    #     e_alpha_disk,
-    #     e_beta_disk,
-    #     A_disk,
-    #     B_disk,
-    #     C_disk,
-    # )
-
-    # bulge_ellipse = Ellipse2DParams(
-    #     alpha_bulge,
-    #     beta_bulge,
-    #     psi_bulge,
-    #     ellipticity_bulge,
-    #     e_alpha_bulge,
-    #     e_beta_bulge,
-    #     A_bulge,
-    #     B_bulge,
-    #     C_bulge,
-    # )
-
-    ### New method: use encapsulated function to compute the Ellipse2DParams
+    # Use encapsulated function to compute the Ellipse2DParams
     a_disk = r50_disk
     b_disk = disk_axis_ratios.b_over_a * a_disk
     c_disk = disk_axis_ratios.c_over_a * a_disk

--- a/diffsky/ellipsoidal_shapes/mc_disk_bulge_shapes.py
+++ b/diffsky/ellipsoidal_shapes/mc_disk_bulge_shapes.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 
 from jax import numpy as jnp
 from jax import random as jran
+from jax import jit as jjit
 
 from . import bulge_shapes, disk_shapes
 from . import ellipse_proj_kernels as epk
@@ -12,7 +13,6 @@ Ellipse2DParams = namedtuple(
     "Ellipse2DParams",
     ("alpha", "beta", "psi", "ellipticity", "e_alpha", "e_beta", "A", "B", "C"),
 )
-
 
 def mc_disk_bulge_ellipsoids(
     ran_key,
@@ -75,102 +75,90 @@ def mc_disk_bulge_ellipsoids(
     project onto the simulation x-y frame. However, when intrinsic alignment is modeled, the (mu, phi, omega)
     expressed in the body frame are no longer uniformly random, and the rigorous projection is required.
     """
+    ### Old method: draw random (mu, phi, omega)
     # (mu_ran, phi_ran, omega_ran) defines the 3D galaxy ellipsoid eigenaxes A, B, C in the simulation frame.
     # The ellipsoid body frame x'-y'-z' is defined such that A=x', B=y', C=z'
     # mu = cos(theta) where theta is the polar angle of C
     # phi is the azimuthal angle of C
     # omega is the angle between A and the pivot axis (z x z')
     # Without intrinsic alignment, the (mu, phi, omega) are drawn from uniform random distribution.
-    mu_ran, phi_ran, omega_ran = epk.mc_mu_phi_omega(n, los_key)
+    #mu_ran, phi_ran, omega_ran = epk.mc_mu_phi_omega(n, los_key)
 
     # Build the 3D vectors of A, B, and C in the simulation frame
-    R = epk._get_eulerxzx_matrix_from_angles(
-        phi_ran + jnp.pi / 2.0, jnp.arccos(mu_ran), omega_ran
-    )
-    A, B, C = R[:, :, 0], R[:, :, 1], R[:, :, 2]
+    #R = epk._get_eulerxzx_matrix_from_angles(
+    #    phi_ran + jnp.pi / 2.0, jnp.arccos(mu_ran), omega_ran
+    #)
+    #A, B, C = R[:, :, 0], R[:, :, 1], R[:, :, 2]
+
+    ### New method: draw random 3D orthonormal vectors A, B, C in the simulation frame
+    ### to be replaced by A, B, C = central_alignment/satellite_alignment in future
+    A, B, C = epk.mc_orthonormal_vectors(ran_key, n)
 
     # Build the West-North-LoS coordinate system in the simulation frame
-    NCP = jnp.array([0, 0, 1])
-    obs_z = jnp.stack([pos_x, pos_y, pos_z], axis=-1)
-    obs_z = (
-        -1 * obs_z / jnp.linalg.norm(obs_z, axis=-1, keepdims=True)
-    )  # LoS points to the observer
+    obs_x, obs_y, obs_z = epk.observer_frame_axes_from_xyz(pos_x, pos_y, pos_z)
 
-    # obs_x = NCP x obs_z vanishes exactly at the celestial poles (obs_z || NCP), where
-    # west/east is undefined anyway; fall back to a fixed default there. The vector fed
-    # to jnp.linalg.norm is swapped in *before* the norm is taken (not the norm's output
-    # afterward), so norm() is never evaluated at the zero vector -- its gradient (v/|v|)
-    # would be a 0/0 NaN there, and jnp.where can't rescue a NaN already computed on the
-    # discarded branch. This keeps the whole thing jit-safe with well-defined gradients.
-    obs_x_raw = jnp.cross(NCP, obs_z)
-    at_pole = jnp.linalg.norm(obs_x_raw, axis=-1, keepdims=True) < 1e-10
-    obs_x_default = jnp.array([1.0, 0.0, 0.0])
-    obs_x_safe = jnp.where(at_pole, obs_x_default, obs_x_raw)
-    obs_x = obs_x_safe / jnp.linalg.norm(obs_x_safe, axis=-1, keepdims=True)
-
-    obs_y = jnp.cross(obs_z, obs_x)
-
+    ### Old method
     # Transform the West-North-LoS coordinate system into the ellipsoid body frame
-    u = epk._transform_axes_to_frame(obs_x, A, B, C)
-    v = epk._transform_axes_to_frame(obs_y, A, B, C)
+    #u = epk._transform_axes_to_frame(obs_x, A, B, C)
+    #v = epk._transform_axes_to_frame(obs_y, A, B, C)
 
     # Get the projection angles in the ellipsoid body frame,
     # which are the Euler angles of the ZXZ rotation from the body frame
     # to the west-north-los frame
-    z1, x2, z3 = epk._get_eulerzxz_angle_from_basis(u, v)
-    mu_proj = jnp.cos(x2)
-    phi_proj = z1 - jnp.pi / 2.0
-    omega_proj = z3
+    #z1, x2, z3 = epk._get_eulerzxz_angle_from_basis(u, v)
+    #mu_proj = jnp.cos(x2)
+    #phi_proj = z1 - jnp.pi / 2.0
+    #omega_proj = z3
 
-    a_disk = r50_disk
-    b_disk = disk_axis_ratios.b_over_a * a_disk
-    c_disk = disk_axis_ratios.c_over_a * a_disk
+    # a_disk = r50_disk
+    # b_disk = disk_axis_ratios.b_over_a * a_disk
+    # c_disk = disk_axis_ratios.c_over_a * a_disk
 
-    A_disk, B_disk, C_disk = epk._compute_2d_ellipse_params(
-        a_disk,
-        b_disk,
-        c_disk,
-        mu_proj,
-        phi_proj,
-        omega_proj,
-        envelop=envelop,
-    )
-    alpha_disk, beta_disk = epk._calculate_ellipse2d_axes(A_disk, B_disk, C_disk)
-    q_disk = beta_disk / alpha_disk
-    if ellipticity_type == 0:
-        ellipticity_disk = 1.0 - q_disk
-    elif ellipticity_type == 1:
-        ellipticity_disk = (1.0 - q_disk) / (1.0 + q_disk)
-    elif ellipticity_type == 2:
-        ellipticity_disk = (1.0 - q_disk**2) / (1.0 + q_disk**2)
-    elif ellipticity_type == 3:
-        ellipticity_disk = -jnp.log(q_disk)
-    else:
-        raise ValueError(
-            f"Invalid ellipticity_type: {ellipticity_type}. Must be 0, 1, 2, or 3."
-        )
+    #A_disk, B_disk, C_disk = epk._compute_2d_ellipse_params(
+    #    a_disk,
+    #    b_disk,
+    #    c_disk,
+    #    mu_proj,
+    #    phi_proj,
+    #    omega_proj,
+    #    envelop=envelop,
+    #)
+    #alpha_disk, beta_disk = epk._calculate_ellipse2d_axes(A_disk, B_disk, C_disk)
+    #q_disk = beta_disk / alpha_disk
+    #if ellipticity_type == 0:
+    #    ellipticity_disk = 1.0 - q_disk
+    #elif ellipticity_type == 1:
+    #    ellipticity_disk = (1.0 - q_disk) / (1.0 + q_disk)
+    #elif ellipticity_type == 2:
+    #    ellipticity_disk = (1.0 - q_disk**2) / (1.0 + q_disk**2)
+    #elif ellipticity_type == 3:
+    #    ellipticity_disk = -jnp.log(q_disk)
+    #else:
+    #    raise ValueError(
+    #        f"Invalid ellipticity_type: {ellipticity_type}. Must be 0, 1, 2, or 3."
+    #    )
 
-    a_bulge = r50_bulge
-    b_bulge = bulge_axis_ratios.b_over_a * a_bulge
-    c_bulge = bulge_axis_ratios.c_over_a * a_bulge
+    # a_bulge = r50_bulge
+    # b_bulge = bulge_axis_ratios.b_over_a * a_bulge
+    # c_bulge = bulge_axis_ratios.c_over_a * a_bulge
 
-    A_bulge, B_bulge, C_bulge = epk._compute_2d_ellipse_params(
-        a_bulge, b_bulge, c_bulge, mu_proj, phi_proj, omega_proj, envelop=envelop
-    )
-    alpha_bulge, beta_bulge = epk._calculate_ellipse2d_axes(A_bulge, B_bulge, C_bulge)
-    q_bulge = beta_bulge / alpha_bulge
-    if ellipticity_type == 0:
-        ellipticity_bulge = 1.0 - q_bulge
-    elif ellipticity_type == 1:
-        ellipticity_bulge = (1.0 - q_bulge) / (1.0 + q_bulge)
-    elif ellipticity_type == 2:
-        ellipticity_bulge = (1.0 - q_bulge**2) / (1.0 + q_bulge**2)
-    elif ellipticity_type == 3:
-        ellipticity_bulge = -jnp.log(q_bulge)
-    else:
-        raise ValueError(
-            f"Invalid ellipticity_type: {ellipticity_type}. Must be 0, 1, 2, or 3."
-        )
+    #A_bulge, B_bulge, C_bulge = epk._compute_2d_ellipse_params(
+    #    a_bulge, b_bulge, c_bulge, mu_proj, phi_proj, omega_proj, envelop=envelop
+    #)
+    #alpha_bulge, beta_bulge = epk._calculate_ellipse2d_axes(A_bulge, B_bulge, C_bulge)
+    #q_bulge = beta_bulge / alpha_bulge
+    #if ellipticity_type == 0:
+    #    ellipticity_bulge = 1.0 - q_bulge
+    #elif ellipticity_type == 1:
+    #    ellipticity_bulge = (1.0 - q_bulge) / (1.0 + q_bulge)
+    #elif ellipticity_type == 2:
+    #    ellipticity_bulge = (1.0 - q_bulge**2) / (1.0 + q_bulge**2)
+    #elif ellipticity_type == 3:
+    #    ellipticity_bulge = -jnp.log(q_bulge)
+    #else:
+    #    raise ValueError(
+    #        f"Invalid ellipticity_type: {ellipticity_type}. Must be 0, 1, 2, or 3."
+    #    )
 
     # How to deal with bulge-disk misalignment?
     # psi_disk_key, psi_bulge_key = jran.split(ran_key, 2)
@@ -178,36 +166,66 @@ def mc_disk_bulge_ellipsoids(
     # psi_noise_rad = jnp.deg2rad(psi_noise_deg)
     # delta_psi_rad = jran.normal(psi_bulge_key, shape=n) * psi_noise_rad
     # psi_bulge = psi_disk + delta_psi_rad
-    psi_noise_rad = jnp.deg2rad(psi_noise_deg)
-    delta_psi_rad = jran.normal(ran_key, shape=n) * psi_noise_rad
-    psi_disk = epk._calculate_ellipse2d_psi(A_disk, B_disk, C_disk)
-    psi_bulge = epk._calculate_ellipse2d_psi(A_bulge, B_bulge, C_bulge) + delta_psi_rad
+    # psi_noise_rad = jnp.deg2rad(psi_noise_deg)
+    # delta_psi_rad = jran.normal(ran_key, shape=n) * psi_noise_rad
+    #psi_disk = epk._calculate_ellipse2d_psi(A_disk, B_disk, C_disk)
+    #psi_bulge = epk._calculate_ellipse2d_psi(A_bulge, B_bulge, C_bulge) + delta_psi_rad
 
-    e_alpha_disk, e_beta_disk = epk._get_xy_coords_of_projected_semi_axes(psi_disk)
-    e_alpha_bulge, e_beta_bulge = epk._get_xy_coords_of_projected_semi_axes(psi_bulge)
+    #e_alpha_disk, e_beta_disk = epk._get_xy_coords_of_projected_semi_axes(psi_disk)
+    #e_alpha_bulge, e_beta_bulge = epk._get_xy_coords_of_projected_semi_axes(psi_bulge)
 
-    disk_ellipse = Ellipse2DParams(
-        alpha_disk,
-        beta_disk,
-        psi_disk,
-        ellipticity_disk,
-        e_alpha_disk,
-        e_beta_disk,
-        A_disk,
-        B_disk,
-        C_disk,
+    # disk_ellipse = Ellipse2DParams(
+    #     alpha_disk,
+    #     beta_disk,
+    #     psi_disk,
+    #     ellipticity_disk,
+    #     e_alpha_disk,
+    #     e_beta_disk,
+    #     A_disk,
+    #     B_disk,
+    #     C_disk,
+    # )
+
+    # bulge_ellipse = Ellipse2DParams(
+    #     alpha_bulge,
+    #     beta_bulge,
+    #     psi_bulge,
+    #     ellipticity_bulge,
+    #     e_alpha_bulge,
+    #     e_beta_bulge,
+    #     A_bulge,
+    #     B_bulge,
+    #     C_bulge,
+    # )
+
+    ### New method: use encapsulated function to compute the Ellipse2DParams
+    a_disk = r50_disk
+    b_disk = disk_axis_ratios.b_over_a * a_disk
+    c_disk = disk_axis_ratios.c_over_a * a_disk
+
+    a_bulge = r50_bulge
+    b_bulge = bulge_axis_ratios.b_over_a * a_bulge
+    c_bulge = bulge_axis_ratios.c_over_a * a_bulge
+
+    disk_ellipse = epk.compute_ellipse2d_in_sim_frame(
+        A, B, C, a_disk, b_disk, c_disk,
+        obs_x, obs_y, obs_z,
+        envelop=envelop,
+        ellipticity_type=ellipticity_type,
     )
 
-    bulge_ellipse = Ellipse2DParams(
-        alpha_bulge,
-        beta_bulge,
-        psi_bulge,
-        ellipticity_bulge,
-        e_alpha_bulge,
-        e_beta_bulge,
-        A_bulge,
-        B_bulge,
-        C_bulge,
+    bulge_ellipse = epk.compute_ellipse2d_in_sim_frame(
+        A, B, C, a_bulge, b_bulge, c_bulge,
+        obs_x, obs_y, obs_z,
+        envelop=envelop,
+        ellipticity_type=ellipticity_type,
+    )
+
+    # inject a random misalignment between the disk and bulge position angles
+    psi_noise_rad = jnp.deg2rad(psi_noise_deg)
+    delta_psi_rad = jran.normal(ran_key, shape=n) * psi_noise_rad
+    bulge_ellipse = bulge_ellipse._replace(
+        psi=bulge_ellipse.psi + delta_psi_rad
     )
 
     return disk_ellipse, bulge_ellipse

--- a/diffsky/experimental/ad_hoc_alignment/inject_ia_adhoc.py
+++ b/diffsky/experimental/ad_hoc_alignment/inject_ia_adhoc.py
@@ -1,0 +1,276 @@
+"""
+Inject IA into DiffSky Mock Catalog 
+Author: Jiachuan Xu
+This script is a standalone script that injects IA into the DiffSky Mock Catalog ad hoc with native DiffSky format. 
+IA strategy:
+- resolved central galaxies: align with the host halo shape
+- unresolved central galaxies: random orientation
+- satellite galaxies: radial alignment to the position vector from the central galaxy to the satellite galaxy
+
+Native DiffSky format: HDF5 file with filename convention
+    lc_cores-aaa.b.diffsky_gals.hdf5
+where aaa is the timestep index and b is the lightcone patch index. Redshift decreases as stepnumber increases.
+The HDF5 file strcture is flat table. Example structure is shown below:
+    data
+      |- stepnum
+      |- ra
+      |- dec
+      |- ...
+      |- central
+"""
+import jax.numpy as jnp
+import jax.random as jran
+from ad_hoc_alignment.intrinsic_alignment import align_to_halo, align_radially
+from diffsky.ellipsoidal_shapes import ellipse_proj_kernels as eproj
+
+def alignment_worker(dataset, mu_central, mu_satellite, central_mask, synthetic_mask,
+                     box_size_in_Mpc=jnp.inf, envelope=True, ellipticity_type=0, seed=514):
+    """
+    Worker function to align the galaxies in the dataset according to the 
+    specified alignment parameters.
+
+    The alignment is done in the following way:
+    - Central galaxies: 
+        - Resolved: align to the host halo shape (central_alignment)
+        - Unresolved: random orientation
+    - Satellite galaxies: 
+        - Resolved and unresolved: align towards halo center (satellite_alignment)
+
+    All the galaxies have both disk and bulge components sharing the same 
+    alignment method. 
+
+    Parameters
+    ----------
+    dataset : HDF5 table
+        The dataset containing the galaxy information.
+    mu_central : float or jax.numpy.ndarray
+        The alignment strength mu for central galaxies. If float, the same alignment strength 
+        is applied to all central galaxies. If array, it should have the same length as the 
+        number of galaxies, and each galaxy has individual alignment strength. 
+        Unresolved (synthetic) centrals are set to mu=0 in this function.
+    mu_satellite : float or jax.numpy.ndarray
+        The alignment strength mu for satellite galaxies. If float, the same alignment strength 
+        is applied to all satellite galaxies. If array, it should have the same length as the 
+        number of galaxies, and each galaxy has individual alignment strength.
+    central_mask : array-like
+        Boolean mask, 1 = central galaxies, 0 = satellite galaxies.
+    synthetic_mask : array-like
+        Boolean mask, 1 = synthetic galaxies, 0 = resolved galaxies.
+    box_size_in_Mpc : float, optional
+        The size of the simulation box in Mpc. Default is np.inf (no periodic boundary conditions).
+    envelope : bool, optional
+        Whether to use the envelope method for projection. Default is True.
+    ellipticity_type : int, optional
+        The type of ellipticity to use for the projection. Default is 0.
+    seed : int, optional
+        Random seed for reproducibility. Default is 514.
+    Returns
+    -------
+    galaxy_axes : dict
+        Dictionary containing the aligned galaxy axes for each galaxy.
+    Ellipse2D_disk : array-like
+        The projected 2D ellipse parameters for the disk component of each galaxy.
+    Ellipse2D_bulge : array-like
+        The projected 2D ellipse parameters for the bulge component of each galaxy.
+    """
+    key_central, key_satellite = jran.split(jran.PRNGKey(seed))
+    # Get the axes in the observed RA/Dec frame for each galaxy, for shape projection. 
+    # x_prime = west, y_prime = north, z_prime = -LOS (toward observer)
+    x_prime, y_prime, z_prime = eproj.observer_frame_axes_from_ra_dec(dataset["ra_nfw"], dataset["dec_nfw"])
+
+    # Get the 3D axes size of disk and bulge for each galaxy
+    disk_3D_sizes = jnp.stack(
+        [
+            dataset["r50_disk_3d"],
+            dataset["r50_disk_3d"] * dataset["b_over_a_disk"],
+            dataset["r50_disk_3d"] * dataset["c_over_a_disk"],
+        ], axis=-1
+    )
+    bulge_3D_sizes = jnp.stack(
+        [
+            dataset["r50_bulge_3d"],
+            dataset["r50_bulge_3d"] * dataset["b_over_a_bulge"],
+            dataset["r50_bulge_3d"] * dataset["c_over_a_bulge"]
+        ], axis=-1
+    )
+
+    # Get the 3D axes direction of central and satellite galaxies.
+    # Every galaxy is run through both strategies at full length (rather than
+    # boolean-mask subsetting, which has data-dependent shape and isn't
+    # jit-compatible), and the unused branch is discarded below with
+    # jnp.where. Unresolved (synthetic) centrals are folded into the same
+    # central_alignment call via a per-galaxy mu of 0 (random orientation)
+    # instead of a separate branch.
+    mu_central_arr = jnp.where(synthetic_mask, 0.0, mu_central)
+    print("Central alignment ...")
+    central_axes = central_alignment(
+        dataset['top_host_infall_fof_halo_eigS3X'],
+        dataset['top_host_infall_fof_halo_eigS3Y'],
+        dataset['top_host_infall_fof_halo_eigS3Z'],
+        mu_central_arr,
+        key_central,
+    )
+    print("Satellite alignment ...")
+    satellite_axes = satellite_alignment(
+        dataset['x_host'], dataset['y_host'], dataset['z_host'],
+        dataset['x_nfw'], dataset['y_nfw'], dataset['z_nfw'],
+        mu_satellite,
+        key_satellite,
+        box_size_in_cMpc=box_size_in_Mpc,
+    )
+    # merge the axes of different types into a single array for each axis
+    cmask = central_mask[:, None]
+    gals_A = jnp.where(cmask, central_axes[0], satellite_axes[0])
+    gals_B = jnp.where(cmask, central_axes[1], satellite_axes[1])
+    gals_C = jnp.where(cmask, central_axes[2], satellite_axes[2])
+
+    ### Measure the galaxy shapes in RA/Dec frame (disk+bulge and central+satellite)
+    Ellipse2D_disk = eproj.compute_ellipse2d_in_sim_frame(
+        gals_A, gals_B, gals_C,
+        disk_3D_sizes[:, 0],
+        disk_3D_sizes[:, 1],
+        disk_3D_sizes[:, 2],
+        x_prime, y_prime,
+        envelop=envelope,
+        ellipticity_type=ellipticity_type,
+    )
+
+    Ellipse2D_bulge = eproj.compute_ellipse2d_in_sim_frame(
+        gals_A, gals_B, gals_C,
+        bulge_3D_sizes[:, 0],
+        bulge_3D_sizes[:, 1],
+        bulge_3D_sizes[:, 2],
+        x_prime, y_prime,
+        envelop=envelope,
+        ellipticity_type=ellipticity_type,
+    )
+
+    return Ellipse2D_disk, Ellipse2D_bulge, {"gal_A": gals_A, "gal_B": gals_B, "gal_C": gals_C}
+
+def central_alignment(gal_axisA_x, gal_axisA_y, gal_axisA_z, mu, key):
+    """ Intrinsic alignment for central galaxies
+    This function is designed to support multiple central galaxy alignment strategies,
+    but currently only implements the "align to halo" strategy.
+    Parameters
+    ----------
+    gal_axisA_x, gal_axisA_y, gal_axisA_z : array-like, shape (N,)
+        The x, y, and z components of the host halo's major axis, for every
+        galaxy (not just centrals) -- the caller selects which rows matter.
+    mu : float or array-like, shape (N,)
+        The alignment strength mu for central galaxies. Pass a per-galaxy
+        array with 0.0 for unresolved/synthetic centrals to randomize them.
+    key : jax.random.PRNGKey
+        Random key for JAX random number generation.
+    Returns
+    -------
+    gal_A : jax.numpy.ndarray
+        The aligned galaxy axis A for central galaxies.
+    gal_B : jax.numpy.ndarray
+        The aligned galaxy axis B for central galaxies.
+    gal_C : jax.numpy.ndarray
+        The aligned galaxy axis C for central galaxies.
+    """
+    gal_A, gal_B, gal_C = align_to_halo(
+        key, gal_axisA_x, gal_axisA_y, gal_axisA_z, mu, prim_gal_axis='A',
+    )
+    return gal_A, gal_B, gal_C
+
+def satellite_alignment(halo_x, halo_y, halo_z, x, y, z, mu, key, box_size_in_cMpc=jnp.inf):
+    """ Intrinsic alignment for satellite galaxies
+    This function is designed to support multiple satellite galaxy alignment strategies,
+    but currently only implements the "radial alignment" strategy.
+    Parameters
+    ----------
+    halo_x, halo_y, halo_z : array-like, shape (N,)
+        Host halo center position, for every galaxy (not just satellites) --
+        the caller selects which rows matter.
+    x, y, z : array-like, shape (N,)
+        Galaxy position, for every galaxy.
+    mu : float or array-like, shape (N,)
+        The alignment strength mu for satellite galaxies.
+    key : jax.random.PRNGKey
+        Random key for JAX random number generation.
+    box_size_in_cMpc : float, optional
+        The size of the simulation box in comoving Mpc. Default is np.inf
+    Returns
+    -------
+    gal_A : jax.numpy.ndarray
+        The aligned galaxy axis A for satellite galaxies.
+    gal_B : jax.numpy.ndarray
+        The aligned galaxy axis B for satellite galaxies.
+    gal_C : jax.numpy.ndarray
+        The aligned galaxy axis C for satellite galaxies.
+    """
+    gal_A, gal_B, gal_C = align_radially(
+        key, halo_x, halo_y, halo_z, x, y, z, mu,
+        jnp.array([box_size_in_cMpc, box_size_in_cMpc, box_size_in_cMpc]),
+        prim_gal_axis='A',
+    )
+    return gal_A, gal_B, gal_C
+
+
+def main():
+    import h5py
+    import argparse
+    import numpy as np
+
+    parser = argparse.ArgumentParser(description="Inject IA into DiffSky Mock Catalog")
+    parser.add_argument("input_file", type=str, help="Input HDF5 file")
+    parser.add_argument("output_file", type=str, help="Output HDF5 file")
+    parser.add_argument("--mu_central", type=float, default=0.5, help="Alignment strength for central galaxies")
+    parser.add_argument("--mu_satellite", type=float, default=0.5, help="Alignment strength for satellite galaxies")
+    parser.add_argument("--seed", type=int, default=514, help="Random seed for reproducibility")
+    args = parser.parse_args()
+
+    with h5py.File(args.input_file, "r") as f:
+        # "data" is a Group of one 1D Dataset per column, not a single
+        # compound-dtype Dataset, so it can't be read with f["data"][:]
+        dataset = {k: f["data"][k][:] for k in f["data"].keys()}
+        central_mask = dataset["central"] == 1
+        # A central galaxy is "unresolved" when its host halo shape wasn't
+        # measured, which shows up as an exactly-zero eigenvector
+        eig_norm = np.sqrt(
+            dataset["top_host_infall_fof_halo_eigS3X"] ** 2
+            + dataset["top_host_infall_fof_halo_eigS3Y"] ** 2
+            + dataset["top_host_infall_fof_halo_eigS3Z"] ** 2
+        )
+        synthetic_mask = central_mask & (eig_norm == 0)
+
+        # Calculate the aligned disk and bulge shapes
+        # axis_disk is for debug and code comparison purpose, not saved.
+        Ellipse2D_disk, Ellipse2D_bulge, axes_disk = alignment_worker(
+            dataset,
+            args.mu_central,
+            args.mu_satellite,
+            central_mask,
+            synthetic_mask,
+            seed=args.seed
+        )
+
+        # overwrite the original dataset with the new shapes
+        # involved properties: ("alpha", "beta", "psi", "ellipticity", "r50"),
+        dataset["alpha_disk"] = Ellipse2D_disk.alpha
+        dataset["beta_disk"] = Ellipse2D_disk.beta
+        dataset["psi_disk"] = Ellipse2D_disk.psi
+        dataset["ellipticity_disk"] = Ellipse2D_disk.ellipticity
+        dataset["r50_disk_2d"] = Ellipse2D_disk.alpha * 0.765
+        dataset["alpha_bulge"] = Ellipse2D_bulge.alpha
+        dataset["beta_bulge"] = Ellipse2D_bulge.beta
+        dataset["psi_bulge"] = Ellipse2D_bulge.psi
+        dataset["ellipticity_bulge"] = Ellipse2D_bulge.ellipticity
+        dataset["r50_bulge_2d"] = Ellipse2D_bulge.alpha * 0.765
+        # columns for debug: the axes of the 3D galaxy ellipsoid after alignment
+        # dataset["gal_Ax"] = axes_disk["gal_A"][:, 0]
+        # dataset["gal_Ay"] = axes_disk["gal_A"][:, 1]
+        # dataset["gal_Az"] = axes_disk["gal_A"][:, 2]
+        # dataset["gal_Bx"] = axes_disk["gal_B"][:, 0]
+        # dataset["gal_By"] = axes_disk["gal_B"][:, 1]
+        # dataset["gal_Bz"] = axes_disk["gal_B"][:, 2]
+        # dataset["gal_Cx"] = axes_disk["gal_C"][:, 0]
+        # dataset["gal_Cy"] = axes_disk["gal_C"][:, 1]
+        # dataset["gal_Cz"] = axes_disk["gal_C"][:, 2]
+
+        with h5py.File(args.output_file, "w") as f:
+            grp = f.create_group("data")
+            for key, val in dataset.items():
+                grp.create_dataset(key, data=np.asarray(val))

--- a/diffsky/experimental/ad_hoc_alignment/intrinsic_alignment.py
+++ b/diffsky/experimental/ad_hoc_alignment/intrinsic_alignment.py
@@ -1,0 +1,429 @@
+""" Standalone script for alignment functions.
+This script collects functions needed for a central + radial alignment strategy for IA injection from halotools.
+Original functions developed by Nick van Alfen, altered by Jiachuan Xu to be compatible with DiffSky Mock Catalog.
+"""
+import math
+from functools import partial
+import jax
+import jax.numpy as jnp
+from jax import jit as jjit
+from jax import random as jran
+from jax import lax
+from diffsky.ellipsoidal_shapes import ellipse_proj_kernels as eproj
+
+def align_to_halo(key, halo_axisA_x, halo_axisA_y, halo_axisA_z,
+                    alignment_strength, prim_gal_axis='A'):
+    """ Aligns the galaxy axes to the halo axes with a given alignment strength.
+    Parameters
+    ----------
+    halo_axisA_x, halo_axisA_y, halo_axisA_z : array_like, shape (N,)
+        The x, y, and z components of the halo's major axis (A-axis)
+    alignment_strength : float or array_like, shape (N,)
+        The strength of the alignment, defined for the DW distribution. If a float, it is applied to all galaxies. 
+        If an array, it must have the same length as the number of galaxies.
+    prim_gal_axis : str, optional
+        The primary axis of the galaxy to align. Can be 'A', 'B', or 'C'. Default is 'A'.
+    key : jax.random.PRNGKey
+        Random key for JAX random number generation.
+    Returns
+    -------
+    aligned_galaxy_axes : (array_like, array_like, array_like), shape (N, 3) each
+        The aligned galaxy axes after applying the alignment transformation.
+    """
+    # type check for alignment_strength
+    assert( ( isinstance(alignment_strength, float) ) or ( isinstance(alignment_strength, jnp.ndarray) ) )
+    if isinstance( alignment_strength, float ):
+        alignment_strength = alignment_strength * jnp.ones( len(halo_axisA_x) )
+    
+    # set prim_gal_axis orientation
+    major_input_vectors = jnp.stack((halo_axisA_x, halo_axisA_y, halo_axisA_z), axis=-1)
+    
+    return align_to_axis(key, major_input_vectors, alignment_strength, prim_gal_axis)
+
+
+def align_radially(key, halo_x, halo_y, halo_z, 
+                   x, y, z, alignment_strength, Lbox, prim_gal_axis='A'):
+    """ Aligns the galaxy axes radially to the halo center with a given alignment strength.
+    Parameters
+    ----------
+    halo_x, halo_y, halo_z : array_like, shape (N,)
+        The x, y, and z coordinates of the halo center.
+    x, y, z : array_like, shape (N,)
+        The x, y, and z coordinates of the galaxies.
+    Lbox : array_like, shape (3,)
+        The size of the simulation box (for periodic boundary conditions).
+    alignment_strength : float or array_like, shape (N,)
+        The strength of the alignment, defined for the DW distribution. If a float, it is applied to all galaxies. 
+        If an array, it must have the same length as the number of galaxies.
+    prim_gal_axis : str, optional
+        The primary axis of the galaxy to align. Can be 'A', 'B', or 'C'. Default is 'A'.
+    key : jax.random.PRNGKey
+        Random key for JAX random number generation.
+    Returns
+    -------
+    aligned_galaxy_axes : (array_like, array_like, array_like), shape (N, 3) each
+        The aligned galaxy axes after applying the radial alignment transformation.
+    """
+    # type check for alignment_strength
+    assert( ( isinstance(alignment_strength, float) ) or ( isinstance(alignment_strength, jnp.ndarray) ) )
+    if isinstance( alignment_strength, float ):
+        alignment_strength = alignment_strength * jnp.ones( len(halo_x) )
+    
+    # set prim_gal_axis orientation
+    major_input_vectors, r = get_radial_vector(halo_x, halo_y, halo_z, x, y, z, Lbox)
+    # check for length 0 radial vectors
+    mask = (r <= 0.0) | (~jnp.isfinite(r))
+    N_bad_axes = int(jnp.sum(mask))
+    if N_bad_axes > 0:
+        key, subkey = jran.split(key)
+        major_input_vectors = major_input_vectors.at[mask, :].set(
+            eproj.random_unit_vectors_3d(subkey, N_bad_axes)
+        )
+    
+    return align_to_axis(key, major_input_vectors, alignment_strength, prim_gal_axis)
+
+@partial(jjit, static_argnums=(3,))
+def align_to_axis(key, major_input_vectors, alignment_strength, prim_gal_axis="A"):
+    """ Aligns the galaxy axes to a given vector with a specified alignment strength.
+    Parameters
+    ----------
+    major_input_vectors : array_like, shape (N, 3)
+        The input vectors to which the galaxy axes will be aligned.
+    alignment_strength : float or array_like, shape (N,)
+        The strength of the alignment, defined for the DW distribution. If a float, it is applied to all galaxies. 
+        If an array, it must have the same length as the number of galaxies.
+    prim_gal_axis : str, optional
+        The primary axis of the galaxy to align. Can be 'A', 'B', or 'C'. Default is 'A'.
+    key : jax.random.PRNGKey
+        Random key for JAX random number generation.
+    Returns
+    -------
+    major_v, inter_v, minor_v : array_like, shape (N, 3)
+        The aligned galaxy axes after applying the alignment transformation. The axes are returned in the order of major, intermediate, and minor axes.
+    """
+    # type check for alignment_strength
+    assert( ( isinstance(alignment_strength, float) ) or ( isinstance(alignment_strength, jnp.ndarray) ) )
+    if isinstance( alignment_strength, float ):
+        alignment_strength = alignment_strength * jnp.ones( len(major_input_vectors) )
+
+    key_A, key_B = jran.split(key)
+
+    #A_v = axes_correlated_with_input_vector(major_input_vectors, p=alignment_strength)
+    A_v = sample_watson_orientations(key_A, major_input_vectors, alignment_strength)
+
+    # check for bad vectors: not finite (nan/inf), or not unit-length -- the
+    # latter also catches a degenerate all-zero reference axis (e.g. an
+    # unmeasured/unresolved halo shape), which _unitize maps to 0 (finite,
+    # so it would slip past a finite-only check) rather than nan.
+    # N_bad_axes is a traced value here (align_to_axis is jitted), so we
+    # can't branch on it or assign into A_v by count; instead always draw N
+    # replacements and select per-row with jnp.where.
+    a_norm = jnp.linalg.norm(A_v, axis=-1)
+    mask = (~jnp.isfinite(a_norm)) | (jnp.abs(a_norm - 1.0) > 1e-3)
+    n_bad_axes = jnp.sum(mask)
+    A_v_random = eproj.random_unit_vectors_3d(key_A, A_v.shape[0])
+    A_v = jnp.where(mask[:, None], A_v_random, A_v)
+    lax.cond(
+        n_bad_axes > 0,
+        lambda _: jax.debug.print(
+            '{n} correlated alignment axis(axes) were found to be degenerate '
+            '(not finite or not unit-length). These were re-assigned random '
+            'vectors.', n=n_bad_axes),
+        lambda _: None,
+        operand=None,
+    )
+
+    # randomly set secondary axis orientation
+    B_v = eproj.random_perpendicular_directions(A_v, key_B)
+
+    # the tertiary axis is determined
+    C_v = jnp.cross(A_v, B_v)
+
+    eproj.assert_orthonormality(A_v, B_v, C_v)
+
+    # depending on the prim_gal_axis, assign correlated axes
+    if prim_gal_axis == 'A':
+        major_v = A_v
+        inter_v = B_v
+        minor_v = C_v
+    elif prim_gal_axis == 'B':
+        major_v = C_v
+        inter_v = A_v
+        minor_v = B_v
+    elif prim_gal_axis == 'C':
+        major_v = B_v
+        inter_v = C_v
+        minor_v = A_v
+        
+    return major_v, inter_v, minor_v
+
+@jjit
+def get_radial_vector(halo_x, halo_y, halo_z, x, y, z, Lbox):
+    """
+    caclulate the radial vector for satellite galaxies
+    Parameters
+    ----------
+    x, y, z : array_like, shape (N,)
+        galaxy positions
+    halo_x, halo_y, halo_z : array_like, shape (N,)
+        host halo positions
+    Lbox : array_like
+        array len(3) giving the simulation box size along each dimension
+    Returns
+    -------
+    r_vec : array_like, shape (N, 3)
+        array of radial vectors of shape (N, 3) between host haloes and satellites
+    r : array_like, shape (N,)
+        radial distance
+    """
+    # define halo-center - satellite vector
+    # accounting for PBCs
+    r_vec = jnp.stack((x-halo_x, y-halo_y, z-halo_z), axis=-1)
+    r_vec = modular_vector(r_vec, Lbox)
+    r = jnp.sqrt(jnp.sum(r_vec*r_vec, axis=-1))
+
+    return r_vec, r
+
+@jjit
+def modular_vector(v, Lbox):
+    """
+    Apply periodic boundary conditions to a vector v.
+    Parameters
+    ----------
+    v : array_like, shape (N,3)
+        Input separation to be wrapped into the periodic box.
+    Lbox : array_like, shape (3,)
+        Value giving the simulation box size along each dimension.
+    Returns
+    -------
+    v_mod : array_like, shape (N,3)
+        Vector after applying periodic boundary conditions.
+    """
+    # whether to wrap is data-dependent (on Lbox), so select with jnp.where
+    # rather than a Python-level if, which would require Lbox to be static
+    is_periodic = jnp.all(jnp.isfinite(Lbox))
+    v_wrapped = jnp.mod(v + 0.5 * Lbox, Lbox) - 0.5 * Lbox
+    return jnp.where(is_periodic, v_wrapped, v)
+
+
+
+### ===========================================================================
+### Dimroth-Watson Distribution Sampling (editted based on diffHOD-IA)
+### Convention: sample the polar angle theta and azimuthal angle phi from D-W
+### P(theta, phi) = B(kappa)/(2pi) * exp(-kappa*cos^2(theta))sin(theta),
+### where the norm factor (Nick's eqn 17 has typo)
+###   B(kappa) = 2pi / (\int_{-1}^{1} exp(-kappa*t^2) * dt)
+### The alignment strength is usually defined as
+### mu = -2/pi * tan^-1(kappa), which is in [-1, 1].
+###   mu = 0 means random orientation
+###   mu = -1 means perfect anti-alignment (orthogonal to ref axis)
+###   mu = 1 means perfect alignment (parallel to ref axis)
+### See https://arxiv.org/abs/2311.07374 and https://arxiv.org/abs/2602.04977
+### ===========================================================================
+
+@jjit
+def _erfi_real(x: jnp.ndarray) -> jnp.ndarray:
+    """
+    Stable real-valued erfi for JAX arrays.
+    Matches your piecewise series/asymptotic form, with bounded iteration counts.
+    Parameters
+    ----------
+    x : jnp.ndarray
+        Input array.
+    Returns
+    -------
+    y: jnp.ndarray
+        The computed erfi values for the input array.
+    """
+
+    def small_branch(xs: jnp.ndarray) -> jnp.ndarray:
+        # erfi(x) = 2/sqrt(pi) * sum_{n>=0} x^{2n+1} / (n! (2n+1))
+        def body_fun(n, carry):
+            term, s = carry
+            term = term * (xs * xs) / n  # multiply by x^2 / n
+            s = s + term / (2 * n + 1)
+            return term, s
+
+        term0 = xs
+        s0 = xs
+        termN, sN = lax.fori_loop(1, 20, body_fun, (term0, s0))
+        return (2.0 / math.sqrt(math.pi)) * sN
+
+    def large_branch(xl: jnp.ndarray) -> jnp.ndarray:
+        inv = 1.0 / xl
+        inv2 = inv * inv
+        series = 1.0 + 0.5 * inv2 + 0.75 * inv2 * inv2 + 1.875 * inv2 * inv2 * inv2
+        return jnp.exp(xl * xl) * series / (math.sqrt(math.pi) * xl)
+
+    y_small = small_branch(x)
+    y_large = large_branch(x)
+    y = jnp.where(jnp.abs(x) <= 3.0, y_small, y_large)
+    return y.astype(x.dtype)
+
+@partial(jjit, static_argnums=(2,))
+def _sample_t_watson(key, kappa, n_newton = 6):
+    """
+    Sample t = cos(theta) from the Dimroth-Watson distribution using Newton's method.
+    (Newton's method is used to solve the inverse CDF of the kappa<0 parallel-alignment branch)
+    Parameters
+    ----------
+    key : jax.random.PRNGKey
+        Random key for JAX random number generation, to generate CDF samples.
+    kappa : jnp.ndarray
+        Concentration parameter for the Dimroth-Watson distribution.
+    n_newton : int, optional
+        Number of Newton iterations for solving the inverse CDF. Default is 6.
+    Returns
+    -------
+    t : jnp.ndarray
+        Sampled values of t = cos(theta) from the Dimroth-Watson distribution
+    """
+    eps = 1e-12
+
+    def one(k_i, u_i):
+        """
+        Sample t = cos(theta) for a single kappa and uniform random number u.
+        Depending on the sign of kappa, different branches of the inverse CDF are used.
+        1. For kappa > 0 (anti-alignment), use
+            CDF(x) = 0.5*[1 + erf(sqrt(kappa)*x)/erf(sqrt(kappa)) ]
+        2. For kappa = 0 (random), use
+            CDF(x) = 0.5*(1 + x)
+        3. For kappa < 0 (alignment), use Newton's method to solve
+            CDF(x) = 0.5*[1 + erfi(sqrt(-kappa)*x)/erfi(sqrt(-kappa)) ]
+        """
+        def pos_branch(_):
+            km = jnp.sqrt(k_i)
+            den = jax.scipy.special.erf(km)
+            arg = jnp.clip((2.0 * u_i - 1.0) * den, -1.0 + 1e-7, 1.0 - 1e-7)
+            return jax.scipy.special.erfinv(arg) / (km + eps)
+
+        def zer_branch(_):
+            return 2.0 * u_i - 1.0
+
+        def neg_branch(_):
+            sp = jnp.sqrt(-k_i)
+            sp2 = sp * sp
+            tp0 = 2.0 * u_i - 1.0
+            den = _erfi_real(sp) + 1e-30
+
+            # erfi(sp) and erfi(sp*t) individually overflow in _erfi_real's
+            # asymptotic branch once sp gets large (near-total alignment,
+            # mu -> 1), even though their ratio (and the pdf, which shares
+            # the same exp(sp^2) factor) stays perfectly well-behaved. Once
+            # BOTH sp and sp*t are large, use erfi's own asymptotic form
+            # erfi(x) ~ exp(x^2)*S(x)/(sqrt(pi)*x) to cancel exp(sp^2)
+            # analytically, leaving only exp(sp^2*(t^2-1)) <= 1 for |t|<=1
+            # -- this never overflows, however large sp is. 80 is a
+            # conservative cutoff (float32 exp overflows past x^2~88.7),
+            # chosen so it doesn't engage until past where the direct path
+            # is already known to work (validated up to mu=0.99, sp^2~64).
+            OVERFLOW_THRESH = 80.0
+
+            def body(_, tp_curr):
+                spt = sp * tp_curr
+                spt2 = spt * spt
+                both_large = (sp2 > OVERFLOW_THRESH) & (spt2 > OVERFLOW_THRESH)
+
+                # direct path: correct whenever neither term overflows, and
+                # also correct (giving ~0) when only the denominator (sp
+                # alone large) overflows -- the ratio of a finite numerator
+                # over an overflowed-to-inf denominator is genuinely ~0.
+                ratio_direct = _erfi_real(spt) / den
+                pdf_direct = (
+                    (sp / math.sqrt(math.pi))
+                    * jnp.exp(-1 * k_i * tp_curr * tp_curr) / den
+                )
+
+                # stable path: only valid/needed when both sp and sp*t are
+                # large, so guard the reciprocals against the masked-out
+                # (small) case to avoid a spurious large value there (still
+                # harmless since jnp.where discards it, but keeps this branch
+                # itself finite).
+                safe_t = jnp.where(both_large, tp_curr, 1.0)
+                safe_spt2 = jnp.where(both_large, spt2, 1.0)
+                inv2_sp = 1.0 / sp2
+                inv2_spt = 1.0 / safe_spt2
+                S_sp = 1.0 + 0.5 * inv2_sp + 0.75 * inv2_sp**2 + 1.875 * inv2_sp**3
+                S_spt = 1.0 + 0.5 * inv2_spt + 0.75 * inv2_spt**2 + 1.875 * inv2_spt**3
+                E = jnp.exp(sp2 * (tp_curr * tp_curr - 1.0))
+                ratio_stable = E * (S_spt / S_sp) / safe_t
+                pdf_stable = sp2 * E / S_sp
+
+                ratio = jnp.where(both_large, ratio_stable, ratio_direct)
+                pdf = jnp.where(both_large, pdf_stable, pdf_direct)
+
+                F = 0.5 * (ratio + 1.0)
+                # 2e-7 (not 1e-6): near mu=1, the true CDF root can sit
+                # closer to +-1 than 1e-6 (the distribution's own width
+                # there is ~1/(2*sp^2), which drops below 1e-6 once sp^2
+                # exceeds ~5e5 -- reachable at mu=1 exactly, sp^2~6.4e5).
+                # A too-loose clip silently saturates Newton at the
+                # boundary instead of the true root. 2e-7 stays a couple
+                # of float32 ULPs above 1.0 (~1.19e-7 there).
+                tp_next = jnp.clip(
+                    tp_curr - (F - u_i) / (pdf + 1e-30), -1.0 + 2e-7, 1.0 - 2e-7
+                )
+                return tp_next
+
+            return lax.fori_loop(0, n_newton, body, tp0)
+
+        return lax.cond(
+            k_i < -1e-12,
+            neg_branch,
+            lambda _: lax.cond(k_i > 1e-12, pos_branch, zer_branch, operand=None),
+            operand=None,
+        )
+    
+    N = kappa.shape[0]
+    u_uni = jnp.clip(
+        jran.uniform(key, (N,), minval=0.0, maxval=1.0), 1e-7, 1 - 1e-7
+    )
+    t = jax.vmap(one)(kappa, u_uni)
+    return jnp.clip(t, -1.0 + 2e-7, 1.0 - 2e-7)
+
+@partial(jjit, static_argnums=(3,))  # n_newton is the 4th argument (index 3)
+def sample_watson_orientations(key, ref_dirs, mu, n_newton=6):
+    """
+    Dimroth–Watson axial samples about ref_dirs (unit vectors).
+    Parameters
+    ----------
+    key : jax.random.PRNGKey
+        Random key for JAX random number generation.
+    ref_dirs : jnp.ndarray, shape (N, 3)
+        Array of reference unit vectors (directions) about which the samples will be generated.
+    mu : jnp.ndarray of shape (N,), or float
+        Alignment strength parameter.
+    n_newton : int, optional
+        Number of Newton iterations for solving the inverse CDF. Default is 6.
+    Returns
+    -------
+    n : jnp.ndarray, shape (N, 3)
+        Array of sampled unit vectors (orientations) from the Dimroth–Watson distribution
+        about the reference directions `ref_dirs`, with the specified alignment strength `mu`.
+    """
+
+    u_axis = eproj._unitize(ref_dirs)
+    N = u_axis.shape[0]
+
+    # turn mu into kappa
+    mu_arr = jnp.asarray(mu, dtype=u_axis.dtype)
+    if mu_arr.ndim == 0:
+        mu = jnp.full((N,), mu_arr, dtype=u_axis.dtype)
+    else:
+        mu = mu_arr.reshape(-1)
+        if mu.shape[0] == 1:
+            mu = jnp.repeat(mu, N, axis=0)
+    mu = jnp.clip(mu, -1.0 + 1e-6, 1.0 - 1e-6)
+    kappa = jnp.tan(-0.5 * math.pi * mu)
+    kappa = jnp.clip(kappa, -1e6, 1e6)
+
+    # sample theta, and an azimuthally-random direction perpendicular to u_axis
+    key_u, key_phi = jran.split(key)
+    t = _sample_t_watson(key_u, kappa, n_newton=n_newton)
+    sinth = jnp.sqrt(jnp.clip(1.0 - t * t, 0.0)).reshape(N, 1)
+    costh = t.reshape(N, 1)
+    perp = eproj.random_perpendicular_directions(u_axis, key_phi)
+
+    # compute the sampled orientations in the orthonormal basis
+    n = eproj._unitize(costh * u_axis + sinth * perp)
+    return n


### PR DESCRIPTION
# Summary 

This PR includes changes that introduce intrinsic alignment (IA) to galaxies. The implementation is based on [van Alfen et al. (2024)](https://arxiv.org/abs/2311.07374) and [Pandya and Blazek (2026)](https://arxiv.org/abs/2602.04977) with modifications. 

This PR only includes a minimal IA model. More sophisticated models (e.g., color and luminosity dependent IA, Iris Reed is working on this) will be introduced in the future. 

# Model 

The IA model introduced in this PR aligns central and satellite galaxies separately:
- Resolved central galaxy: align the major-axis of the galaxy to its host halo major-axis (central alignment), with a random misalignment angle $\theta_\mathrm{MA}$.
- Unresolved central galaxy: align the galaxy uniformly random. 
- Satellite galaxy: align the major-axis of the galaxy to its position inside the host halo (radial alignment), with a random misalignment angle $\theta_\mathrm{MA}$. 

The misalignment angle follows the Dimroth-Watson distribution, with the alignment strength controlled by the parameter $\mu$. 

$$ P(\theta, \phi) \propto exp(-\kappa \cos^2(\theta)) \sin (\theta) d\theta d\phi,$$

where $\theta$ and $\phi$ are the colatitude and the longitude angles of galaxy's major-axis when the halo major-axis is aligned to the +z direction. $\kappa$ is related to the directly used strength parameter $\mu$ as 

$$ \mu = \frac{-2 \mathrm{tan}^{-1}(\kappa)}{\pi}. $$ 

$\mu=1$ means perfect parallel-alignment, and $\mu=0$ means perfect anti-alignment. $\mu=0$ means uniformly random alignment. 

Both the disk and the bulge share the same IA, although an extra random offset is injected in the position angle of the 2D projected bulge. 

# Implementation

- With an input DiffSky-native HDF5 data, the main function in `inject_ia_adhoc.py` shows how to call `alignment_worker` to calculate the projected 2D ellipticity parameters for both disk and bulge. 
- The `inject_ia_adhoc.py/alignment_worker` will call the corresponding IA model for different types of galaxies
- The `inject_ia_adhoc.py/central_alignment` (`satellite_alignment`) will call the corresponding IA model for central and satellite galaxies. Note that only one alignment model is implemented for central and satellite galaxies, so now these two functions are just duplicates of the underlying function. When more IA models are introduced in the future, these two functions will determine which IA model to use for the central and satellite galaxies, and call the corresponding lower-level functions. (Note: many functions are taken from [modular_alignment](https://github.com/nvanalfen/modular_alignments))
- The lower-level alignment functions are in `intrinsic_alignment.py`, including `align_to_halo` and `align_radially`, which both call `align_to_axis` as the backbone implementation.
- The Dimroth-Watson distribution sampler `intrinsic_alignment.py/sample_watson_orientations` samples through inverse CDF of the D-W distribution. Conditioned on the sign of $\kappa$, this function switches among different branches for a closed-form CDF equation. (Note: this part is taken from [diffHOD-IA](https://github.com/snehjp2/diffHOD-IA/blob/main/src/scripts/diffHOD_IA.py) with edits to improve numerical stability at edge cases.)

Regarding how to put this stand-alone script into the lightcone generation script, the DiffSky developers may have much better idea than me. 

The code structure of this PR is not fully integrated into DiffSky, meaning:
1. The function that introduces IA is a standalone post-processing script, not a step inside the lightcone generation script.
2. Some helper functions introduced in ellipse_proj_kernels.py are doing vector operation (`random_unit_vectors_3d`, `random_perpendicular_directions`, `assert_orthonormality`, `_unitize`) and coordinate system conversion (`_get_eulerxzx_matrix_from_angles`, `_get_eulerzxz_angle_from_basis`, `_transform_axes_to_frame`, `observer_frame_axes_from_ra_dec`, `observer_frame_axes_from_pos_3D`). Conceptually, they should be distributed to other utility scripts.
3. A structure describing the IA model parametrization is missing, and also a script to calibrate the IA strength $\mu$. 

# Misc

I find the ra/dec and ra_nfw/dec_nfw in the [example DiffSky-native data](https://portal.nersc.gov/project/hacc/aphearin/diffsky_data/c260710_08_12_2026/) have different conventions (ra_nfw = 0 means +x direction, but ra = 0 means -x direction). I don't know if this is because the example data is outdated, or a similar issue is still in the latest mocks. 